### PR TITLE
Work on parser, comments, type lookups and type queries

### DIFF
--- a/importer/src/main/scala/com/olvind/tso/importer/ImportEnum.scala
+++ b/importer/src/main/scala/com/olvind/tso/importer/ImportEnum.scala
@@ -21,7 +21,9 @@ object ImportEnum {
     val TsDeclEnum(cs, _, ImportName(name), members, isValue, exportedFrom, _, codePath) = e
 
     val baseInterface: TypeRef =
-      ImportType(Wildcards.No, scope)(TsTypeRef(exportedFrom.fold(codePath.forceHasPath.codePath)(_.name), Nil))
+      ImportType(Wildcards.No, scope)(
+        TsTypeRef(NoComments, exportedFrom.fold(codePath.forceHasPath.codePath)(_.name), Nil)
+      )
 
     val underlying = underlyingType(e)
 
@@ -31,7 +33,7 @@ object ImportEnum {
           scalajs.TypeAliasTree(
             name     = name,
             tparams  = Nil,
-            alias    = ImportType(Wildcards.No, scope)(TsTypeRef(ef.name, Nil)),
+            alias    = ImportType(Wildcards.No, scope)(TsTypeRef(NoComments, ef.name, Nil)),
             comments = NoComments
           )
         case None =>
@@ -88,8 +90,8 @@ object ImportEnum {
                 )
 
             val memberComments = Comments(literalOpt map {
-              case Left(x)  => Comment(s"/* ${x.literal} */ ")
-              case Right(x) => Comment(s"/* ${x.value} */ ")
+              case Left(x)  => Comment(s"/* ${x.literal} */")
+              case Right(x) => Comment(s"/* ${x.value} */")
             })
             val memberTypeRef = baseInterface.copy(typeName = baseInterface.typeName + memberName)
 

--- a/importer/src/main/scala/com/olvind/tso/importer/ImportTree.scala
+++ b/importer/src/main/scala/com/olvind/tso/importer/ImportTree.scala
@@ -341,9 +341,9 @@ object ImportTree {
 
             val rewritten: TypeRef =
               if (indexTpe === TypeRef.String)
-                TypeRef.StringDictionary(valueTpe, m.comments + Comment(s"/* ${indexName.value} */ "))
+                TypeRef.StringDictionary(valueTpe, m.comments + Comment(s"/* ${indexName.value} */"))
               else if (indexTpe === TypeRef.Double)
-                TypeRef.NumberDictionary(valueTpe, m.comments + Comment(s"/* ${indexName.value} */ "))
+                TypeRef.NumberDictionary(valueTpe, m.comments + Comment(s"/* ${indexName.value} */"))
               else scope.logger.fatal(s"Unsupported index type $indexTpe")
 
             Seq(MemberRet.Inheritance(rewritten))

--- a/importer/src/main/scala/com/olvind/tso/importer/Libraries.scala
+++ b/importer/src/main/scala/com/olvind/tso/importer/Libraries.scala
@@ -75,6 +75,7 @@ object Libraries {
     "prisma-binding",
     "@protobufjs/aspromise",
     "@protobufjs/codegen",
+    "@pulumi/aws",
     "@pulumi/pulumi",
     "@pulumi/cloud",
     "@pulumi/kubernetes",
@@ -157,16 +158,8 @@ object Libraries {
       "yfiles",
       "chromecast-caf-receiver",
       "snoowrap",
-      // exponential growth in parsing time :/
-      "echarts",
-      "@pulumi/aws",
       // some new kind of circular dependency causes the phase runner to wait forever
       "mali",
       "apollo-tracing"
-      // these are just slow
-      //      "dojo",
-      //      "react-icons",
-      //      "aws-sdk",
-      //      "winrt-uwp",
     )
 }

--- a/importer/src/main/scala/com/olvind/tso/importer/Phase1ReadTypescript.scala
+++ b/importer/src/main/scala/com/olvind/tso/importer/Phase1ReadTypescript.scala
@@ -169,7 +169,7 @@ class Phase1ReadTypescript(resolve:          LibraryResolver,
                 ).visitTsParsedFile(scope),
                 T.QualifyReferences.visitTsParsedFile(scope.caching),
                 AugmentModules(scope),
-                T.ResolveTypeQueries.visitTsParsedFile(scope),
+                T.ResolveTypeQueries.visitTsParsedFile(scope), // before ReplaceExports
                 new ReplaceExports(new LoopDetector()).visitTsParsedFile(scope.caching),
                 f => FlattenTrees(f :: Nil),
                 (

--- a/importer/src/test/resources/augment-module/check/l/lodash/build.sbt
+++ b/importer/src/test/resources/augment-module/check/l/lodash/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "lodash"
-version := "4.14-ec5b9a"
+version := "4.14-4de0c4"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ec0a62")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-166d05")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/fpMod/Global/Map.scala
+++ b/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/fpMod/Global/Map.scala
@@ -6,6 +6,5 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 // tslint:disable-next-line:no-empty-interface
-
 trait Map[K, V] extends js.Object
 

--- a/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/fpMod/Global/Set.scala
+++ b/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/fpMod/Global/Set.scala
@@ -6,6 +6,5 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 // tslint:disable-next-line:no-empty-interface
-
 trait Set[T] extends js.Object
 

--- a/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/fpMod/Global/WeakMap.scala
+++ b/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/fpMod/Global/WeakMap.scala
@@ -6,6 +6,5 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 // tslint:disable-next-line:no-empty-interface
-
 trait WeakMap[K /* <: js.Object */, V] extends js.Object
 

--- a/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/fpMod/Global/WeakSet.scala
+++ b/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/fpMod/Global/WeakSet.scala
@@ -6,6 +6,5 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 // tslint:disable-next-line:no-empty-interface
-
 trait WeakSet[T] extends js.Object
 

--- a/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/fpMod/underscoreNs/LoDashFp.scala
+++ b/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/fpMod/underscoreNs/LoDashFp.scala
@@ -5,8 +5,11 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
+@js.native
 trait LoDashFp extends js.Object {
-  var curry: js.Any
+  @JSName("curry")
+  var curry_Original: lodashLib.fpCurryMod.Curry = js.native
+  def curry[T1, R](func: js.Function1[/* t1 */ T1, R]): lodashLib.lodashMod.underscoreNs.CurriedFunction1[T1, R] = js.native
+  def curry[T1, T2, R](func: js.Function2[/* t1 */ T1, /* t2 */ T2, R]): lodashLib.lodashMod.underscoreNs.CurriedFunction2[T1, T2, R] = js.native
 }
 

--- a/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/lodashMod/Global/Map.scala
+++ b/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/lodashMod/Global/Map.scala
@@ -6,6 +6,5 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 // tslint:disable-next-line:no-empty-interface
-
 trait Map[K, V] extends js.Object
 

--- a/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/lodashMod/Global/Set.scala
+++ b/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/lodashMod/Global/Set.scala
@@ -6,6 +6,5 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 // tslint:disable-next-line:no-empty-interface
-
 trait Set[T] extends js.Object
 

--- a/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/lodashMod/Global/WeakMap.scala
+++ b/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/lodashMod/Global/WeakMap.scala
@@ -6,6 +6,5 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 // tslint:disable-next-line:no-empty-interface
-
 trait WeakMap[K /* <: js.Object */, V] extends js.Object
 

--- a/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/lodashMod/Global/WeakSet.scala
+++ b/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/lodashMod/Global/WeakSet.scala
@@ -6,6 +6,5 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 // tslint:disable-next-line:no-empty-interface
-
 trait WeakSet[T] extends js.Object
 

--- a/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/lodashMod/underscoreNs/LoDashStatic.scala
+++ b/importer/src/test/resources/augment-module/check/l/lodash/src/main/scala/typings/lodashLib/lodashMod/underscoreNs/LoDashStatic.scala
@@ -11,43 +11,28 @@ import scala.scalajs.js.annotation._
 @js.native
 trait LoDashStatic extends js.Object {
   /**
-           * Adds two numbers.
-           *
-           * @param augend The first number to add.
-           * @param addend The second number to add.
-           * @return Returns the sum.
-           */
+    * Adds two numbers.
+    *
+    * @param augend The first number to add.
+    * @param addend The second number to add.
+    * @return Returns the sum.
+    */
   def add(augend: scala.Double, addend: scala.Double): scala.Double = js.native
   /**
-       * @see _.at
-       */
-  def at[T /* <: js.Object */](`object`: T, props: Many[java.lang.String]*): js.Array[
-    /* import warning: Failed type conversion: TsTypeLookup(TsTypeRef(TsQIdent(List(TsIdentSimple(T))),List()),Right(TsTypeKeyOf(TsTypeRef(TsQIdent(List(TsIdentSimple(T))),List())))) */js.Any
-  ] = js.native
+    * @see _.at
+    */
+  def at[T /* <: js.Object */](`object`: T, props: Many[java.lang.String]*): js.Array[/* import warning: ImportType.apply Failed type conversion: T[keyof T] */ js.Any] = js.native
   /**
-       * Creates an array of elements corresponding to the given keys, or indexes, of collection. Keys may be
-       * specified as individual arguments or as arrays of keys.
-       *
-       * @param object The object to iterate over.
-       * @param props The property names or indexes of elements to pick, specified individually or in arrays.
-       * @return Returns the new array of picked elements.
-       */
+    * Creates an array of elements corresponding to the given keys, or indexes, of collection. Keys may be
+    * specified as individual arguments or as arrays of keys.
+    *
+    * @param object The object to iterate over.
+    * @param props The property names or indexes of elements to pick, specified individually or in arrays.
+    * @return Returns the new array of picked elements.
+    */
   def at[T](`object`: List[T], props: PropertyPath*): js.Array[T] = js.native
-  /**
-       * Creates an array of elements corresponding to the given keys, or indexes, of collection. Keys may be
-       * specified as individual arguments or as arrays of keys.
-       *
-       * @param object The object to iterate over.
-       * @param props The property names or indexes of elements to pick, specified individually or in arrays.
-       * @return Returns the new array of picked elements.
-       */
   def at[T](props: PropertyPath*): js.Array[T] = js.native
-  /**
-       * @see _.at
-       */
   @JSName("at")
-  def at_TObject[T /* <: js.Object */](props: Many[java.lang.String]*): js.Array[
-    /* import warning: Failed type conversion: TsTypeLookup(TsTypeRef(TsQIdent(List(TsIdentSimple(T))),List()),Right(TsTypeKeyOf(TsTypeRef(TsQIdent(List(TsIdentSimple(T))),List())))) */js.Any
-  ] = js.native
+  def at_TObject[T /* <: js.Object */](props: Many[java.lang.String]*): js.Array[/* import warning: ImportType.apply Failed type conversion: T[keyof T] */ js.Any] = js.native
 }
 

--- a/importer/src/test/resources/augment-module/check/l/lodash_dot_add/build.sbt
+++ b/importer/src/test/resources/augment-module/check/l/lodash_dot_add/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "lodash_dot_add"
-version := "3.7-df9b14"
+version := "3.7-c0fca0"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "lodash" % "4.14-ec5b9a",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ec0a62")
+  "org.scalablytyped" %%% "lodash" % "4.14-4de0c4",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-166d05")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/augment-module/check/s/std/build.sbt
+++ b/importer/src/test/resources/augment-module/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-ec0a62"
+version := "0.0-unknown-166d05"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/augment-module/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/augment-module/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/augment-module/check/s/std/src/main/scala/typings/stdLib/ArrayLike.scala
+++ b/importer/src/test/resources/augment-module/check/s/std/src/main/scala/typings/stdLib/ArrayLike.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ArrayLike[T] extends js.Object
 

--- a/importer/src/test/resources/aws-sdk/check/a/aws-sdk/build.sbt
+++ b/importer/src/test/resources/aws-sdk/check/a/aws-sdk/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "aws-sdk"
-version := "2.247.1-55971f"
+version := "2.247.1-bd3b30"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-20654c")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f6c17e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/awsDashSdkMod/DynamoDBNs.scala
+++ b/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/awsDashSdkMod/DynamoDBNs.scala
@@ -13,11 +13,11 @@ object DynamoDBNs extends js.Object {
     extends awsDashSdkLib.clientsAllMod.DynamoDBNs.Converter
   
   @js.native
+  /**
+    * Creates a DynamoDB document client with a set of configuration options.
+    */
   class DocumentClient ()
     extends awsDashSdkLib.clientsAllMod.DynamoDBNs.DocumentClient {
-    /**
-         * Creates a DynamoDB document client with a set of configuration options.
-         */
     def this(options: awsDashSdkLib.libDynamodbDocumentUnderscoreClientMod.DocumentClientNs.DocumentClientOptions with awsDashSdkLib.clientsDynamodbMod.DynamoDBNs.ClientConfiguration) = this()
   }
   
@@ -42,11 +42,11 @@ object DynamoDBNs extends js.Object {
       extends awsDashSdkLib.clientsAllMod.DynamoDBNs.DynamoDBNs.Converter
     
     @js.native
+    /**
+      * Creates a DynamoDB document client with a set of configuration options.
+      */
     class DocumentClient ()
       extends awsDashSdkLib.clientsAllMod.DynamoDBNs.DynamoDBNs.DocumentClient {
-      /**
-           * Creates a DynamoDB document client with a set of configuration options.
-           */
       def this(options: awsDashSdkLib.libDynamodbDocumentUnderscoreClientMod.DocumentClientNs.DocumentClientOptions with awsDashSdkLib.clientsDynamodbMod.DynamoDBNs.ClientConfiguration) = this()
     }
     

--- a/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/clientsAllMod/DynamoDBNs.scala
+++ b/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/clientsAllMod/DynamoDBNs.scala
@@ -13,11 +13,11 @@ object DynamoDBNs extends js.Object {
     extends awsDashSdkLib.clientsDynamodbMod.Converter
   
   @js.native
+  /**
+    * Creates a DynamoDB document client with a set of configuration options.
+    */
   class DocumentClient ()
     extends awsDashSdkLib.clientsDynamodbMod.DocumentClient {
-    /**
-         * Creates a DynamoDB document client with a set of configuration options.
-         */
     def this(options: awsDashSdkLib.libDynamodbDocumentUnderscoreClientMod.DocumentClientNs.DocumentClientOptions with awsDashSdkLib.clientsDynamodbMod.DynamoDBNs.ClientConfiguration) = this()
   }
   
@@ -42,11 +42,11 @@ object DynamoDBNs extends js.Object {
       extends awsDashSdkLib.clientsDynamodbMod.DynamoDBNs.Converter
     
     @js.native
+    /**
+      * Creates a DynamoDB document client with a set of configuration options.
+      */
     class DocumentClient ()
       extends awsDashSdkLib.clientsDynamodbMod.DynamoDBNs.DocumentClient {
-      /**
-           * Creates a DynamoDB document client with a set of configuration options.
-           */
       def this(options: awsDashSdkLib.libDynamodbDocumentUnderscoreClientMod.DocumentClientNs.DocumentClientOptions with awsDashSdkLib.clientsDynamodbMod.DynamoDBNs.ClientConfiguration) = this()
     }
     

--- a/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/clientsDynamodbMod/DocumentClient.scala
+++ b/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/clientsDynamodbMod/DocumentClient.scala
@@ -7,11 +7,11 @@ import scala.scalajs.js.annotation._
 
 @JSImport("aws-sdk/clients/dynamodb", "DocumentClient")
 @js.native
+/**
+  * Creates a DynamoDB document client with a set of configuration options.
+  */
 class DocumentClient ()
   extends awsDashSdkLib.clientsDynamodbMod.DynamoDBNs.DocumentClient {
-  /**
-       * Creates a DynamoDB document client with a set of configuration options.
-       */
   def this(options: awsDashSdkLib.libDynamodbDocumentUnderscoreClientMod.DocumentClientNs.DocumentClientOptions with awsDashSdkLib.clientsDynamodbMod.DynamoDBNs.ClientConfiguration) = this()
 }
 

--- a/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/clientsDynamodbMod/DynamoDBNs.scala
+++ b/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/clientsDynamodbMod/DynamoDBNs.scala
@@ -12,10 +12,10 @@ object DynamoDBNs extends js.Object {
   class Converter () extends js.Object
   
   @js.native
+  /**
+    * Creates a DynamoDB document client with a set of configuration options.
+    */
   class DocumentClient () extends js.Object {
-    /**
-         * Creates a DynamoDB document client with a set of configuration options.
-         */
     def this(options: awsDashSdkLib.libDynamodbDocumentUnderscoreClientMod.DocumentClientNs.DocumentClientOptions with ClientConfiguration) = this()
   }
   
@@ -35,31 +35,29 @@ object DynamoDBNs extends js.Object {
   @JSName("DocumentClient")
   @js.native
   object DocumentClientNs extends js.Object {
-    
     trait ConverterOptions extends js.Object {
       /**
-               * An optional flag indicating that the document client should cast
-               * empty strings, buffers, and sets to NULL shapes
-               */
+        * An optional flag indicating that the document client should cast
+        * empty strings, buffers, and sets to NULL shapes
+        */
       var convertEmptyValues: js.UndefOr[scala.Boolean] = js.undefined
       /**
-               * Whether to return numbers as a NumberValue object instead of
-               * converting them to native JavaScript numbers. This allows for the
-               * safe round-trip transport of numbers of arbitrary size.
-               */
+        * Whether to return numbers as a NumberValue object instead of
+        * converting them to native JavaScript numbers. This allows for the
+        * safe round-trip transport of numbers of arbitrary size.
+        */
       var wrapNumbers: js.UndefOr[scala.Boolean] = js.undefined
     }
-    
     
     trait DocumentClientOptions
       extends awsDashSdkLib.libDynamodbDocumentUnderscoreClientMod.DocumentClientNs.ConverterOptions {
       /**
-               * An optional map of parameters to bind to every request sent by this service object.
-               */
+        * An optional map of parameters to bind to every request sent by this service object.
+        */
       var params: js.UndefOr[org.scalablytyped.runtime.StringDictionary[js.Any]] = js.undefined
       /**
-               * An optional pre-configured instance of the AWS.DynamoDB service object to use for requests. The object may bound parameters used by the document client.
-               */
+        * An optional pre-configured instance of the AWS.DynamoDB service object to use for requests. The object may bound parameters used by the document client.
+        */
       var service: js.UndefOr[awsDashSdkLib.clientsDynamodbMod.namespaced] = js.undefined
     }
     

--- a/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/libConfigMod/APIVersions.scala
+++ b/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/libConfigMod/APIVersions.scala
@@ -5,15 +5,14 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait APIVersions extends js.Object {
   /**
-       * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in all services (unless overridden by apiVersions). Specify \'latest\' to use the latest possible version.
-       */
+    * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in all services (unless overridden by apiVersions). Specify \'latest\' to use the latest possible version.
+    */
   var apiVersion: js.UndefOr[awsDashSdkLib.awsDashSdkLibStrings.latest | java.lang.String] = js.undefined
   /**
-       * A map of service identifiers (the lowercase service class name) with the API version to use when instantiating a service. Specify 'latest' for each individual that can use the latest available version.
-       */
+    * A map of service identifiers (the lowercase service class name) with the API version to use when instantiating a service. Specify 'latest' for each individual that can use the latest available version.
+    */
   var apiVersions: js.UndefOr[
     awsDashSdkLib.libConfigUnderscoreServiceUnderscorePlaceholdersMod.ConfigurationServiceApiVersions
   ] = js.undefined

--- a/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/libConfigMod/Config.scala
+++ b/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/libConfigMod/Config.scala
@@ -7,19 +7,19 @@ import scala.scalajs.js.annotation._
 
 @JSImport("aws-sdk/lib/config", "Config")
 @js.native
+/**
+  * Creates a new configuration object.
+  * This is the object that passes option data along to service requests, including credentials, security, region information, and some service specific settings.
+  */
 class Config () extends js.Object {
-  /**
-       * Creates a new configuration object.
-       * This is the object that passes option data along to service requests, including credentials, security, region information, and some service specific settings.
-       */
   def this(options: awsDashSdkLib.libConfigUnderscoreServiceUnderscorePlaceholdersMod.ConfigurationServicePlaceholders with APIVersions) = this()
   /**
-       * Loads configuration data from a JSON file into this config object.
-       * Loading configuration willr eset all existing configuration on the object.
-       * This feature is not supported in the browser environment of the SDK.
-       *
-       * @param {string} path - the path relative to your process's current working directory to load configuration from.
-       */
+    * Loads configuration data from a JSON file into this config object.
+    * Loading configuration willr eset all existing configuration on the object.
+    * This feature is not supported in the browser environment of the SDK.
+    *
+    * @param {string} path - the path relative to your process's current working directory to load configuration from.
+    */
   def loadFromPath(path: java.lang.String): Config with awsDashSdkLib.libConfigUnderscoreServiceUnderscorePlaceholdersMod.ConfigurationServicePlaceholders with APIVersions = js.native
 }
 

--- a/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/libConfigUnderscoreServiceUnderscorePlaceholdersMod/ConfigurationServiceApiVersions.scala
+++ b/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/libConfigUnderscoreServiceUnderscorePlaceholdersMod/ConfigurationServiceApiVersions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ConfigurationServiceApiVersions extends js.Object {
   var dynamodb: js.UndefOr[awsDashSdkLib.clientsDynamodbMod.DynamoDBNs.apiVersion] = js.undefined
 }

--- a/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/libDynamodbDocumentUnderscoreClientMod/DocumentClient.scala
+++ b/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/libDynamodbDocumentUnderscoreClientMod/DocumentClient.scala
@@ -7,10 +7,10 @@ import scala.scalajs.js.annotation._
 
 @JSImport("aws-sdk/lib/dynamodb/document_client", "DocumentClient")
 @js.native
+/**
+  * Creates a DynamoDB document client with a set of configuration options.
+  */
 class DocumentClient () extends js.Object {
-  /**
-       * Creates a DynamoDB document client with a set of configuration options.
-       */
   def this(options: awsDashSdkLib.libDynamodbDocumentUnderscoreClientMod.DocumentClientNs.DocumentClientOptions with awsDashSdkLib.clientsDynamodbMod.DynamoDBNs.ClientConfiguration) = this()
 }
 

--- a/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/libDynamodbDocumentUnderscoreClientMod/DocumentClientNs/ConverterOptions.scala
+++ b/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/libDynamodbDocumentUnderscoreClientMod/DocumentClientNs/ConverterOptions.scala
@@ -5,18 +5,17 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ConverterOptions extends js.Object {
   /**
-           * An optional flag indicating that the document client should cast
-           * empty strings, buffers, and sets to NULL shapes
-           */
+    * An optional flag indicating that the document client should cast
+    * empty strings, buffers, and sets to NULL shapes
+    */
   var convertEmptyValues: js.UndefOr[scala.Boolean] = js.undefined
   /**
-           * Whether to return numbers as a NumberValue object instead of
-           * converting them to native JavaScript numbers. This allows for the
-           * safe round-trip transport of numbers of arbitrary size.
-           */
+    * Whether to return numbers as a NumberValue object instead of
+    * converting them to native JavaScript numbers. This allows for the
+    * safe round-trip transport of numbers of arbitrary size.
+    */
   var wrapNumbers: js.UndefOr[scala.Boolean] = js.undefined
 }
 

--- a/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/libDynamodbDocumentUnderscoreClientMod/DocumentClientNs/DocumentClientOptions.scala
+++ b/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/libDynamodbDocumentUnderscoreClientMod/DocumentClientNs/DocumentClientOptions.scala
@@ -5,15 +5,14 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait DocumentClientOptions extends ConverterOptions {
   /**
-           * An optional map of parameters to bind to every request sent by this service object.
-           */
+    * An optional map of parameters to bind to every request sent by this service object.
+    */
   var params: js.UndefOr[org.scalablytyped.runtime.StringDictionary[js.Any]] = js.undefined
   /**
-           * An optional pre-configured instance of the AWS.DynamoDB service object to use for requests. The object may bound parameters used by the document client.
-           */
+    * An optional pre-configured instance of the AWS.DynamoDB service object to use for requests. The object may bound parameters used by the document client.
+    */
   var service: js.UndefOr[awsDashSdkLib.clientsDynamodbMod.namespaced] = js.undefined
 }
 

--- a/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/libServicesDynamodbMod/DynamoDBCustomizations.scala
+++ b/importer/src/test/resources/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsDashSdkLib/libServicesDynamodbMod/DynamoDBCustomizations.scala
@@ -9,3 +9,18 @@ import scala.scalajs.js.annotation._
 @js.native
 class DynamoDBCustomizations () extends js.Object
 
+@JSImport("aws-sdk/lib/services/dynamodb", "DynamoDBCustomizations")
+@js.native
+object DynamoDBCustomizations extends js.Object {
+  /**
+    * The document client simplifies working with items in Amazon DynamoDB by abstracting away the notion of attribute values.
+    * This abstraction annotates native JavaScript types supplied as input parameters, as well as converts annotated response data to native JavaScript types.
+    */
+  var DocumentClient: org.scalablytyped.runtime.Instantiable1[
+    /* options */ js.UndefOr[
+      /* options */ awsDashSdkLib.libDynamodbDocumentUnderscoreClientMod.DocumentClientNs.DocumentClientOptions with awsDashSdkLib.clientsDynamodbMod.DynamoDBNs.ClientConfiguration
+    ], 
+    awsDashSdkLib.libDynamodbDocumentUnderscoreClientMod.DocumentClient
+  ] = js.native
+}
+

--- a/importer/src/test/resources/aws-sdk/check/s/std/build.sbt
+++ b/importer/src/test/resources/aws-sdk/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-20654c"
+version := "0.0-unknown-f6c17e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/aws-sdk/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/aws-sdk/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/bigint/check/b/bigint/build.sbt
+++ b/importer/src/test/resources/bigint/check/b/bigint/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "bigint"
-version := "v5.5.3-40c1d6"
+version := "v5.5.3-457866"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-20654c")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f6c17e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/bigint/check/s/std/build.sbt
+++ b/importer/src/test/resources/bigint/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-20654c"
+version := "0.0-unknown-f6c17e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/bigint/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/bigint/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/chart.js/check/c/chart_dot_js/build.sbt
+++ b/importer/src/test/resources/chart.js/check/c/chart_dot_js/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "chart_dot_js"
-version := "0.0-unknown-a1f07d"
+version := "0.0-unknown-92a337"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-1ab5f2")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-2cc44b")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/chart.js/check/c/chart_dot_js/src/main/scala/typings/chartDotJsLib/Anon_Key.scala
+++ b/importer/src/test/resources/chart.js/check/c/chart_dot_js/src/main/scala/typings/chartDotJsLib/Anon_Key.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_Key
   extends /* key */ org.scalablytyped.runtime.StringDictionary[js.Any] {
   var global: chartDotJsLib.chartDotJsMod.ChartNs.ChartOptions with chartDotJsLib.chartDotJsMod.ChartNs.ChartFontOptions

--- a/importer/src/test/resources/chart.js/check/c/chart_dot_js/src/main/scala/typings/chartDotJsLib/chartDotJsMod/ChartNs/ChartData.scala
+++ b/importer/src/test/resources/chart.js/check/c/chart_dot_js/src/main/scala/typings/chartDotJsLib/chartDotJsMod/ChartNs/ChartData.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ChartData extends js.Object {
   var labels: js.UndefOr[js.Array[java.lang.String | js.Array[java.lang.String]]] = js.undefined
 }

--- a/importer/src/test/resources/chart.js/check/c/chart_dot_js/src/main/scala/typings/chartDotJsLib/chartDotJsMod/ChartNs/ChartFontOptions.scala
+++ b/importer/src/test/resources/chart.js/check/c/chart_dot_js/src/main/scala/typings/chartDotJsLib/chartDotJsMod/ChartNs/ChartFontOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ChartFontOptions extends js.Object {
   var foo: scala.Boolean
 }

--- a/importer/src/test/resources/chart.js/check/c/chart_dot_js/src/main/scala/typings/chartDotJsLib/chartDotJsMod/ChartNs/ChartOptions.scala
+++ b/importer/src/test/resources/chart.js/check/c/chart_dot_js/src/main/scala/typings/chartDotJsLib/chartDotJsMod/ChartNs/ChartOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ChartOptions extends js.Object {
   // Plugins can require any options
   var plugins: js.UndefOr[org.scalablytyped.runtime.StringDictionary[js.Any]] = js.undefined

--- a/importer/src/test/resources/chart.js/check/c/chart_dot_js/src/main/scala/typings/chartDotJsLib/chartDotJsMod/namespaced.scala
+++ b/importer/src/test/resources/chart.js/check/c/chart_dot_js/src/main/scala/typings/chartDotJsLib/chartDotJsMod/namespaced.scala
@@ -17,6 +17,11 @@ class namespaced protected () extends Chart {
 @JSImport("chart.js", JSImport.Namespace)
 @js.native
 object namespaced extends js.Object {
+  val Chart: org.scalablytyped.runtime.Instantiable2[
+    /* context */ java.lang.String | stdLib.CanvasRenderingContext2D | stdLib.HTMLCanvasElement | (stdLib.ArrayLike[stdLib.CanvasRenderingContext2D | stdLib.HTMLCanvasElement]), 
+    /* options */ js.Any, 
+    chartDotJsLib.chartDotJsMod.Chart
+  ] = js.native
   var controllers: org.scalablytyped.runtime.StringDictionary[js.Any] = js.native
   var defaults: chartDotJsLib.Anon_Key = js.native
 }

--- a/importer/src/test/resources/chart.js/check/s/std/build.sbt
+++ b/importer/src/test/resources/chart.js/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-1ab5f2"
+version := "0.0-unknown-2cc44b"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/chart.js/check/s/std/src/main/scala/typings/stdLib/CanvasRenderingContext2D.scala
+++ b/importer/src/test/resources/chart.js/check/s/std/src/main/scala/typings/stdLib/CanvasRenderingContext2D.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait CanvasRenderingContext2D extends js.Object
 

--- a/importer/src/test/resources/chart.js/check/s/std/src/main/scala/typings/stdLib/HTMLCanvasElement.scala
+++ b/importer/src/test/resources/chart.js/check/s/std/src/main/scala/typings/stdLib/HTMLCanvasElement.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait HTMLCanvasElement extends js.Object
 

--- a/importer/src/test/resources/cldrjs/check/c/cldrjs/build.sbt
+++ b/importer/src/test/resources/cldrjs/check/c/cldrjs/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "cldrjs"
-version := "0.4.4-826fd2"
+version := "0.4.4-e3f245"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-20654c")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f6c17e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/cldrjs/check/c/cldrjs/src/main/scala/typings/cldrjsLib/cldrjsMod/selfNs/Attributes.scala
+++ b/importer/src/test/resources/cldrjs/check/c/cldrjs/src/main/scala/typings/cldrjsLib/cldrjsMod/selfNs/Attributes.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Attributes extends js.Object {
   var language: js.Any
 }

--- a/importer/src/test/resources/cldrjs/check/c/cldrjs/src/main/scala/typings/cldrjsLib/cldrjsMod/selfNs/CldrFactory.scala
+++ b/importer/src/test/resources/cldrjs/check/c/cldrjs/src/main/scala/typings/cldrjsLib/cldrjsMod/selfNs/CldrFactory.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait CldrFactory extends js.Object {
   def load(json: js.Any, otherJson: js.Any*): scala.Unit
   def off(

--- a/importer/src/test/resources/cldrjs/check/c/cldrjs/src/main/scala/typings/cldrjsLib/cldrjsMod/selfNs/CldrStatic.scala
+++ b/importer/src/test/resources/cldrjs/check/c/cldrjs/src/main/scala/typings/cldrjsLib/cldrjsMod/selfNs/CldrStatic.scala
@@ -6,13 +6,13 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 /**
-     * @name CldrStatic
-     * @memberof cldr
-     * @kind interface
-     *
-     * @description
-     * The cldr class definition.
-     */
+  * @name CldrStatic
+  * @memberof cldr
+  * @kind interface
+  *
+  * @description
+  * The cldr class definition.
+  */
 @js.native
 trait CldrStatic extends js.Object {
   @JSName("supplemental")

--- a/importer/src/test/resources/cldrjs/check/c/cldrjs/src/main/scala/typings/cldrjsLib/cldrjsMod/selfNs/TimeDataStatic.scala
+++ b/importer/src/test/resources/cldrjs/check/c/cldrjs/src/main/scala/typings/cldrjsLib/cldrjsMod/selfNs/TimeDataStatic.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait TimeDataStatic extends js.Object {
   def allowed(): java.lang.String
   def preferred(): java.lang.String

--- a/importer/src/test/resources/cldrjs/check/c/cldrjs/src/main/scala/typings/cldrjsLib/cldrjsMod/selfNs/WeekDataStatic.scala
+++ b/importer/src/test/resources/cldrjs/check/c/cldrjs/src/main/scala/typings/cldrjsLib/cldrjsMod/selfNs/WeekDataStatic.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait WeekDataStatic extends js.Object {
   def firstDay(): java.lang.String
   def minDays(): scala.Double

--- a/importer/src/test/resources/cldrjs/check/s/std/build.sbt
+++ b/importer/src/test/resources/cldrjs/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-20654c"
+version := "0.0-unknown-f6c17e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/cldrjs/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/cldrjs/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/commander/check/c/commander/build.sbt
+++ b/importer/src/test/resources/commander/check/c/commander/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "commander"
-version := "2.15.1-287d74"
+version := "2.15.1-de45df"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "node" % "0.0-unknown-6c61ad",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-eaf1a4")
+  "org.scalablytyped" %%% "node" % "0.0-unknown-15e4a1",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-10068e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/commander/check/c/commander/src/main/scala/typings/commanderLib/commanderMod/commanderNs/CommandOptions.scala
+++ b/importer/src/test/resources/commander/check/c/commander/src/main/scala/typings/commanderLib/commanderMod/commanderNs/CommandOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait CommandOptions extends js.Object {
   var isDefault: js.UndefOr[scala.Boolean] = js.undefined
   var noHelp: js.UndefOr[scala.Boolean] = js.undefined

--- a/importer/src/test/resources/commander/check/c/commander/src/main/scala/typings/commanderLib/commanderMod/commanderNs/ParseOptionsResult.scala
+++ b/importer/src/test/resources/commander/check/c/commander/src/main/scala/typings/commanderLib/commanderMod/commanderNs/ParseOptionsResult.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ParseOptionsResult extends js.Object {
   var args: js.Array[java.lang.String]
   var unknown: js.Array[java.lang.String]

--- a/importer/src/test/resources/commander/check/c/commander/src/main/scala/typings/commanderLib/commanderMod/localNs/Command.scala
+++ b/importer/src/test/resources/commander/check/c/commander/src/main/scala/typings/commanderLib/commanderMod/localNs/Command.scala
@@ -11,228 +11,104 @@ trait Command
      with /* key */ org.scalablytyped.runtime.StringDictionary[js.Any] {
   var args: js.Array[java.lang.String] = js.native
   /**
-           * Register callback `fn` for the command.
-           *
-           * @example
-           *      program
-           *        .command('help')
-           *        .description('display verbose help')
-           *        .action(function() {
-           *           // output help here
-           *        });
-           *
-           * @param {(...args: any[]) => void} fn
-           * @returns {Command} for chaining
-           */
-  def action(fn: js.Function1[/* repeated */js.Any, scala.Unit]): Command = js.native
+    * Register callback `fn` for the command.
+    *
+    * @example
+    *      program
+    *        .command('help')
+    *        .description('display verbose help')
+    *        .action(function() {
+    *           // output help here
+    *        });
+    *
+    * @param {(...args: any[]) => void} fn
+    * @returns {Command} for chaining
+    */
+  def action(fn: js.Function1[/* repeated */ js.Any, scala.Unit]): Command = js.native
   def alias(): java.lang.String = js.native
   /**
-           * Set an alias for the command.
-           *
-           * @param {string} alias
-           * @return {(Command | string)}
-           */
+    * Set an alias for the command.
+    *
+    * @param {string} alias
+    * @return {(Command | string)}
+    */
   def alias(alias: java.lang.String): Command = js.native
   /**
-           * Allow unknown options on the command line.
-           *
-           * @param {boolean} [arg] if `true` or omitted, no error will be thrown for unknown options.
-           * @returns {Command} for chaining
-           */
+    * Allow unknown options on the command line.
+    *
+    * @param {boolean} [arg] if `true` or omitted, no error will be thrown for unknown options.
+    * @returns {Command} for chaining
+    */
   def allowUnknownOption(): Command = js.native
-  /**
-           * Allow unknown options on the command line.
-           *
-           * @param {boolean} [arg] if `true` or omitted, no error will be thrown for unknown options.
-           * @returns {Command} for chaining
-           */
   def allowUnknownOption(arg: scala.Boolean): Command = js.native
   /**
-           * Define argument syntax for the top-level command.
-           *
-           * @param {string} desc
-           * @returns {Command} for chaining
-           */
+    * Define argument syntax for the top-level command.
+    *
+    * @param {string} desc
+    * @returns {Command} for chaining
+    */
   def arguments(desc: java.lang.String): Command = js.native
   /**
-           * Add command `name`.
-           *
-           * The `.action()` callback is invoked when the
-           * command `name` is specified via __ARGV__,
-           * and the remaining arguments are applied to the
-           * function for access.
-           *
-           * When the `name` is "*" an un-matched command
-           * will be passed as the first arg, followed by
-           * the rest of __ARGV__ remaining.
-           *
-           * @example
-           *      program
-           *        .version('0.0.1')
-           *        .option('-C, --chdir <path>', 'change the working directory')
-           *        .option('-c, --config <path>', 'set config path. defaults to ./deploy.conf')
-           *        .option('-T, --no-tests', 'ignore test hook')
-           *
-           *      program
-           *        .command('setup')
-           *        .description('run remote setup commands')
-           *        .action(function() {
-           *          console.log('setup');
-           *        });
-           *
-           *      program
-           *        .command('exec <cmd>')
-           *        .description('run the given remote command')
-           *        .action(function(cmd) {
-           *          console.log('exec "%s"', cmd);
-           *        });
-           *
-           *      program
-           *        .command('teardown <dir> [otherDirs...]')
-           *        .description('run teardown commands')
-           *        .action(function(dir, otherDirs) {
-           *          console.log('dir "%s"', dir);
-           *          if (otherDirs) {
-           *            otherDirs.forEach(function (oDir) {
-           *              console.log('dir "%s"', oDir);
-           *            });
-           *          }
-           *        });
-           *
-           *      program
-           *        .command('*')
-           *        .description('deploy the given env')
-           *        .action(function(env) {
-           *          console.log('deploying "%s"', env);
-           *        });
-           *
-           *      program.parse(process.argv);
-           *
-           * @param {string} name
-           * @param {string} [desc] for git-style sub-commands
-           * @param {CommandOptions} [opts] command options
-           * @returns {Command} the new command
-           */
+    * Add command `name`.
+    *
+    * The `.action()` callback is invoked when the
+    * command `name` is specified via __ARGV__,
+    * and the remaining arguments are applied to the
+    * function for access.
+    *
+    * When the `name` is "*" an un-matched command
+    * will be passed as the first arg, followed by
+    * the rest of __ARGV__ remaining.
+    *
+    * @example
+    *      program
+    *        .version('0.0.1')
+    *        .option('-C, --chdir <path>', 'change the working directory')
+    *        .option('-c, --config <path>', 'set config path. defaults to ./deploy.conf')
+    *        .option('-T, --no-tests', 'ignore test hook')
+    *
+    *      program
+    *        .command('setup')
+    *        .description('run remote setup commands')
+    *        .action(function() {
+    *          console.log('setup');
+    *        });
+    *
+    *      program
+    *        .command('exec <cmd>')
+    *        .description('run the given remote command')
+    *        .action(function(cmd) {
+    *          console.log('exec "%s"', cmd);
+    *        });
+    *
+    *      program
+    *        .command('teardown <dir> [otherDirs...]')
+    *        .description('run teardown commands')
+    *        .action(function(dir, otherDirs) {
+    *          console.log('dir "%s"', dir);
+    *          if (otherDirs) {
+    *            otherDirs.forEach(function (oDir) {
+    *              console.log('dir "%s"', oDir);
+    *            });
+    *          }
+    *        });
+    *
+    *      program
+    *        .command('*')
+    *        .description('deploy the given env')
+    *        .action(function(env) {
+    *          console.log('deploying "%s"', env);
+    *        });
+    *
+    *      program.parse(process.argv);
+    *
+    * @param {string} name
+    * @param {string} [desc] for git-style sub-commands
+    * @param {CommandOptions} [opts] command options
+    * @returns {Command} the new command
+    */
   def command(name: java.lang.String): Command = js.native
-  /**
-           * Add command `name`.
-           *
-           * The `.action()` callback is invoked when the
-           * command `name` is specified via __ARGV__,
-           * and the remaining arguments are applied to the
-           * function for access.
-           *
-           * When the `name` is "*" an un-matched command
-           * will be passed as the first arg, followed by
-           * the rest of __ARGV__ remaining.
-           *
-           * @example
-           *      program
-           *        .version('0.0.1')
-           *        .option('-C, --chdir <path>', 'change the working directory')
-           *        .option('-c, --config <path>', 'set config path. defaults to ./deploy.conf')
-           *        .option('-T, --no-tests', 'ignore test hook')
-           *
-           *      program
-           *        .command('setup')
-           *        .description('run remote setup commands')
-           *        .action(function() {
-           *          console.log('setup');
-           *        });
-           *
-           *      program
-           *        .command('exec <cmd>')
-           *        .description('run the given remote command')
-           *        .action(function(cmd) {
-           *          console.log('exec "%s"', cmd);
-           *        });
-           *
-           *      program
-           *        .command('teardown <dir> [otherDirs...]')
-           *        .description('run teardown commands')
-           *        .action(function(dir, otherDirs) {
-           *          console.log('dir "%s"', dir);
-           *          if (otherDirs) {
-           *            otherDirs.forEach(function (oDir) {
-           *              console.log('dir "%s"', oDir);
-           *            });
-           *          }
-           *        });
-           *
-           *      program
-           *        .command('*')
-           *        .description('deploy the given env')
-           *        .action(function(env) {
-           *          console.log('deploying "%s"', env);
-           *        });
-           *
-           *      program.parse(process.argv);
-           *
-           * @param {string} name
-           * @param {string} [desc] for git-style sub-commands
-           * @param {CommandOptions} [opts] command options
-           * @returns {Command} the new command
-           */
   def command(name: java.lang.String, desc: java.lang.String): Command = js.native
-  /**
-           * Add command `name`.
-           *
-           * The `.action()` callback is invoked when the
-           * command `name` is specified via __ARGV__,
-           * and the remaining arguments are applied to the
-           * function for access.
-           *
-           * When the `name` is "*" an un-matched command
-           * will be passed as the first arg, followed by
-           * the rest of __ARGV__ remaining.
-           *
-           * @example
-           *      program
-           *        .version('0.0.1')
-           *        .option('-C, --chdir <path>', 'change the working directory')
-           *        .option('-c, --config <path>', 'set config path. defaults to ./deploy.conf')
-           *        .option('-T, --no-tests', 'ignore test hook')
-           *
-           *      program
-           *        .command('setup')
-           *        .description('run remote setup commands')
-           *        .action(function() {
-           *          console.log('setup');
-           *        });
-           *
-           *      program
-           *        .command('exec <cmd>')
-           *        .description('run the given remote command')
-           *        .action(function(cmd) {
-           *          console.log('exec "%s"', cmd);
-           *        });
-           *
-           *      program
-           *        .command('teardown <dir> [otherDirs...]')
-           *        .description('run teardown commands')
-           *        .action(function(dir, otherDirs) {
-           *          console.log('dir "%s"', dir);
-           *          if (otherDirs) {
-           *            otherDirs.forEach(function (oDir) {
-           *              console.log('dir "%s"', oDir);
-           *            });
-           *          }
-           *        });
-           *
-           *      program
-           *        .command('*')
-           *        .description('deploy the given env')
-           *        .action(function(env) {
-           *          console.log('deploying "%s"', env);
-           *        });
-           *
-           *      program.parse(process.argv);
-           *
-           * @param {string} name
-           * @param {string} [desc] for git-style sub-commands
-           * @param {CommandOptions} [opts] command options
-           * @returns {Command} the new command
-           */
   def command(
     name: java.lang.String,
     desc: java.lang.String,
@@ -240,397 +116,148 @@ trait Command
   ): Command = js.native
   def description(): java.lang.String = js.native
   /**
-           * Set the description to `str`.
-           *
-           * @param {string} str
-           * @return {(Command | string)}
-           */
+    * Set the description to `str`.
+    *
+    * @param {string} str
+    * @return {(Command | string)}
+    */
   def description(str: java.lang.String): Command = js.native
   /** Output help information and exit.
-           *
-           * @param {(str: string) => string} [cb]
-           */
+    *
+    * @param {(str: string) => string} [cb]
+    */
   def help(): scala.Unit = js.native
-  /** Output help information and exit.
-           *
-           * @param {(str: string) => string} [cb]
-           */
   def help(cb: js.Function1[/* str */ java.lang.String, java.lang.String]): scala.Unit = js.native
   /**
-           * Get the name of the command.
-           *
-           * @return {string}
-           */
+    * Get the name of the command.
+    *
+    * @return {string}
+    */
   def name(): java.lang.String = js.native
   /**
-           * Set the name of the command.
-           *
-           * @param {string} str
-           * @return {Command}
-           */
+    * Set the name of the command.
+    *
+    * @param {string} str
+    * @return {Command}
+    */
   def name(str: java.lang.String): Command = js.native
   /**
-           * Define option with `flags`, `description` and optional
-           * coercion `fn`.
-           *
-           * The `flags` string should contain both the short and long flags,
-           * separated by comma, a pipe or space. The following are all valid
-           * all will output this way when `--help` is used.
-           *
-           *    "-p, --pepper"
-           *    "-p|--pepper"
-           *    "-p --pepper"
-           *
-           * @example
-           *     // simple boolean defaulting to false
-           *     program.option('-p, --pepper', 'add pepper');
-           *
-           *     --pepper
-           *     program.pepper
-           *     // => Boolean
-           *
-           *     // simple boolean defaulting to true
-           *     program.option('-C, --no-cheese', 'remove cheese');
-           *
-           *     program.cheese
-           *     // => true
-           *
-           *     --no-cheese
-           *     program.cheese
-           *     // => false
-           *
-           *     // required argument
-           *     program.option('-C, --chdir <path>', 'change the working directory');
-           *
-           *     --chdir /tmp
-           *     program.chdir
-           *     // => "/tmp"
-           *
-           *     // optional argument
-           *     program.option('-c, --cheese [type]', 'add cheese [marble]');
-           *
-           * @param {string} flags
-           * @param {string} [description]
-           * @param {((arg1: any, arg2: any) => void) | RegExp} [fn] function or default
-           * @param {*} [defaultValue]
-           * @returns {Command} for chaining
-           */
+    * Define option with `flags`, `description` and optional
+    * coercion `fn`.
+    *
+    * The `flags` string should contain both the short and long flags,
+    * separated by comma, a pipe or space. The following are all valid
+    * all will output this way when `--help` is used.
+    *
+    *    "-p, --pepper"
+    *    "-p|--pepper"
+    *    "-p --pepper"
+    *
+    * @example
+    *     // simple boolean defaulting to false
+    *     program.option('-p, --pepper', 'add pepper');
+    *
+    *     --pepper
+    *     program.pepper
+    *     // => Boolean
+    *
+    *     // simple boolean defaulting to true
+    *     program.option('-C, --no-cheese', 'remove cheese');
+    *
+    *     program.cheese
+    *     // => true
+    *
+    *     --no-cheese
+    *     program.cheese
+    *     // => false
+    *
+    *     // required argument
+    *     program.option('-C, --chdir <path>', 'change the working directory');
+    *
+    *     --chdir /tmp
+    *     program.chdir
+    *     // => "/tmp"
+    *
+    *     // optional argument
+    *     program.option('-c, --cheese [type]', 'add cheese [marble]');
+    *
+    * @param {string} flags
+    * @param {string} [description]
+    * @param {((arg1: any, arg2: any) => void) | RegExp} [fn] function or default
+    * @param {*} [defaultValue]
+    * @returns {Command} for chaining
+    */
   def option(flags: java.lang.String): Command = js.native
-  /**
-           * Define option with `flags`, `description` and optional
-           * coercion `fn`.
-           *
-           * The `flags` string should contain both the short and long flags,
-           * separated by comma, a pipe or space. The following are all valid
-           * all will output this way when `--help` is used.
-           *
-           *    "-p, --pepper"
-           *    "-p|--pepper"
-           *    "-p --pepper"
-           *
-           * @example
-           *     // simple boolean defaulting to false
-           *     program.option('-p, --pepper', 'add pepper');
-           *
-           *     --pepper
-           *     program.pepper
-           *     // => Boolean
-           *
-           *     // simple boolean defaulting to true
-           *     program.option('-C, --no-cheese', 'remove cheese');
-           *
-           *     program.cheese
-           *     // => true
-           *
-           *     --no-cheese
-           *     program.cheese
-           *     // => false
-           *
-           *     // required argument
-           *     program.option('-C, --chdir <path>', 'change the working directory');
-           *
-           *     --chdir /tmp
-           *     program.chdir
-           *     // => "/tmp"
-           *
-           *     // optional argument
-           *     program.option('-c, --cheese [type]', 'add cheese [marble]');
-           *
-           * @param {string} flags
-           * @param {string} [description]
-           * @param {((arg1: any, arg2: any) => void) | RegExp} [fn] function or default
-           * @param {*} [defaultValue]
-           * @returns {Command} for chaining
-           */
   def option(flags: java.lang.String, description: java.lang.String): Command = js.native
   def option(flags: java.lang.String, description: java.lang.String, defaultValue: js.Any): Command = js.native
-  /**
-           * Define option with `flags`, `description` and optional
-           * coercion `fn`.
-           *
-           * The `flags` string should contain both the short and long flags,
-           * separated by comma, a pipe or space. The following are all valid
-           * all will output this way when `--help` is used.
-           *
-           *    "-p, --pepper"
-           *    "-p|--pepper"
-           *    "-p --pepper"
-           *
-           * @example
-           *     // simple boolean defaulting to false
-           *     program.option('-p, --pepper', 'add pepper');
-           *
-           *     --pepper
-           *     program.pepper
-           *     // => Boolean
-           *
-           *     // simple boolean defaulting to true
-           *     program.option('-C, --no-cheese', 'remove cheese');
-           *
-           *     program.cheese
-           *     // => true
-           *
-           *     --no-cheese
-           *     program.cheese
-           *     // => false
-           *
-           *     // required argument
-           *     program.option('-C, --chdir <path>', 'change the working directory');
-           *
-           *     --chdir /tmp
-           *     program.chdir
-           *     // => "/tmp"
-           *
-           *     // optional argument
-           *     program.option('-c, --cheese [type]', 'add cheese [marble]');
-           *
-           * @param {string} flags
-           * @param {string} [description]
-           * @param {((arg1: any, arg2: any) => void) | RegExp} [fn] function or default
-           * @param {*} [defaultValue]
-           * @returns {Command} for chaining
-           */
   def option(
     flags: java.lang.String,
     description: java.lang.String,
     fn: js.Function2[/* arg1 */ js.Any, /* arg2 */ js.Any, scala.Unit]
   ): Command = js.native
-  /**
-           * Define option with `flags`, `description` and optional
-           * coercion `fn`.
-           *
-           * The `flags` string should contain both the short and long flags,
-           * separated by comma, a pipe or space. The following are all valid
-           * all will output this way when `--help` is used.
-           *
-           *    "-p, --pepper"
-           *    "-p|--pepper"
-           *    "-p --pepper"
-           *
-           * @example
-           *     // simple boolean defaulting to false
-           *     program.option('-p, --pepper', 'add pepper');
-           *
-           *     --pepper
-           *     program.pepper
-           *     // => Boolean
-           *
-           *     // simple boolean defaulting to true
-           *     program.option('-C, --no-cheese', 'remove cheese');
-           *
-           *     program.cheese
-           *     // => true
-           *
-           *     --no-cheese
-           *     program.cheese
-           *     // => false
-           *
-           *     // required argument
-           *     program.option('-C, --chdir <path>', 'change the working directory');
-           *
-           *     --chdir /tmp
-           *     program.chdir
-           *     // => "/tmp"
-           *
-           *     // optional argument
-           *     program.option('-c, --cheese [type]', 'add cheese [marble]');
-           *
-           * @param {string} flags
-           * @param {string} [description]
-           * @param {((arg1: any, arg2: any) => void) | RegExp} [fn] function or default
-           * @param {*} [defaultValue]
-           * @returns {Command} for chaining
-           */
   def option(
     flags: java.lang.String,
     description: java.lang.String,
     fn: js.Function2[/* arg1 */ js.Any, /* arg2 */ js.Any, scala.Unit],
     defaultValue: js.Any
   ): Command = js.native
-  /**
-           * Define option with `flags`, `description` and optional
-           * coercion `fn`.
-           *
-           * The `flags` string should contain both the short and long flags,
-           * separated by comma, a pipe or space. The following are all valid
-           * all will output this way when `--help` is used.
-           *
-           *    "-p, --pepper"
-           *    "-p|--pepper"
-           *    "-p --pepper"
-           *
-           * @example
-           *     // simple boolean defaulting to false
-           *     program.option('-p, --pepper', 'add pepper');
-           *
-           *     --pepper
-           *     program.pepper
-           *     // => Boolean
-           *
-           *     // simple boolean defaulting to true
-           *     program.option('-C, --no-cheese', 'remove cheese');
-           *
-           *     program.cheese
-           *     // => true
-           *
-           *     --no-cheese
-           *     program.cheese
-           *     // => false
-           *
-           *     // required argument
-           *     program.option('-C, --chdir <path>', 'change the working directory');
-           *
-           *     --chdir /tmp
-           *     program.chdir
-           *     // => "/tmp"
-           *
-           *     // optional argument
-           *     program.option('-c, --cheese [type]', 'add cheese [marble]');
-           *
-           * @param {string} flags
-           * @param {string} [description]
-           * @param {((arg1: any, arg2: any) => void) | RegExp} [fn] function or default
-           * @param {*} [defaultValue]
-           * @returns {Command} for chaining
-           */
   def option(flags: java.lang.String, description: java.lang.String, fn: stdLib.RegExp): Command = js.native
-  /**
-           * Define option with `flags`, `description` and optional
-           * coercion `fn`.
-           *
-           * The `flags` string should contain both the short and long flags,
-           * separated by comma, a pipe or space. The following are all valid
-           * all will output this way when `--help` is used.
-           *
-           *    "-p, --pepper"
-           *    "-p|--pepper"
-           *    "-p --pepper"
-           *
-           * @example
-           *     // simple boolean defaulting to false
-           *     program.option('-p, --pepper', 'add pepper');
-           *
-           *     --pepper
-           *     program.pepper
-           *     // => Boolean
-           *
-           *     // simple boolean defaulting to true
-           *     program.option('-C, --no-cheese', 'remove cheese');
-           *
-           *     program.cheese
-           *     // => true
-           *
-           *     --no-cheese
-           *     program.cheese
-           *     // => false
-           *
-           *     // required argument
-           *     program.option('-C, --chdir <path>', 'change the working directory');
-           *
-           *     --chdir /tmp
-           *     program.chdir
-           *     // => "/tmp"
-           *
-           *     // optional argument
-           *     program.option('-c, --cheese [type]', 'add cheese [marble]');
-           *
-           * @param {string} flags
-           * @param {string} [description]
-           * @param {((arg1: any, arg2: any) => void) | RegExp} [fn] function or default
-           * @param {*} [defaultValue]
-           * @returns {Command} for chaining
-           */
   def option(flags: java.lang.String, description: java.lang.String, fn: stdLib.RegExp, defaultValue: js.Any): Command = js.native
   /**
-           * Return an object containing options as key-value pairs
-           *
-           * @returns {{[key: string]: string}}
-           */
+    * Return an object containing options as key-value pairs
+    *
+    * @returns {{[key: string]: string}}
+    */
   def opts(): org.scalablytyped.runtime.StringDictionary[java.lang.String] = js.native
   /**
-           * Output help information for this command.
-           *
-           * @param {(str: string) => string} [cb]
-           */
+    * Output help information for this command.
+    *
+    * @param {(str: string) => string} [cb]
+    */
   def outputHelp(): scala.Unit = js.native
-  /**
-           * Output help information for this command.
-           *
-           * @param {(str: string) => string} [cb]
-           */
   def outputHelp(cb: js.Function1[/* str */ java.lang.String, java.lang.String]): scala.Unit = js.native
   /**
-           * Parse `argv`, settings options and invoking commands when defined.
-           *
-           * @param {string[]} argv
-           * @returns {Command} for chaining
-           */
+    * Parse `argv`, settings options and invoking commands when defined.
+    *
+    * @param {string[]} argv
+    * @returns {Command} for chaining
+    */
   def parse(argv: js.Array[java.lang.String]): Command = js.native
   /**
-           * Parse expected `args`.
-           *
-           * For example `["[type]"]` becomes `[{ required: false, name: 'type' }]`.
-           *
-           * @param {string[]} args
-           * @returns {Command} for chaining
-           */
+    * Parse expected `args`.
+    *
+    * For example `["[type]"]` becomes `[{ required: false, name: 'type' }]`.
+    *
+    * @param {string[]} args
+    * @returns {Command} for chaining
+    */
   def parseExpectedArgs(args: js.Array[java.lang.String]): Command = js.native
   /**
-           * Parse options from `argv` returning `argv` void of these options.
-           *
-           * @param {string[]} argv
-           * @returns {ParseOptionsResult}
-           */
+    * Parse options from `argv` returning `argv` void of these options.
+    *
+    * @param {string[]} argv
+    * @returns {ParseOptionsResult}
+    */
   def parseOptions(argv: js.Array[java.lang.String]): commanderLib.commanderMod.commanderNs.ParseOptionsResult = js.native
   def usage(): java.lang.String = js.native
   /**
-           * Set or get the command usage.
-           *
-           * @param {string} str
-           * @return {(Command | string)}
-           */
+    * Set or get the command usage.
+    *
+    * @param {string} str
+    * @return {(Command | string)}
+    */
   def usage(str: java.lang.String): Command = js.native
   /**
-           * Set the program version to `str`.
-           *
-           * This method auto-registers the "-V, --version" flag
-           * which will print the version number when passed.
-           *
-           * @param {string} str
-           * @param {string} [flags]
-           * @returns {Command} for chaining
-           */
+    * Set the program version to `str`.
+    *
+    * This method auto-registers the "-V, --version" flag
+    * which will print the version number when passed.
+    *
+    * @param {string} str
+    * @param {string} [flags]
+    * @returns {Command} for chaining
+    */
   def version(str: java.lang.String): Command = js.native
-  /**
-           * Set the program version to `str`.
-           *
-           * This method auto-registers the "-V, --version" flag
-           * which will print the version number when passed.
-           *
-           * @param {string} str
-           * @param {string} [flags]
-           * @returns {Command} for chaining
-           */
   def version(str: java.lang.String, flags: java.lang.String): Command = js.native
 }
 

--- a/importer/src/test/resources/commander/check/c/commander/src/main/scala/typings/commanderLib/commanderMod/localNs/Option.scala
+++ b/importer/src/test/resources/commander/check/c/commander/src/main/scala/typings/commanderLib/commanderMod/localNs/Option.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Option extends js.Object {
   var bool: scala.Boolean
   var description: java.lang.String

--- a/importer/src/test/resources/commander/check/n/node/build.sbt
+++ b/importer/src/test/resources/commander/check/n/node/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "0.0-unknown-6c61ad"
+version := "0.0-unknown-15e4a1"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-eaf1a4")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-10068e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/commander/check/n/node/src/main/scala/typings/nodeLib/NodeJSNs/EventEmitter.scala
+++ b/importer/src/test/resources/commander/check/n/node/src/main/scala/typings/nodeLib/NodeJSNs/EventEmitter.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait EventEmitter extends js.Object
 

--- a/importer/src/test/resources/commander/check/s/std/build.sbt
+++ b/importer/src/test/resources/commander/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-eaf1a4"
+version := "0.0-unknown-10068e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/commander/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/commander/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/commander/check/s/std/src/main/scala/typings/stdLib/RegExp.scala
+++ b/importer/src/test/resources/commander/check/s/std/src/main/scala/typings/stdLib/RegExp.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait RegExp extends js.Object
 

--- a/importer/src/test/resources/create-error/check/c/create-error/build.sbt
+++ b/importer/src/test/resources/create-error/check/c/create-error/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "create-error"
-version := "0.3.1-5fb8e1"
+version := "0.3.1-55cbc5"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-de23c2")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-c5616f")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/create-error/check/s/std/build.sbt
+++ b/importer/src/test/resources/create-error/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-de23c2"
+version := "0.0-unknown-c5616f"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/create-error/check/s/std/src/main/scala/typings/stdLib/Error.scala
+++ b/importer/src/test/resources/create-error/check/s/std/src/main/scala/typings/stdLib/Error.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Error extends js.Object
 

--- a/importer/src/test/resources/defaulted-tparams/check/d/defaulted-tparams/build.sbt
+++ b/importer/src/test/resources/defaulted-tparams/check/d/defaulted-tparams/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "defaulted-tparams"
-version := "0.0-unknown-6147a4"
+version := "0.0-unknown-23ad30"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-019a16")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4ca018")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/defaulted-tparams/check/d/defaulted-tparams/src/main/scala/typings/defaultedDashTparamsLib/Queue.scala
+++ b/importer/src/test/resources/defaulted-tparams/check/d/defaulted-tparams/src/main/scala/typings/defaultedDashTparamsLib/Queue.scala
@@ -9,24 +9,24 @@ import scala.scalajs.js.annotation._
 @js.native
 class Queue[S, T] () extends js.Object {
   /**
-       * Whether the queue is empty
-       */
+    * Whether the queue is empty
+    */
   val empty: scala.Boolean = js.native
   /**
-       * Whether the queue is full
-       */
+    * Whether the queue is full
+    */
   val full: scala.Boolean = js.native
   /**
-       * The length of the queue
-       */
+    * The length of the queue
+    */
   val length: scala.Double = js.native
   /**
-       * Removes and returns an element from the beginning
-       */
+    * Removes and returns an element from the beginning
+    */
   def pop(): js.UndefOr[T] = js.native
   /**
-       * Inserts a new element at the end
-       */
+    * Inserts a new element at the end
+    */
   def push(x: S): this.type = js.native
 }
 

--- a/importer/src/test/resources/defaulted-tparams/check/s/std/build.sbt
+++ b/importer/src/test/resources/defaulted-tparams/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-019a16"
+version := "0.0-unknown-4ca018"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/defaulted-tparams/check/s/std/src/main/scala/typings/stdLib/Iterable.scala
+++ b/importer/src/test/resources/defaulted-tparams/check/s/std/src/main/scala/typings/stdLib/Iterable.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Iterable[T] extends js.Object
 

--- a/importer/src/test/resources/electron/check/e/electron/build.sbt
+++ b/importer/src/test/resources/electron/check/e/electron/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "electron"
-version := "2.0.0-d8d9c5"
+version := "2.0.0-62df3a"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "node" % "0.0-unknown-f66666",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ecf678")
+  "org.scalablytyped" %%% "node" % "0.0-unknown-89fbe9",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-9785a2")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/electron/check/e/electron/src/main/scala/typings/electronLib/ElectronNs/App.scala
+++ b/importer/src/test/resources/electron/check/e/electron/src/main/scala/typings/electronLib/ElectronNs/App.scala
@@ -9,11 +9,11 @@ import scala.scalajs.js.annotation._
 trait App extends EventEmitter {
   // Docs: http://electron.atom.io/docs/api/app
   /**
-       * Emitted when Chrome's accessibility support changes. This event fires when
-       * assistive technologies, such as screen readers, are enabled or disabled. See
-       * https://www.chromium.org/developers/design-documents/accessibility for more
-       * details.
-       */
+    * Emitted when Chrome's accessibility support changes. This event fires when
+    * assistive technologies, such as screen readers, are enabled or disabled. See
+    * https://www.chromium.org/developers/design-documents/accessibility for more
+    * details.
+    */
   @JSName("on")
   def `on_accessibility-support-changed`(event: electronLib.electronLibStrings.`accessibility-support-changed`, listener: js.Any): java.lang.String = js.native
 }

--- a/importer/src/test/resources/electron/check/e/electron/src/main/scala/typings/electronLib/ElectronNs/CommonInterface.scala
+++ b/importer/src/test/resources/electron/check/e/electron/src/main/scala/typings/electronLib/ElectronNs/CommonInterface.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait CommonInterface extends js.Object
 

--- a/importer/src/test/resources/electron/check/e/electron/src/main/scala/typings/electronLib/ElectronNs/Event.scala
+++ b/importer/src/test/resources/electron/check/e/electron/src/main/scala/typings/electronLib/ElectronNs/Event.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Event
   extends stdLib.Event {
   var altKey: js.UndefOr[scala.Boolean] = js.undefined

--- a/importer/src/test/resources/electron/check/e/electron/src/main/scala/typings/electronLib/ElectronNs/MainInterface.scala
+++ b/importer/src/test/resources/electron/check/e/electron/src/main/scala/typings/electronLib/ElectronNs/MainInterface.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait MainInterface extends CommonInterface {
   var app: App
 }

--- a/importer/src/test/resources/electron/check/n/node/build.sbt
+++ b/importer/src/test/resources/electron/check/n/node/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "0.0-unknown-f66666"
+version := "0.0-unknown-89fbe9"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ecf678")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-9785a2")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/electron/check/n/node/src/main/scala/typings/nodeLib/Error.scala
+++ b/importer/src/test/resources/electron/check/n/node/src/main/scala/typings/nodeLib/Error.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Error extends js.Object {
   var stack: js.UndefOr[java.lang.String] = js.undefined
 }

--- a/importer/src/test/resources/electron/check/n/node/src/main/scala/typings/nodeLib/NodeJSNs/ErrnoException.scala
+++ b/importer/src/test/resources/electron/check/n/node/src/main/scala/typings/nodeLib/NodeJSNs/ErrnoException.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ErrnoException
   extends nodeLib.Error {
   var code: js.UndefOr[java.lang.String] = js.undefined

--- a/importer/src/test/resources/electron/check/n/node/src/main/scala/typings/nodeLib/SymbolConstructor.scala
+++ b/importer/src/test/resources/electron/check/n/node/src/main/scala/typings/nodeLib/SymbolConstructor.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait SymbolConstructor extends js.Object {
   val asyncIterator: js.Symbol
   val iterator: js.Symbol

--- a/importer/src/test/resources/electron/check/n/node/src/main/scala/typings/nodeLib/streamMod/internalNs/Stream.scala
+++ b/importer/src/test/resources/electron/check/n/node/src/main/scala/typings/nodeLib/streamMod/internalNs/Stream.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Stream extends js.Object
 

--- a/importer/src/test/resources/electron/check/s/std/build.sbt
+++ b/importer/src/test/resources/electron/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-ecf678"
+version := "0.0-unknown-9785a2"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/Boolean.scala
+++ b/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/Boolean.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Boolean extends js.Object
 

--- a/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/Event.scala
+++ b/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/Event.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Event extends js.Object
 

--- a/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/IArguments.scala
+++ b/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/IArguments.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait IArguments extends js.Object
 

--- a/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/Number.scala
+++ b/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/Number.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Number extends js.Object
 

--- a/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/Object.scala
+++ b/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/Object.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Object extends js.Object
 

--- a/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/RegExp.scala
+++ b/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/RegExp.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait RegExp extends js.Object
 

--- a/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/String.scala
+++ b/importer/src/test/resources/electron/check/s/std/src/main/scala/typings/stdLib/String.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait String extends js.Object
 

--- a/importer/src/test/resources/export-as-namespace/check/a/angular-agility/build.sbt
+++ b/importer/src/test/resources/export-as-namespace/check/a/angular-agility/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "angular-agility"
-version := "0.0-unknown-69d698"
+version := "0.0-unknown-d8bf35"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "angular" % "1.6-f4a783",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ce3565")
+  "org.scalablytyped" %%% "angular" % "1.6-d4d05e",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-093c5c")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/export-as-namespace/check/a/angular-agility/src/main/scala/typings/angularDashAgilityLib/aaNs/INotifyConfigProvider.scala
+++ b/importer/src/test/resources/export-as-namespace/check/a/angular-agility/src/main/scala/typings/angularDashAgilityLib/aaNs/INotifyConfigProvider.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait INotifyConfigProvider
   extends angularLib.angularMod.angularNs.IServiceProvider {
   var defaultNotifyConfig: java.lang.String

--- a/importer/src/test/resources/export-as-namespace/check/a/angular/build.sbt
+++ b/importer/src/test/resources/export-as-namespace/check/a/angular/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "angular"
-version := "1.6-f4a783"
+version := "1.6-d4d05e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ce3565")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-093c5c")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/export-as-namespace/check/a/angular/src/main/scala/typings/angularLib/JQLite.scala
+++ b/importer/src/test/resources/export-as-namespace/check/a/angular/src/main/scala/typings/angularLib/JQLite.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait JQLite
   extends JQuery
      with /* index */ org.scalablytyped.runtime.NumberDictionary[stdLib.HTMLElement]

--- a/importer/src/test/resources/export-as-namespace/check/a/angular/src/main/scala/typings/angularLib/JQuery.scala
+++ b/importer/src/test/resources/export-as-namespace/check/a/angular/src/main/scala/typings/angularLib/JQuery.scala
@@ -5,14 +5,13 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait JQuery extends js.Object {
   /**
-       * Adds the specified class(es) to each of the set of matched elements.
-       *
-       * @param className One or more space-separated classes to be added to the class attribute of each matched element.
-       * @see {@link https://api.jquery.com/addClass/#addClass-className}
-       */
+    * Adds the specified class(es) to each of the set of matched elements.
+    *
+    * @param className One or more space-separated classes to be added to the class attribute of each matched element.
+    * @see {@link https://api.jquery.com/addClass/#addClass-className}
+    */
   def addClass(className: java.lang.String): this.type
   def injector(): angularLib.angularMod.angularNs.autoNs.IInjectorService
 }

--- a/importer/src/test/resources/export-as-namespace/check/a/angular/src/main/scala/typings/angularLib/angularMod/angularNs/IAngularStatic.scala
+++ b/importer/src/test/resources/export-as-namespace/check/a/angular/src/main/scala/typings/angularLib/angularMod/angularNs/IAngularStatic.scala
@@ -12,57 +12,32 @@ import scala.scalajs.js.annotation._
 @js.native
 trait IAngularStatic extends js.Object {
   /**
-           * Wraps a raw DOM element or HTML string as a jQuery element.
-           *
-           * If jQuery is available, angular.element is an alias for the jQuery function. If jQuery is not available, angular.element delegates to Angular's built-in subset of jQuery, called "jQuery lite" or "jqLite."
-           */
+    * Wraps a raw DOM element or HTML string as a jQuery element.
+    *
+    * If jQuery is available, angular.element is an alias for the jQuery function. If jQuery is not available, angular.element delegates to Angular's built-in subset of jQuery, called "jQuery lite" or "jqLite."
+    */
   @JSName("element")
   var element_Original: angularLib.JQueryStatic = js.native
   /**
-           * If window.name contains prefix NG_DEFER_BOOTSTRAP! when angular.bootstrap is called, the bootstrap process will be paused until angular.resumeBootstrap() is called.
-           * @param extraModules An optional array of modules that should be added to the original list of modules that the app was about to be bootstrapped with.
-           */
+    * If window.name contains prefix NG_DEFER_BOOTSTRAP! when angular.bootstrap is called, the bootstrap process will be paused until angular.resumeBootstrap() is called.
+    * @param extraModules An optional array of modules that should be added to the original list of modules that the app was about to be bootstrapped with.
+    */
   var resumeBootstrap: js.UndefOr[
     js.Function1[
       /* extraModules */ js.UndefOr[js.Array[java.lang.String]], 
       angularLib.angularMod.angularNs.autoNs.IInjectorService
     ]
   ] = js.native
-  /**
-           * Wraps a raw DOM element or HTML string as a jQuery element.
-           *
-           * If jQuery is available, angular.element is an alias for the jQuery function. If jQuery is not available, angular.element delegates to Angular's built-in subset of jQuery, called "jQuery lite" or "jqLite."
-           */
   def element(element: angularLib.JQuery): angularLib.JQLite = js.native
   /**
-           * Wraps a raw DOM element or HTML string as a jQuery element.
-           *
-           * If jQuery is available, angular.element is an alias for the jQuery function. If jQuery is not available, angular.element delegates to Angular's built-in subset of jQuery, called "jQuery lite" or "jqLite."
-           */
+    * Wraps a raw DOM element or HTML string as a jQuery element.
+    *
+    * If jQuery is available, angular.element is an alias for the jQuery function. If jQuery is not available, angular.element delegates to Angular's built-in subset of jQuery, called "jQuery lite" or "jqLite."
+    */
   def element(element: java.lang.String): angularLib.JQLite = js.native
-  /**
-           * Wraps a raw DOM element or HTML string as a jQuery element.
-           *
-           * If jQuery is available, angular.element is an alias for the jQuery function. If jQuery is not available, angular.element delegates to Angular's built-in subset of jQuery, called "jQuery lite" or "jqLite."
-           */
   def element(element: js.Function0[scala.Unit]): angularLib.JQLite = js.native
-  /**
-           * Wraps a raw DOM element or HTML string as a jQuery element.
-           *
-           * If jQuery is available, angular.element is an alias for the jQuery function. If jQuery is not available, angular.element delegates to Angular's built-in subset of jQuery, called "jQuery lite" or "jqLite."
-           */
   def element(element: stdLib.ArrayLike[stdLib.Element]): angularLib.JQLite = js.native
-  /**
-           * Wraps a raw DOM element or HTML string as a jQuery element.
-           *
-           * If jQuery is available, angular.element is an alias for the jQuery function. If jQuery is not available, angular.element delegates to Angular's built-in subset of jQuery, called "jQuery lite" or "jqLite."
-           */
   def element(element: stdLib.Document): angularLib.JQLite = js.native
-  /**
-           * Wraps a raw DOM element or HTML string as a jQuery element.
-           *
-           * If jQuery is available, angular.element is an alias for the jQuery function. If jQuery is not available, angular.element delegates to Angular's built-in subset of jQuery, called "jQuery lite" or "jqLite."
-           */
   def element(element: stdLib.Element): angularLib.JQLite = js.native
   def equals(value1: js.Any, value2: js.Any): scala.Boolean = js.native
   def extend(destination: js.Any, sources: js.Any*): js.Any = js.native

--- a/importer/src/test/resources/export-as-namespace/check/a/angular/src/main/scala/typings/angularLib/angularMod/angularNs/IServiceProvider.scala
+++ b/importer/src/test/resources/export-as-namespace/check/a/angular/src/main/scala/typings/angularLib/angularMod/angularNs/IServiceProvider.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 // All service providers extend this interface
-
 trait IServiceProvider extends js.Object {
   @JSName("$get")
   var $get: js.Any

--- a/importer/src/test/resources/export-as-namespace/check/a/angular/src/main/scala/typings/angularLib/angularMod/angularNs/autoNs/IInjectorService.scala
+++ b/importer/src/test/resources/export-as-namespace/check/a/angular/src/main/scala/typings/angularLib/angularMod/angularNs/autoNs/IInjectorService.scala
@@ -21,14 +21,14 @@ trait IInjectorService extends js.Object {
   def instantiate[T](typeConstructor: angularLib.Anon_Args[T]): T = js.native
   def instantiate[T](typeConstructor: angularLib.Anon_Args[T], locals: js.Any): T = js.native
   def invoke[T](
-    func: angularLib.angularMod.angularNs.Injectable[angularLib.angularMod.Global.Function | (js.Function1[/* repeated */_, T])]
+    func: angularLib.angularMod.angularNs.Injectable[angularLib.angularMod.Global.Function | (js.Function1[/* repeated */ _, T])]
   ): T = js.native
   def invoke[T](
-    func: angularLib.angularMod.angularNs.Injectable[angularLib.angularMod.Global.Function | (js.Function1[/* repeated */_, T])],
+    func: angularLib.angularMod.angularNs.Injectable[angularLib.angularMod.Global.Function | (js.Function1[/* repeated */ _, T])],
     context: js.Any
   ): T = js.native
   def invoke[T](
-    func: angularLib.angularMod.angularNs.Injectable[angularLib.angularMod.Global.Function | (js.Function1[/* repeated */_, T])],
+    func: angularLib.angularMod.angularNs.Injectable[angularLib.angularMod.Global.Function | (js.Function1[/* repeated */ _, T])],
     context: js.Any,
     locals: js.Any
   ): T = js.native

--- a/importer/src/test/resources/export-as-namespace/check/s/std/build.sbt
+++ b/importer/src/test/resources/export-as-namespace/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-ce3565"
+version := "0.0-unknown-093c5c"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/export-as-namespace/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/export-as-namespace/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/export-as-namespace/check/s/std/src/main/scala/typings/stdLib/ArrayLike.scala
+++ b/importer/src/test/resources/export-as-namespace/check/s/std/src/main/scala/typings/stdLib/ArrayLike.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ArrayLike[T] extends js.Object
 

--- a/importer/src/test/resources/export-as-namespace/check/s/std/src/main/scala/typings/stdLib/Document.scala
+++ b/importer/src/test/resources/export-as-namespace/check/s/std/src/main/scala/typings/stdLib/Document.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Document extends js.Object
 

--- a/importer/src/test/resources/export-as-namespace/check/s/std/src/main/scala/typings/stdLib/Element.scala
+++ b/importer/src/test/resources/export-as-namespace/check/s/std/src/main/scala/typings/stdLib/Element.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Element extends js.Object
 

--- a/importer/src/test/resources/export-as-namespace/check/s/std/src/main/scala/typings/stdLib/ReadonlyArray.scala
+++ b/importer/src/test/resources/export-as-namespace/check/s/std/src/main/scala/typings/stdLib/ReadonlyArray.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ReadonlyArray[T] extends js.Object
 

--- a/importer/src/test/resources/fp-ts/check/f/fp-ts/build.sbt
+++ b/importer/src/test/resources/fp-ts/check/f/fp-ts/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "fp-ts"
-version := "1.2.0-9e09b8"
+version := "1.2.0-6836f4"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-15c3b6")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f770d2")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/fp-ts/check/f/fp-ts/src/main/scala/typings/fpDashTsLib/Anon_Never.scala
+++ b/importer/src/test/resources/fp-ts/check/f/fp-ts/src/main/scala/typings/fpDashTsLib/Anon_Never.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_Never extends js.Object {
   var never: fpDashTsLib.libHKTMod.HKT[scala.Nothing, scala.Nothing]
 }

--- a/importer/src/test/resources/fp-ts/check/f/fp-ts/src/main/scala/typings/fpDashTsLib/libEitherTMod/EitherT.scala
+++ b/importer/src/test/resources/fp-ts/check/f/fp-ts/src/main/scala/typings/fpDashTsLib/libEitherTMod/EitherT.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait EitherT[F]
   extends Foo[F, fpDashTsLib.libEitherMod.URI] {
   def chain[L, A, B](

--- a/importer/src/test/resources/fp-ts/check/f/fp-ts/src/main/scala/typings/fpDashTsLib/libEitherTMod/Foo.scala
+++ b/importer/src/test/resources/fp-ts/check/f/fp-ts/src/main/scala/typings/fpDashTsLib/libEitherTMod/Foo.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Foo[T, U] extends js.Object
 

--- a/importer/src/test/resources/fp-ts/check/f/fp-ts/src/main/scala/typings/fpDashTsLib/libHKTMod/HKT.scala
+++ b/importer/src/test/resources/fp-ts/check/f/fp-ts/src/main/scala/typings/fpDashTsLib/libHKTMod/HKT.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait HKT[URI, A] extends js.Object {
   val _A: A
   val _URI: URI

--- a/importer/src/test/resources/fp-ts/check/f/fp-ts/src/main/scala/typings/fpDashTsLib/libHKTMod/URI2HKT.scala
+++ b/importer/src/test/resources/fp-ts/check/f/fp-ts/src/main/scala/typings/fpDashTsLib/libHKTMod/URI2HKT.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait URI2HKT[A] extends js.Object
 

--- a/importer/src/test/resources/fp-ts/check/f/fp-ts/src/main/scala/typings/fpDashTsLib/libHKTMod/package.scala
+++ b/importer/src/test/resources/fp-ts/check/f/fp-ts/src/main/scala/typings/fpDashTsLib/libHKTMod/package.scala
@@ -6,6 +6,6 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 package object libHKTMod {
-  type Type[URI /* <: URIS */, A] = js.Any
-  type URIS = /* import warning: Failed type conversion: TsTypeLookup(TsTypeLookup(TsTypeIntersect(List(TsTypeRef(TsQIdent(List(TsIdentLibrarySimple(fp-ts), TsIdentModule(None,List(fp-ts, lib, HKT)), TsIdentSimple(URI2HKT))),List(TsTypeRef(TsQIdent(List(TsIdentSimple(any))),List()))), TsTypeRef(TsQIdent(List(TsIdentLibrarySimple(fp-ts), TsIdentSimple(Anon_Never))),List()))),Right(TsTypeKeyOf(TsTypeUnion(List(TsTypeRef(TsQIdent(List(TsIdentLibrarySimple(fp-ts), TsIdentModule(None,List(fp-ts, lib, HKT)), TsIdentSimple(URI2HKT))),List(TsTypeRef(TsQIdent(List(TsIdentSimple(any))),List()))), TsTypeLiteral(TsLiteralString(never))))))),Left(TsIdentSimple(_URI))) */js.Any
+  type Type[URI /* <: URIS */, A] = /* import warning: ImportType.apply Failed type conversion: fp-ts.fp-ts/lib/HKT.URI2HKT<A>[URI] */ js.Any
+  type URIS = /* import warning: ImportType.apply Failed type conversion: fp-ts.fp-ts/lib/HKT.URI2HKT<any> & fp-ts.Anon_Never[keyof fp-ts.fp-ts/lib/HKT.URI2HKT<any> | 'never']['_URI'] */ js.Any
 }

--- a/importer/src/test/resources/fp-ts/check/s/std/build.sbt
+++ b/importer/src/test/resources/fp-ts/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-15c3b6"
+version := "0.0-unknown-f770d2"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/fp-ts/check/s/std/src/main/scala/typings/stdLib/Promise.scala
+++ b/importer/src/test/resources/fp-ts/check/s/std/src/main/scala/typings/stdLib/Promise.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Promise[T] extends js.Object
 

--- a/importer/src/test/resources/fullcalendar/check/f/fullcalendar/build.sbt
+++ b/importer/src/test/resources/fullcalendar/check/f/fullcalendar/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "fullcalendar"
-version := "0.0-unknown-2a07d8"
+version := "0.0-unknown-f4bd3c"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-20654c")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f6c17e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/fullcalendar/check/f/fullcalendar/src/main/scala/typings/fullcalendarLib/emittermixinMod/EmitterInterface.scala
+++ b/importer/src/test/resources/fullcalendar/check/f/fullcalendar/src/main/scala/typings/fullcalendarLib/emittermixinMod/EmitterInterface.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait EmitterInterface extends js.Object {
   def on(types: js.Any, handler: js.Any): js.Any
 }

--- a/importer/src/test/resources/fullcalendar/check/s/std/build.sbt
+++ b/importer/src/test/resources/fullcalendar/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-20654c"
+version := "0.0-unknown-f6c17e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/fullcalendar/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/fullcalendar/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/insight/check/i/insight/build.sbt
+++ b/importer/src/test/resources/insight/check/i/insight/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "insight"
-version := "0.0-unknown-48319d"
+version := "0.0-unknown-c7880d"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-20654c")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f6c17e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/insight/check/i/insight/src/main/scala/typings/insightLib/insightMod/Insight.scala
+++ b/importer/src/test/resources/insight/check/i/insight/src/main/scala/typings/insightLib/insightMod/Insight.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Insight extends js.Object {
   var clientId: java.lang.String
   var config: insightLib.insightMod.insightNs.IConfigstore

--- a/importer/src/test/resources/insight/check/i/insight/src/main/scala/typings/insightLib/insightMod/insightNs/IConfigstore.scala
+++ b/importer/src/test/resources/insight/check/i/insight/src/main/scala/typings/insightLib/insightMod/insightNs/IConfigstore.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait IConfigstore extends js.Object {
   var all: js.Any
   var path: java.lang.String

--- a/importer/src/test/resources/insight/check/i/insight/src/main/scala/typings/insightLib/insightMod/insightNs/IOptions.scala
+++ b/importer/src/test/resources/insight/check/i/insight/src/main/scala/typings/insightLib/insightMod/insightNs/IOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait IOptions extends js.Object {
   var trackingCode: java.lang.String
 }

--- a/importer/src/test/resources/insight/check/s/std/build.sbt
+++ b/importer/src/test/resources/insight/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-20654c"
+version := "0.0-unknown-f6c17e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/insight/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/insight/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/material-ui/check/m/material-ui/build.sbt
+++ b/importer/src/test/resources/material-ui/check/m/material-ui/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "material-ui"
-version := "0.0-unknown-34fb63"
+version := "0.0-unknown-9fce5b"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-1845d4",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-7949e8")
+  "org.scalablytyped" %%% "react" % "0.0-unknown-c9d5f7",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d66db1")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/material-ui/check/m/material-ui/src/main/scala/typings/materialDashUiLib/underscoreUnderscoreMaterialUINs/BottomNavigationNs/BottomNavigationItemProps.scala
+++ b/importer/src/test/resources/material-ui/check/m/material-ui/src/main/scala/typings/materialDashUiLib/underscoreUnderscoreMaterialUINs/BottomNavigationNs/BottomNavigationItemProps.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait BottomNavigationItemProps extends js.Object {
   var className: js.UndefOr[java.lang.String] = js.undefined
 }

--- a/importer/src/test/resources/material-ui/check/m/material-ui/src/main/scala/typings/materialDashUiLib/underscoreUnderscoreMaterialUINs/StylesNs/MuiTheme.scala
+++ b/importer/src/test/resources/material-ui/check/m/material-ui/src/main/scala/typings/materialDashUiLib/underscoreUnderscoreMaterialUINs/StylesNs/MuiTheme.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait MuiTheme extends js.Object {
   var spacing: js.UndefOr[js.Any] = js.undefined
 }

--- a/importer/src/test/resources/material-ui/check/r/react/build.sbt
+++ b/importer/src/test/resources/material-ui/check/r/react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-1845d4"
+version := "0.0-unknown-c9d5f7"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-7949e8")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d66db1")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/material-ui/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Component.scala
+++ b/importer/src/test/resources/material-ui/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Component.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Component[P, S] extends js.Object
 

--- a/importer/src/test/resources/material-ui/check/s/std/build.sbt
+++ b/importer/src/test/resources/material-ui/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-7949e8"
+version := "0.0-unknown-d66db1"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/material-ui/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/material-ui/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/material-ui/check/s/std/src/main/scala/typings/stdLib/Node.scala
+++ b/importer/src/test/resources/material-ui/check/s/std/src/main/scala/typings/stdLib/Node.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Node extends js.Object
 

--- a/importer/src/test/resources/monaco-editor/check/m/monaco-editor/build.sbt
+++ b/importer/src/test/resources/monaco-editor/check/m/monaco-editor/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "monaco-editor"
-version := "0.0-unknown-568ffc"
+version := "0.0-unknown-52562e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/monaco-editor/check/m/monaco-editor/src/main/scala/typings/monacoDashEditorLib/Anon_Key.scala
+++ b/importer/src/test/resources/monaco-editor/check/m/monaco-editor/src/main/scala/typings/monacoDashEditorLib/Anon_Key.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_Key[T] extends js.Object {
   var key: java.lang.String
   var value: monacoDashEditorLib.monacoNs.Promise[T, _]

--- a/importer/src/test/resources/mongoose-simple-random/check/m/mongoose-simple-random/build.sbt
+++ b/importer/src/test/resources/mongoose-simple-random/check/m/mongoose-simple-random/build.sbt
@@ -1,14 +1,14 @@
 organization := "org.scalablytyped"
 name := "mongoose-simple-random"
-version := "0.4-34e116"
+version := "0.4-1ab64d"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "mongoose" % "0.0-unknown-a2e620",
-  "org.scalablytyped" %%% "node" % "0.0-unknown-0deac5",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-032a31")
+  "org.scalablytyped" %%% "mongoose" % "0.0-unknown-98bacf",
+  "org.scalablytyped" %%% "node" % "0.0-unknown-e2d417",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-2374ff")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/mongoose-simple-random/check/m/mongoose/build.sbt
+++ b/importer/src/test/resources/mongoose-simple-random/check/m/mongoose/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "mongoose"
-version := "0.0-unknown-a2e620"
+version := "0.0-unknown-98bacf"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-032a31")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-2374ff")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/mongoose-simple-random/check/m/mongoose/src/main/scala/typings/mongooseLib/mongooseMod/Document.scala
+++ b/importer/src/test/resources/mongoose-simple-random/check/m/mongoose/src/main/scala/typings/mongooseLib/mongooseMod/Document.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Document extends js.Object
 

--- a/importer/src/test/resources/mongoose-simple-random/check/m/mongoose/src/main/scala/typings/mongooseLib/mongooseMod/ModelProperties.scala
+++ b/importer/src/test/resources/mongoose-simple-random/check/m/mongoose/src/main/scala/typings/mongooseLib/mongooseMod/ModelProperties.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ModelProperties extends js.Object
 

--- a/importer/src/test/resources/mongoose-simple-random/check/m/mongoose/src/main/scala/typings/mongooseLib/mongooseMod/Schema.scala
+++ b/importer/src/test/resources/mongoose-simple-random/check/m/mongoose/src/main/scala/typings/mongooseLib/mongooseMod/Schema.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Schema extends js.Object
 

--- a/importer/src/test/resources/mongoose-simple-random/check/n/node/build.sbt
+++ b/importer/src/test/resources/mongoose-simple-random/check/n/node/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "0.0-unknown-0deac5"
+version := "0.0-unknown-e2d417"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-032a31")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-2374ff")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/mongoose-simple-random/check/n/node/src/main/scala/typings/nodeLib/NodeJSNs/EventEmitter.scala
+++ b/importer/src/test/resources/mongoose-simple-random/check/n/node/src/main/scala/typings/nodeLib/NodeJSNs/EventEmitter.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait EventEmitter extends js.Object
 

--- a/importer/src/test/resources/mongoose-simple-random/check/s/std/build.sbt
+++ b/importer/src/test/resources/mongoose-simple-random/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-032a31"
+version := "0.0-unknown-2374ff"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/mongoose-simple-random/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/mongoose-simple-random/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/mongoose-simple-random/check/s/std/src/main/scala/typings/stdLib/Object.scala
+++ b/importer/src/test/resources/mongoose-simple-random/check/s/std/src/main/scala/typings/stdLib/Object.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Object extends js.Object
 

--- a/importer/src/test/resources/numjs/check/n/ndarray/build.sbt
+++ b/importer/src/test/resources/numjs/check/n/ndarray/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "ndarray"
-version := "0.0-unknown-4edab9"
+version := "0.0-unknown-391c8a"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-20654c")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f6c17e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/numjs/check/n/ndarray/src/main/scala/typings/ndarrayLib/ndarrayMod/ndarray.scala
+++ b/importer/src/test/resources/numjs/check/n/ndarray/src/main/scala/typings/ndarrayLib/ndarrayMod/ndarray.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ndarray[T] extends js.Object {
   var T: ndarray[T]
   var data: ndarrayLib.ndarrayMod.ndarrayNs.Data[T]

--- a/importer/src/test/resources/numjs/check/n/numjs/build.sbt
+++ b/importer/src/test/resources/numjs/check/n/numjs/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "numjs"
-version := "0.0-unknown-b71ae2"
+version := "0.0-unknown-59a24d"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "ndarray" % "0.0-unknown-4edab9",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-20654c")
+  "org.scalablytyped" %%% "ndarray" % "0.0-unknown-391c8a",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f6c17e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/numjs/check/n/numjs/src/main/scala/typings/numjsLib/numjsMod/NdArray.scala
+++ b/importer/src/test/resources/numjs/check/n/numjs/src/main/scala/typings/numjsLib/numjsMod/NdArray.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait NdArray[T]
   extends ndarrayLib.ndarrayMod.ndarray[T] {
   @JSName("T")

--- a/importer/src/test/resources/numjs/check/s/std/build.sbt
+++ b/importer/src/test/resources/numjs/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-20654c"
+version := "0.0-unknown-f6c17e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/numjs/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/numjs/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/build.sbt
+++ b/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-9b48c1"
+version := "0.32-a8a60f"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-a21837",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-01cd7e")
+  "org.scalablytyped" %%% "react" % "0.0-unknown-731d81",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d9ab6c")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/src/main/scala/typings/reactDashBootstrapLib/Anon_X.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/src/main/scala/typings/reactDashBootstrapLib/Anon_X.scala
@@ -1,0 +1,11 @@
+package typings
+package reactDashBootstrapLib
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+trait Anon_X[T, K /* <: java.lang.String */]
+  extends /* x */ org.scalablytyped.runtime.StringDictionary[scala.Nothing]
+     with /* x */ org.scalablytyped.runtime.NumberDictionary[scala.Nothing]
+

--- a/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/src/main/scala/typings/reactDashBootstrapLib/libButtonGroupMod/ButtonGroupNs/ButtonGroupProps.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/src/main/scala/typings/reactDashBootstrapLib/libButtonGroupMod/ButtonGroupNs/ButtonGroupProps.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ButtonGroupProps
   extends reactLib.reactMod.ReactNs.HTMLProps[reactDashBootstrapLib.libButtonGroupMod.ButtonGroup] {
   var block: js.UndefOr[scala.Boolean] = js.undefined

--- a/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/src/main/scala/typings/reactDashBootstrapLib/libToggleButtonGroupMod/ToggleButtonGroupNs/BaseProps.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/src/main/scala/typings/reactDashBootstrapLib/libToggleButtonGroupMod/ToggleButtonGroupNs/BaseProps.scala
@@ -5,17 +5,16 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait BaseProps extends js.Object {
   /**
-       * You'll usually want to use string|number|string[]|number[] here,
-       * but you can technically use any|any[].
-       */
+    * You'll usually want to use string|number|string[]|number[] here,
+    * but you can technically use any|any[].
+    */
   var defaultValue: js.UndefOr[js.Any] = js.undefined
   /**
-       * You'll usually want to use string|number|string[]|number[] here,
-       * but you can technically use any|any[].
-       */
+    * You'll usually want to use string|number|string[]|number[] here,
+    * but you can technically use any|any[].
+    */
   var value: js.UndefOr[js.Any] = js.undefined
 }
 

--- a/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/src/main/scala/typings/reactDashBootstrapLib/libToggleButtonGroupMod/ToggleButtonGroupNs/CheckboxProps.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/src/main/scala/typings/reactDashBootstrapLib/libToggleButtonGroupMod/ToggleButtonGroupNs/CheckboxProps.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait CheckboxProps extends js.Object {
   var name: js.UndefOr[java.lang.String] = js.undefined
   var onChange: js.UndefOr[js.Function1[/* values */ js.Array[_], scala.Unit]] = js.undefined

--- a/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/src/main/scala/typings/reactDashBootstrapLib/libToggleButtonGroupMod/ToggleButtonGroupNs/RadioProps.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/src/main/scala/typings/reactDashBootstrapLib/libToggleButtonGroupMod/ToggleButtonGroupNs/RadioProps.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait RadioProps extends js.Object {
   /** Required if `type` is set to "radio" */
   var name: java.lang.String

--- a/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/src/main/scala/typings/reactDashBootstrapLib/libUtilsBootstrapUtilsMod/BSProps.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/src/main/scala/typings/reactDashBootstrapLib/libUtilsBootstrapUtilsMod/BSProps.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait BSProps extends js.Object {
   var bsClass: js.Any
 }

--- a/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/src/main/scala/typings/reactDashBootstrapLib/reactDashBootstrapMod/package.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react-bootstrap/src/main/scala/typings/reactDashBootstrapLib/reactDashBootstrapMod/package.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.annotation._
 package object reactDashBootstrapMod {
   type Omit[T, K /* <: java.lang.String */] = stdLib.Pick[
     T, 
-    /* import warning: Failed type conversion: TsTypeLookup(TsTypeIntersect(List(TsTypeObject(List(TsMemberTypeMapped(NoComments,Default,false,TsIdentSimple(P),TsTypeKeyOf(TsTypeRef(TsQIdent(List(TsIdentSimple(T))),List())),Noop,TsTypeRef(TsQIdent(List(TsIdentSimple(P))),List())))), TsTypeObject(List(TsMemberTypeMapped(NoComments,Default,false,TsIdentSimple(P),TsTypeRef(TsQIdent(List(TsIdentSimple(K))),List()),Noop,TsTypeRef(TsQIdent(List(TsIdentSimple(never))),List())))), TsTypeObject(List(TsMemberIndex(NoComments,false,Default,IndexingDict(TsIdentSimple(x),TsTypeRef(TsQIdent(List(TsIdentSimple(string))),List())),false,TsTypeRef(TsQIdent(List(TsIdentSimple(never))),List())), TsMemberIndex(NoComments,false,Default,IndexingDict(TsIdentSimple(x),TsTypeRef(TsQIdent(List(TsIdentSimple(number))),List())),false,TsTypeRef(TsQIdent(List(TsIdentSimple(never))),List())))))),Right(TsTypeKeyOf(TsTypeRef(TsQIdent(List(TsIdentSimple(T))),List())))) */js.Any
+    /* import warning: ImportType.apply Failed type conversion: react-bootstrap.Anon_X<T, K>[keyof T] */ js.Any
   ]
   type Sizes = reactDashBootstrapLib.reactDashBootstrapLibStrings.xs | reactDashBootstrapLib.reactDashBootstrapLibStrings.xsmall | reactDashBootstrapLib.reactDashBootstrapLibStrings.sm | reactDashBootstrapLib.reactDashBootstrapLibStrings.small | reactDashBootstrapLib.reactDashBootstrapLibStrings.medium | reactDashBootstrapLib.reactDashBootstrapLibStrings.lg | reactDashBootstrapLib.reactDashBootstrapLibStrings.large
 }

--- a/importer/src/test/resources/react-bootstrap/check/r/react/build.sbt
+++ b/importer/src/test/resources/react-bootstrap/check/r/react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-a21837"
+version := "0.0-unknown-731d81"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-01cd7e")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d9ab6c")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/Anon_Html.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/Anon_Html.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_Html extends js.Object {
   var __html: java.lang.String
 }

--- a/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/AllHTMLAttributes.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/AllHTMLAttributes.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait AllHTMLAttributes[T] extends HTMLAttributes[T] {
   var accept: js.UndefOr[java.lang.String] = js.undefined
   var acceptCharset: js.UndefOr[java.lang.String] = js.undefined

--- a/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Attributes.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Attributes.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Attributes extends js.Object {
   var key: js.UndefOr[Key] = js.undefined
 }

--- a/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ClassAttributes.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ClassAttributes.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ClassAttributes[T] extends Attributes {
   var ref: js.UndefOr[Ref[T]] = js.undefined
 }

--- a/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Component.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Component.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Component[P, S] extends js.Object
 

--- a/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/DOMAttributes.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/DOMAttributes.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait DOMAttributes[T] extends js.Object {
   var children: js.UndefOr[ReactNode] = js.undefined
   var dangerouslySetInnerHTML: js.UndefOr[reactLib.Anon_Html] = js.undefined

--- a/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/HTMLAttributes.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/HTMLAttributes.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait HTMLAttributes[T] extends DOMAttributes[T] {
   var defaultChecked: js.UndefOr[scala.Boolean] = js.undefined
 }

--- a/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/HTMLProps.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/HTMLProps.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait HTMLProps[T]
   extends AllHTMLAttributes[T]
      with ClassAttributes[T] {

--- a/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Props.scala
+++ b/importer/src/test/resources/react-bootstrap/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Props.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Props[T] extends js.Object {
   var key: js.UndefOr[java.lang.String] = js.undefined
 }

--- a/importer/src/test/resources/react-bootstrap/check/s/std/build.sbt
+++ b/importer/src/test/resources/react-bootstrap/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-01cd7e"
+version := "0.0-unknown-d9ab6c"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/react-bootstrap/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/react-bootstrap/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/react-bootstrap/check/s/std/src/main/scala/typings/stdLib/Error.scala
+++ b/importer/src/test/resources/react-bootstrap/check/s/std/src/main/scala/typings/stdLib/Error.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Error extends js.Object
 

--- a/importer/src/test/resources/react-bootstrap/check/s/std/src/main/scala/typings/stdLib/HTMLElement.scala
+++ b/importer/src/test/resources/react-bootstrap/check/s/std/src/main/scala/typings/stdLib/HTMLElement.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait HTMLElement extends js.Object
 

--- a/importer/src/test/resources/react-icons/check/r/react-icon-base/build.sbt
+++ b/importer/src/test/resources/react-icons/check/r/react-icon-base/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-icon-base"
-version := "2.1-f9653c"
+version := "2.1-ef4088"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-14fb0e",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-fdea87")
+  "org.scalablytyped" %%% "react" % "0.0-unknown-727aad",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-a8de11")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/react-icons/check/r/react-icon-base/src/main/scala/typings/reactDashIconDashBaseLib/reactDashIconDashBaseMod/IconBaseProps.scala
+++ b/importer/src/test/resources/react-icons/check/r/react-icon-base/src/main/scala/typings/reactDashIconDashBaseLib/reactDashIconDashBaseMod/IconBaseProps.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait IconBaseProps
   extends reactLib.reactMod.ReactNs.ClassAttributes[reactLib.reactMod.ReactNs.ReactSVGElement] {
   var size: js.UndefOr[java.lang.String | scala.Double] = js.undefined

--- a/importer/src/test/resources/react-icons/check/r/react-icons/build.sbt
+++ b/importer/src/test/resources/react-icons/check/r/react-icons/build.sbt
@@ -1,14 +1,14 @@
 organization := "org.scalablytyped"
 name := "react-icons"
-version := "2.2-bf3697"
+version := "2.2-68450c"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-14fb0e",
-  "org.scalablytyped" %%% "react-icon-base" % "2.1-f9653c",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-fdea87")
+  "org.scalablytyped" %%% "react" % "0.0-unknown-727aad",
+  "org.scalablytyped" %%% "react-icon-base" % "2.1-ef4088",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-a8de11")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/react-icons/check/r/react/build.sbt
+++ b/importer/src/test/resources/react-icons/check/r/react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-14fb0e"
+version := "0.0-unknown-727aad"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-fdea87")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-a8de11")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/Anon_Html.scala
+++ b/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/Anon_Html.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_Html extends js.Object {
   var __html: java.lang.String
 }

--- a/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/Element.scala
+++ b/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/Element.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Element extends js.Object
 

--- a/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/Event.scala
+++ b/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/Event.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Event extends js.Object
 

--- a/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Attributes.scala
+++ b/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Attributes.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Attributes extends js.Object {
   var key: js.UndefOr[Key] = js.undefined
 }

--- a/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ClassAttributes.scala
+++ b/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ClassAttributes.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ClassAttributes[T] extends Attributes {
   var ref: js.UndefOr[Ref[T]] = js.undefined
 }

--- a/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Component.scala
+++ b/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Component.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Component[P, S] extends js.Object
 

--- a/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ComponentState.scala
+++ b/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ComponentState.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ComponentState extends js.Object
 

--- a/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/DOMAttributes.scala
+++ b/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/DOMAttributes.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait DOMAttributes[T] extends js.Object {
   var children: js.UndefOr[ReactNode] = js.undefined
   var dangerouslySetInnerHTML: js.UndefOr[reactLib.Anon_Html] = js.undefined

--- a/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/DOMElement.scala
+++ b/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/DOMElement.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 // string fallback for custom web-components
-
 trait DOMElement[P /* <: HTMLAttributes[T] | SVGAttributes[T] */, T /* <: reactLib.Element */] extends ReactElement[P] {
   var ref: Ref[T]
   @JSName("type")

--- a/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/HTMLAttributes.scala
+++ b/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/HTMLAttributes.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait HTMLAttributes[T] extends DOMAttributes[T] {
   var defaultChecked: js.UndefOr[scala.Boolean] = js.undefined
 }

--- a/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ReactElement.scala
+++ b/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ReactElement.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ReactElement[P] extends js.Object {
   var key: Key | scala.Null
   var props: P

--- a/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ReactSVGElement.scala
+++ b/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ReactSVGElement.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 // ReactSVG for ReactSVGElement
-
 trait ReactSVGElement
   extends DOMElement[SVGAttributes[reactLib.SVGElement], reactLib.SVGElement] {
   @JSName("type")

--- a/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/SVGAttributes.scala
+++ b/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/SVGAttributes.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait SVGAttributes[T] extends DOMAttributes[T] {
   // Attributes which also defined in HTMLAttributes
   // See comment in SVGDOMPropertyConfig.js

--- a/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/package.scala
+++ b/importer/src/test/resources/react-icons/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/package.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.annotation._
 package object ReactNs {
   type DOMFactory[P /* <: DOMAttributes[T] */, T /* <: reactLib.Element */] = js.Function2[
     /* props */ js.UndefOr[ClassAttributes[T] with (P | scala.Null)], 
-    /* repeated */ReactNode, 
+    /* repeated */ ReactNode, 
     DOMElement[P, T]
   ]
   type Key = java.lang.String | scala.Double

--- a/importer/src/test/resources/react-icons/check/s/std/build.sbt
+++ b/importer/src/test/resources/react-icons/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-fdea87"
+version := "0.0-unknown-a8de11"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/react-icons/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/react-icons/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/react-select/check/r/react-select/build.sbt
+++ b/importer/src/test/resources/react-select/check/r/react-select/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-c0c249"
+version := "0.0-unknown-398881"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-499228",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ec0634")
+  "org.scalablytyped" %%% "react" % "0.0-unknown-bdfd3d",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-ec0d19")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/react-select/check/r/react-select/src/main/scala/typings/reactDashSelectLib/reactDashSelectMod/Option.scala
+++ b/importer/src/test/resources/react-select/check/r/react-select/src/main/scala/typings/reactDashSelectLib/reactDashSelectMod/Option.scala
@@ -5,12 +5,11 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Option[TValue]
   extends /**
-     * In the event that a custom menuRenderer is provided, Option should be able
-     * to accept arbitrary key-value pairs. See react-virtualized-select.
-     */
+  * In the event that a custom menuRenderer is provided, Option should be able
+  * to accept arbitrary key-value pairs. See react-virtualized-select.
+  */
 /* property */ org.scalablytyped.runtime.StringDictionary[js.Any] {
   /** Value for searching */
   var value: js.UndefOr[TValue] = js.undefined

--- a/importer/src/test/resources/react-select/check/r/react-select/src/main/scala/typings/reactDashSelectLib/reactDashSelectMod/ReactSelectProps.scala
+++ b/importer/src/test/resources/react-select/check/r/react-select/src/main/scala/typings/reactDashSelectLib/reactDashSelectMod/ReactSelectProps.scala
@@ -5,13 +5,12 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ReactSelectProps[TValue]
   extends reactLib.reactMod.ReactNs.Props[ReactSelectClass[TValue]] {
   /**
-       * text to display when `allowCreate` is true.
-       * @default 'Add "{label}"?'
-       */
+    * text to display when `allowCreate` is true.
+    * @default 'Add "{label}"?'
+    */
   var addLabelText: js.UndefOr[java.lang.String] = js.undefined
 }
 

--- a/importer/src/test/resources/react-select/check/r/react/build.sbt
+++ b/importer/src/test/resources/react-select/check/r/react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-499228"
+version := "0.0-unknown-bdfd3d"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ec0634")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-ec0d19")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/react-select/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Component.scala
+++ b/importer/src/test/resources/react-select/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Component.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Component[P, S] extends js.Object
 

--- a/importer/src/test/resources/react-select/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Props.scala
+++ b/importer/src/test/resources/react-select/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Props.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Props[T] extends js.Object {
   var key: js.UndefOr[java.lang.String] = js.undefined
 }

--- a/importer/src/test/resources/react-select/check/s/std/build.sbt
+++ b/importer/src/test/resources/react-select/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-ec0634"
+version := "0.0-unknown-ec0d19"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/react-select/check/s/std/src/main/scala/typings/stdLib/foo.scala
+++ b/importer/src/test/resources/react-select/check/s/std/src/main/scala/typings/stdLib/foo.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait foo extends js.Object
 

--- a/importer/src/test/resources/react-transition-group/check/r/react-transition-group/build.sbt
+++ b/importer/src/test/resources/react-transition-group/check/r/react-transition-group/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-transition-group"
-version := "2.0-7bdd8f"
+version := "2.0-c9fc24"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-41ad7a",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-7499aa")
+  "org.scalablytyped" %%% "react" % "0.0-unknown-7bc43a",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-6a45f5")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/react-transition-group/check/r/react-transition-group/src/main/scala/typings/reactDashTransitionDashGroupLib/Anon_ChildFactory.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react-transition-group/src/main/scala/typings/reactDashTransitionDashGroupLib/Anon_ChildFactory.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_ChildFactory extends js.Object {
   var childFactory: js.UndefOr[
     js.Function1[

--- a/importer/src/test/resources/react-transition-group/check/r/react-transition-group/src/main/scala/typings/reactDashTransitionDashGroupLib/transitiongroupMod/TransitionGroup.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react-transition-group/src/main/scala/typings/reactDashTransitionDashGroupLib/transitiongroupMod/TransitionGroup.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait TransitionGroup
   extends reactLib.reactMod.ReactNs.Component[
       reactDashTransitionDashGroupLib.transitiongroupMod.TransitionGroupNs.TransitionGroupProps[

--- a/importer/src/test/resources/react-transition-group/check/r/react-transition-group/src/main/scala/typings/reactDashTransitionDashGroupLib/transitiongroupMod/TransitionGroupNs/ComponentTransitionGroupProps.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react-transition-group/src/main/scala/typings/reactDashTransitionDashGroupLib/transitiongroupMod/TransitionGroupNs/ComponentTransitionGroupProps.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ComponentTransitionGroupProps[T /* <: reactLib.reactMod.ReactNs.ReactType[_] */] extends js.Object {
   var component: T
 }

--- a/importer/src/test/resources/react-transition-group/check/r/react-transition-group/src/main/scala/typings/reactDashTransitionDashGroupLib/transitiongroupMod/TransitionGroupNs/IntrinsicTransitionGroupProps.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react-transition-group/src/main/scala/typings/reactDashTransitionDashGroupLib/transitiongroupMod/TransitionGroupNs/IntrinsicTransitionGroupProps.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait IntrinsicTransitionGroupProps[T /* <: reactDashTransitionDashGroupLib.reactDashTransitionDashGroupLibStrings.abbr | reactDashTransitionDashGroupLib.reactDashTransitionDashGroupLibStrings.animate */] extends js.Object {
   var component: js.UndefOr[T] = js.undefined
 }

--- a/importer/src/test/resources/react-transition-group/check/r/react-transition-group/src/main/scala/typings/reactDashTransitionDashGroupLib/transitiongroupMod/TransitionGroupNs/package.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react-transition-group/src/main/scala/typings/reactDashTransitionDashGroupLib/transitiongroupMod/TransitionGroupNs/package.scala
@@ -6,5 +6,5 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 package object TransitionGroupNs {
-  type TransitionGroupProps[T /* <: reactDashTransitionDashGroupLib.reactDashTransitionDashGroupLibStrings.abbr | reactDashTransitionDashGroupLib.reactDashTransitionDashGroupLibStrings.animate */, V /* <: reactLib.reactMod.ReactNs.ReactType[_] */] = ((IntrinsicTransitionGroupProps[T] with js.Any) | ComponentTransitionGroupProps[V]) with reactDashTransitionDashGroupLib.Anon_ChildFactory
+  type TransitionGroupProps[T /* <: reactDashTransitionDashGroupLib.reactDashTransitionDashGroupLibStrings.abbr | reactDashTransitionDashGroupLib.reactDashTransitionDashGroupLibStrings.animate */, V /* <: reactLib.reactMod.ReactNs.ReactType[_] */] = ((IntrinsicTransitionGroupProps[T] with (/* import warning: ImportType.apply Failed type conversion: react.react.Global.JSX.IntrinsicElements[T] */ js.Any)) | ComponentTransitionGroupProps[V]) with reactDashTransitionDashGroupLib.Anon_ChildFactory
 }

--- a/importer/src/test/resources/react-transition-group/check/r/react/build.sbt
+++ b/importer/src/test/resources/react-transition-group/check/r/react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-41ad7a"
+version := "0.0-unknown-7bc43a"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-7499aa")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-6a45f5")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/Anon_Children.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/Anon_Children.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_Children extends js.Object {
   var children: js.UndefOr[reactLib.reactMod.ReactNs.ReactNode] = js.undefined
 }

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/Anon_Html.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/Anon_Html.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_Html extends js.Object {
   var __html: java.lang.String
 }

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/Element.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/Element.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Element extends js.Object
 

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/Event.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/Event.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Event extends js.Object
 

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/EventTarget.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/EventTarget.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait EventTarget extends js.Object
 

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/Global/JSXNs/ElementAttributesProperty.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/Global/JSXNs/ElementAttributesProperty.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ElementAttributesProperty extends js.Object
 

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/Global/JSXNs/ElementChildrenAttribute.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/Global/JSXNs/ElementChildrenAttribute.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ElementChildrenAttribute extends js.Object
 

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/Global/JSXNs/ElementClass.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/Global/JSXNs/ElementClass.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ElementClass
   extends reactLib.reactMod.ReactNs.Component[js.Any, js.Object] {
   def render(): reactLib.reactMod.ReactNs.ReactNode

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/Global/JSXNs/IntrinsicElements.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/Global/JSXNs/IntrinsicElements.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait IntrinsicElements extends js.Object {
   // HTML
   var abbr: reactLib.reactMod.ReactNs.DetailedHTMLProps[

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/AllHTMLAttributes.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/AllHTMLAttributes.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait AllHTMLAttributes[T] extends HTMLAttributes[T] {
   var accept: js.UndefOr[java.lang.String] = js.undefined
   var acceptCharset: js.UndefOr[java.lang.String] = js.undefined

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Attributes.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Attributes.scala
@@ -11,7 +11,6 @@ import scala.scalajs.js.annotation._
 // interface AnimationEvent<T> extends SyntheticEvent<T> {
 //     nativeEvent: NativeAnimationEvent;
 // }
-
 trait Attributes extends js.Object {
   var key: js.UndefOr[Key] = js.undefined
 }

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ClassAttributes.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ClassAttributes.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ClassAttributes[T] extends Attributes {
   var ref: js.UndefOr[Ref[T]] = js.undefined
 }

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Component.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/Component.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Component[P, S] extends js.Object
 

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ComponentState.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ComponentState.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ComponentState extends js.Object
 

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/DOMAttributes.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/DOMAttributes.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait DOMAttributes[T] extends js.Object {
   var children: js.UndefOr[ReactNode] = js.undefined
   var dangerouslySetInnerHTML: js.UndefOr[reactLib.Anon_Html] = js.undefined

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/HTMLAttributes.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/HTMLAttributes.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait HTMLAttributes[T] extends DOMAttributes[T] {
   var defaultChecked: js.UndefOr[scala.Boolean] = js.undefined
 }

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/HTMLProps.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/HTMLProps.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait HTMLProps[T]
   extends AllHTMLAttributes[T]
      with ClassAttributes[T]

--- a/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ReactElement.scala
+++ b/importer/src/test/resources/react-transition-group/check/r/react/src/main/scala/typings/reactLib/reactMod/ReactNs/ReactElement.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ReactElement[P] extends js.Object {
   var key: Key | scala.Null
   var props: P

--- a/importer/src/test/resources/react-transition-group/check/s/std/build.sbt
+++ b/importer/src/test/resources/react-transition-group/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-7499aa"
+version := "0.0-unknown-6a45f5"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/react-transition-group/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/react-transition-group/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/rxjs/check/r/rxjs/build.sbt
+++ b/importer/src/test/resources/rxjs/check/r/rxjs/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "rxjs"
-version := "0.0-unknown-db38ac"
+version := "0.0-unknown-b014f8"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-d13df6")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-2e254c")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/rxjs/check/r/rxjs/src/main/scala/typings/rxjsLib/internalSubscriptionMod/Subscription.scala
+++ b/importer/src/test/resources/rxjs/check/r/rxjs/src/main/scala/typings/rxjsLib/internalSubscriptionMod/Subscription.scala
@@ -7,12 +7,12 @@ import scala.scalajs.js.annotation._
 
 @JSImport("rxjs/internal/Subscription", "Subscription")
 @js.native
+/**
+  * @param {function(): void} [unsubscribe] A function describing how to
+  * perform the disposal of resources when the `unsubscribe` method is called.
+  */
 class Subscription ()
   extends rxjsLib.internalTypesMod.SubscriptionLike {
-  /**
-       * @param {function(): void} [unsubscribe] A function describing how to
-       * perform the disposal of resources when the `unsubscribe` method is called.
-       */
   def this(unsubscribe: js.Function0[scala.Unit]) = this()
   /** @internal */
   var _subscriptions: js.Any = js.native

--- a/importer/src/test/resources/rxjs/check/r/rxjs/src/main/scala/typings/rxjsLib/internalTypesMod/CompletionObserver.scala
+++ b/importer/src/test/resources/rxjs/check/r/rxjs/src/main/scala/typings/rxjsLib/internalTypesMod/CompletionObserver.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait CompletionObserver[T] extends js.Object {
   var closed: js.UndefOr[scala.Boolean] = js.undefined
   var error: js.UndefOr[js.Function1[/* err */ js.Any, scala.Unit]] = js.undefined

--- a/importer/src/test/resources/rxjs/check/r/rxjs/src/main/scala/typings/rxjsLib/internalTypesMod/ErrorObserver.scala
+++ b/importer/src/test/resources/rxjs/check/r/rxjs/src/main/scala/typings/rxjsLib/internalTypesMod/ErrorObserver.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ErrorObserver[T] extends js.Object {
   var closed: js.UndefOr[scala.Boolean] = js.undefined
   var complete: js.UndefOr[js.Function0[scala.Unit]] = js.undefined

--- a/importer/src/test/resources/rxjs/check/r/rxjs/src/main/scala/typings/rxjsLib/internalTypesMod/NextObserver.scala
+++ b/importer/src/test/resources/rxjs/check/r/rxjs/src/main/scala/typings/rxjsLib/internalTypesMod/NextObserver.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait NextObserver[T] extends js.Object {
   var closed: js.UndefOr[scala.Boolean] = js.undefined
   var complete: js.UndefOr[js.Function0[scala.Unit]] = js.undefined

--- a/importer/src/test/resources/rxjs/check/r/rxjs/src/main/scala/typings/rxjsLib/internalTypesMod/Observer.scala
+++ b/importer/src/test/resources/rxjs/check/r/rxjs/src/main/scala/typings/rxjsLib/internalTypesMod/Observer.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Observer[T] extends js.Object {
   var closed: js.UndefOr[scala.Boolean] = js.undefined
   def complete(): scala.Unit

--- a/importer/src/test/resources/rxjs/check/r/rxjs/src/main/scala/typings/rxjsLib/internalTypesMod/SubscriptionLike.scala
+++ b/importer/src/test/resources/rxjs/check/r/rxjs/src/main/scala/typings/rxjsLib/internalTypesMod/SubscriptionLike.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait SubscriptionLike extends Unsubscribable {
   val closed: scala.Boolean
 }

--- a/importer/src/test/resources/rxjs/check/r/rxjs/src/main/scala/typings/rxjsLib/internalTypesMod/Unsubscribable.scala
+++ b/importer/src/test/resources/rxjs/check/r/rxjs/src/main/scala/typings/rxjsLib/internalTypesMod/Unsubscribable.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Unsubscribable extends js.Object {
   def unsubscribe(): scala.Unit
 }

--- a/importer/src/test/resources/rxjs/check/s/std/build.sbt
+++ b/importer/src/test/resources/rxjs/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-d13df6"
+version := "0.0-unknown-2e254c"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/rxjs/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/rxjs/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/rxjs/check/s/std/src/main/scala/typings/stdLib/Node.scala
+++ b/importer/src/test/resources/rxjs/check/s/std/src/main/scala/typings/stdLib/Node.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Node extends js.Object
 

--- a/importer/src/test/resources/sax/check/n/node/build.sbt
+++ b/importer/src/test/resources/sax/check/n/node/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "9.6.x-654d6b"
+version := "9.6.x-2d4596"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-c58968")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d1e191")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/Anon_End.scala
+++ b/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/Anon_End.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_End extends js.Object {
   var end: js.UndefOr[scala.Boolean] = js.undefined
 }

--- a/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/Anon_From.scala
+++ b/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/Anon_From.scala
@@ -7,48 +7,42 @@ import scala.scalajs.js.annotation._
 
 @js.native
 trait Anon_From
-  extends /**
-     * Allocates a new buffer containing the given {str}.
-     *
-     * @param str String to store in buffer.
-     * @param encoding encoding to use, optional.  Default is 'utf8'
-     */
-org.scalablytyped.runtime.Instantiable2[/* str */ java.lang.String, /* encoding */ java.lang.String, Buffer]
+  extends org.scalablytyped.runtime.Instantiable2[/* str */ java.lang.String, /* encoding */ java.lang.String, Buffer]
      with /**
-     * Allocates a new buffer containing the given {str}.
-     *
-     * @param str String to store in buffer.
-     * @param encoding encoding to use, optional.  Default is 'utf8'
-     */
+  * Allocates a new buffer containing the given {str}.
+  *
+  * @param str String to store in buffer.
+  * @param encoding encoding to use, optional.  Default is 'utf8'
+  */
 /**
-     * Allocates a new buffer of {size} octets.
-     *
-     * @param size count of octets to allocate.
-     */
+  * Allocates a new buffer of {size} octets.
+  *
+  * @param size count of octets to allocate.
+  */
 /**
-     * Allocates a new buffer containing the given {array} of octets.
-     *
-     * @param array The octets to store.
-     */
+  * Allocates a new buffer containing the given {array} of octets.
+  *
+  * @param array The octets to store.
+  */
 /**
-     * Produces a Buffer backed by the same allocated memory as
-     * the given {ArrayBuffer}.
-     *
-     *
-     * @param arrayBuffer The ArrayBuffer with which to share memory.
-     */
+  * Produces a Buffer backed by the same allocated memory as
+  * the given {ArrayBuffer}.
+  *
+  *
+  * @param arrayBuffer The ArrayBuffer with which to share memory.
+  */
 /**
-     * Copies the passed {buffer} data onto a new {Buffer} instance.
-     *
-     * @param buffer The buffer to copy.
-     */
+  * Copies the passed {buffer} data onto a new {Buffer} instance.
+  *
+  * @param buffer The buffer to copy.
+  */
 org.scalablytyped.runtime.Instantiable1[
       (/* array */ js.Array[js.Any]) | (/* arrayBuffer */ stdLib.ArrayBuffer) | (/* buffer */ Buffer) | (/* size */ scala.Double) | (/* str */ java.lang.String) | (/* array */ stdLib.Uint8Array), 
       Buffer
     ] {
   /**
-       * Allocates a new Buffer using an {array} of octets.
-       */
+    * Allocates a new Buffer using an {array} of octets.
+    */
   def from(array: js.Array[_]): Buffer = js.native
 }
 

--- a/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/Buffer.scala
+++ b/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/Buffer.scala
@@ -6,55 +6,49 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 /**
- * Raw data is stored in instances of the Buffer class.
- * A Buffer is similar to an array of integers but corresponds to a raw memory allocation outside the V8 heap.  A Buffer cannot be resized.
- * Valid string encodings: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
- */
+  * Raw data is stored in instances of the Buffer class.
+  * A Buffer is similar to an array of integers but corresponds to a raw memory allocation outside the V8 heap.  A Buffer cannot be resized.
+  * Valid string encodings: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
+  */
 @JSGlobal("Buffer")
 @js.native
 object Buffer
-  extends /**
-     * Allocates a new buffer containing the given {str}.
-     *
-     * @param str String to store in buffer.
-     * @param encoding encoding to use, optional.  Default is 'utf8'
-     */
-org.scalablytyped.runtime.Instantiable2[/* str */ java.lang.String, /* encoding */ java.lang.String, Buffer]
+  extends org.scalablytyped.runtime.Instantiable2[/* str */ java.lang.String, /* encoding */ java.lang.String, Buffer]
      with /**
-     * Allocates a new buffer containing the given {str}.
-     *
-     * @param str String to store in buffer.
-     * @param encoding encoding to use, optional.  Default is 'utf8'
-     */
+  * Allocates a new buffer containing the given {str}.
+  *
+  * @param str String to store in buffer.
+  * @param encoding encoding to use, optional.  Default is 'utf8'
+  */
 /**
-     * Allocates a new buffer of {size} octets.
-     *
-     * @param size count of octets to allocate.
-     */
+  * Allocates a new buffer of {size} octets.
+  *
+  * @param size count of octets to allocate.
+  */
 /**
-     * Allocates a new buffer containing the given {array} of octets.
-     *
-     * @param array The octets to store.
-     */
+  * Allocates a new buffer containing the given {array} of octets.
+  *
+  * @param array The octets to store.
+  */
 /**
-     * Produces a Buffer backed by the same allocated memory as
-     * the given {ArrayBuffer}.
-     *
-     *
-     * @param arrayBuffer The ArrayBuffer with which to share memory.
-     */
+  * Produces a Buffer backed by the same allocated memory as
+  * the given {ArrayBuffer}.
+  *
+  *
+  * @param arrayBuffer The ArrayBuffer with which to share memory.
+  */
 /**
-     * Copies the passed {buffer} data onto a new {Buffer} instance.
-     *
-     * @param buffer The buffer to copy.
-     */
+  * Copies the passed {buffer} data onto a new {Buffer} instance.
+  *
+  * @param buffer The buffer to copy.
+  */
 org.scalablytyped.runtime.Instantiable1[
       (/* array */ js.Array[js.Any]) | (/* arrayBuffer */ stdLib.ArrayBuffer) | (/* buffer */ Buffer) | (/* size */ scala.Double) | (/* str */ java.lang.String) | (/* array */ stdLib.Uint8Array), 
       Buffer
     ] {
   /**
-       * Allocates a new Buffer using an {array} of octets.
-       */
+    * Allocates a new Buffer using an {array} of octets.
+    */
   def from(array: js.Array[_]): nodeLib.Buffer = js.native
 }
 

--- a/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/Error.scala
+++ b/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/Error.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Error extends js.Object {
   var stack: js.UndefOr[java.lang.String] = js.undefined
 }

--- a/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/NodeJSNs/EventEmitter.scala
+++ b/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/NodeJSNs/EventEmitter.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.annotation._
 @JSGlobal("NodeJS.EventEmitter")
 @js.native
 class EventEmitter () extends js.Object {
-  def on(event: java.lang.String, listener: js.Function1[/* repeated */js.Any, scala.Unit]): this.type = js.native
-  def on(event: js.Symbol, listener: js.Function1[/* repeated */js.Any, scala.Unit]): this.type = js.native
+  def on(event: java.lang.String, listener: js.Function1[/* repeated */ js.Any, scala.Unit]): this.type = js.native
+  def on(event: js.Symbol, listener: js.Function1[/* repeated */ js.Any, scala.Unit]): this.type = js.native
 }
 

--- a/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/NodeJSNs/Global.scala
+++ b/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/NodeJSNs/Global.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Global extends js.Object {
   var Array: stdLib.ArrayConstrucor
   var global: Global

--- a/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/streamMod/internalNs/DuplexOptions.scala
+++ b/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/streamMod/internalNs/DuplexOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait DuplexOptions
   extends ReadableOptions
      with WritableOptions {

--- a/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/streamMod/internalNs/ReadableOptions.scala
+++ b/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/streamMod/internalNs/ReadableOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ReadableOptions extends js.Object {
   var destroy: js.UndefOr[js.Function1[/* error */ js.UndefOr[nodeLib.Error], _]] = js.undefined
   var encoding: js.UndefOr[java.lang.String] = js.undefined

--- a/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/streamMod/internalNs/WritableOptions.scala
+++ b/importer/src/test/resources/sax/check/n/node/src/main/scala/typings/nodeLib/streamMod/internalNs/WritableOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait WritableOptions extends js.Object {
   var `final`: js.UndefOr[
     js.Function1[

--- a/importer/src/test/resources/sax/check/s/sax/build.sbt
+++ b/importer/src/test/resources/sax/check/s/sax/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "sax"
-version := "1.x-441832"
+version := "1.x-39a231"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "node" % "9.6.x-654d6b",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-c58968")
+  "org.scalablytyped" %%% "node" % "9.6.x-2d4596",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d1e191")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/sax/check/s/sax/src/main/scala/typings/saxLib/saxMod/BaseTag.scala
+++ b/importer/src/test/resources/sax/check/s/sax/src/main/scala/typings/saxLib/saxMod/BaseTag.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait BaseTag extends js.Object {
   var isSelfClosing: scala.Boolean
   var name: java.lang.String

--- a/importer/src/test/resources/sax/check/s/sax/src/main/scala/typings/saxLib/saxMod/QualifiedAttribute.scala
+++ b/importer/src/test/resources/sax/check/s/sax/src/main/scala/typings/saxLib/saxMod/QualifiedAttribute.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait QualifiedAttribute extends QualifiedName {
   var value: java.lang.String
 }

--- a/importer/src/test/resources/sax/check/s/sax/src/main/scala/typings/saxLib/saxMod/QualifiedName.scala
+++ b/importer/src/test/resources/sax/check/s/sax/src/main/scala/typings/saxLib/saxMod/QualifiedName.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait QualifiedName extends js.Object {
   var local: java.lang.String
   var name: java.lang.String

--- a/importer/src/test/resources/sax/check/s/sax/src/main/scala/typings/saxLib/saxMod/QualifiedTag.scala
+++ b/importer/src/test/resources/sax/check/s/sax/src/main/scala/typings/saxLib/saxMod/QualifiedTag.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 /* RemoveMultipleInheritance: Dropped parents List(saxLib.saxMod.BaseTag because Would inherit conflicting mutable fields List(name))*/
-
 trait QualifiedTag extends QualifiedName {
   var attributes: org.scalablytyped.runtime.StringDictionary[QualifiedAttribute]
   var ns: org.scalablytyped.runtime.StringDictionary[java.lang.String]

--- a/importer/src/test/resources/sax/check/s/sax/src/main/scala/typings/saxLib/saxMod/SAXOptions.scala
+++ b/importer/src/test/resources/sax/check/s/sax/src/main/scala/typings/saxLib/saxMod/SAXOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait SAXOptions extends js.Object {
   var lowercase: js.UndefOr[scala.Boolean] = js.undefined
   var normalize: js.UndefOr[scala.Boolean] = js.undefined

--- a/importer/src/test/resources/sax/check/s/sax/src/main/scala/typings/saxLib/saxMod/Tag.scala
+++ b/importer/src/test/resources/sax/check/s/sax/src/main/scala/typings/saxLib/saxMod/Tag.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Tag extends BaseTag {
   var attributes: org.scalablytyped.runtime.StringDictionary[java.lang.String]
 }

--- a/importer/src/test/resources/sax/check/s/std/build.sbt
+++ b/importer/src/test/resources/sax/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-c58968"
+version := "0.0-unknown-d1e191"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/sax/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/sax/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/sax/check/s/std/src/main/scala/typings/stdLib/ArrayBuffer.scala
+++ b/importer/src/test/resources/sax/check/s/std/src/main/scala/typings/stdLib/ArrayBuffer.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ArrayBuffer extends js.Object
 

--- a/importer/src/test/resources/sax/check/s/std/src/main/scala/typings/stdLib/ArrayConstrucor.scala
+++ b/importer/src/test/resources/sax/check/s/std/src/main/scala/typings/stdLib/ArrayConstrucor.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ArrayConstrucor extends js.Object
 

--- a/importer/src/test/resources/sax/check/s/std/src/main/scala/typings/stdLib/Uint8Array.scala
+++ b/importer/src/test/resources/sax/check/s/std/src/main/scala/typings/stdLib/Uint8Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Uint8Array extends js.Object
 

--- a/importer/src/test/resources/serve-static/check/e/express-serve-static-core/build.sbt
+++ b/importer/src/test/resources/serve-static/check/e/express-serve-static-core/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "express-serve-static-core"
-version := "0.0-unknown-a2e249"
+version := "0.0-unknown-ed6a6e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-20654c")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f6c17e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/serve-static/check/e/express-serve-static-core/src/main/scala/typings/expressDashServeDashStaticDashCoreLib/expressDashServeDashStaticDashCoreMod/Global/ExpressNs/Application.scala
+++ b/importer/src/test/resources/serve-static/check/e/express-serve-static-core/src/main/scala/typings/expressDashServeDashStaticDashCoreLib/expressDashServeDashStaticDashCoreMod/Global/ExpressNs/Application.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Application extends js.Object
 

--- a/importer/src/test/resources/serve-static/check/e/express-serve-static-core/src/main/scala/typings/expressDashServeDashStaticDashCoreLib/expressDashServeDashStaticDashCoreMod/Global/ExpressNs/Request.scala
+++ b/importer/src/test/resources/serve-static/check/e/express-serve-static-core/src/main/scala/typings/expressDashServeDashStaticDashCoreLib/expressDashServeDashStaticDashCoreMod/Global/ExpressNs/Request.scala
@@ -7,6 +7,5 @@ import scala.scalajs.js.annotation._
 
 // These open interfaces may be extended in an application-specific manner via declaration merging.
 // See for example method-override.d.ts (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/method-override/index.d.ts)
-
 trait Request extends js.Object
 

--- a/importer/src/test/resources/serve-static/check/e/express-serve-static-core/src/main/scala/typings/expressDashServeDashStaticDashCoreLib/expressDashServeDashStaticDashCoreMod/Global/ExpressNs/Response.scala
+++ b/importer/src/test/resources/serve-static/check/e/express-serve-static-core/src/main/scala/typings/expressDashServeDashStaticDashCoreLib/expressDashServeDashStaticDashCoreMod/Global/ExpressNs/Response.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Response extends js.Object
 

--- a/importer/src/test/resources/serve-static/check/e/express-serve-static-core/src/main/scala/typings/expressDashServeDashStaticDashCoreLib/expressDashServeDashStaticDashCoreMod/Request.scala
+++ b/importer/src/test/resources/serve-static/check/e/express-serve-static-core/src/main/scala/typings/expressDashServeDashStaticDashCoreLib/expressDashServeDashStaticDashCoreMod/Request.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Request
   extends expressDashServeDashStaticDashCoreLib.expressDashServeDashStaticDashCoreMod.Global.ExpressNs.Request {
   var url: java.lang.String

--- a/importer/src/test/resources/serve-static/check/e/express-serve-static-core/src/main/scala/typings/expressDashServeDashStaticDashCoreLib/expressDashServeDashStaticDashCoreMod/Response.scala
+++ b/importer/src/test/resources/serve-static/check/e/express-serve-static-core/src/main/scala/typings/expressDashServeDashStaticDashCoreLib/expressDashServeDashStaticDashCoreMod/Response.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Response
   extends expressDashServeDashStaticDashCoreLib.expressDashServeDashStaticDashCoreMod.Global.ExpressNs.Response {
   def location(url: java.lang.String): Response

--- a/importer/src/test/resources/serve-static/check/m/mime/build.sbt
+++ b/importer/src/test/resources/serve-static/check/m/mime/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "mime"
-version := "2.0-aa3c41"
+version := "2.0-68268d"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-20654c")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f6c17e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/serve-static/check/m/mime/src/main/scala/typings/mimeLib/mimeMod/TypeMap.scala
+++ b/importer/src/test/resources/serve-static/check/m/mime/src/main/scala/typings/mimeLib/mimeMod/TypeMap.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait TypeMap
   extends /* key */ org.scalablytyped.runtime.StringDictionary[js.Array[java.lang.String]]
 

--- a/importer/src/test/resources/serve-static/check/s/serve-static/build.sbt
+++ b/importer/src/test/resources/serve-static/check/s/serve-static/build.sbt
@@ -1,14 +1,14 @@
 organization := "org.scalablytyped"
 name := "serve-static"
-version := "0.0-unknown-4ab3c4"
+version := "0.0-unknown-65f009"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "express-serve-static-core" % "0.0-unknown-a2e249",
-  "org.scalablytyped" %%% "mime" % "2.0-aa3c41",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-20654c")
+  "org.scalablytyped" %%% "express-serve-static-core" % "0.0-unknown-ed6a6e",
+  "org.scalablytyped" %%% "mime" % "2.0-68268d",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f6c17e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/serve-static/check/s/serve-static/src/main/scala/typings/serveDashStaticLib/Anon_Defaulttype.scala
+++ b/importer/src/test/resources/serve-static/check/s/serve-static/src/main/scala/typings/serveDashStaticLib/Anon_Defaulttype.scala
@@ -1,0 +1,16 @@
+package typings
+package serveDashStaticLib
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait Anon_Defaulttype extends js.Object {
+  val default_type: java.lang.String = js.native
+  def define(mimes: mimeLib.mimeMod.TypeMap): scala.Unit = js.native
+  def define(mimes: mimeLib.mimeMod.TypeMap, force: scala.Boolean): scala.Unit = js.native
+  def getExtension(mime: java.lang.String): java.lang.String | scala.Null = js.native
+  def getType(path: java.lang.String): java.lang.String | scala.Null = js.native
+}
+

--- a/importer/src/test/resources/serve-static/check/s/serve-static/src/main/scala/typings/serveDashStaticLib/serveDashStaticMod/serveDashStaticModMembers.scala
+++ b/importer/src/test/resources/serve-static/check/s/serve-static/src/main/scala/typings/serveDashStaticLib/serveDashStaticMod/serveDashStaticModMembers.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.annotation._
 @JSImport("serve-static", JSImport.Namespace)
 @js.native
 object serveDashStaticModMembers extends js.Object {
-  var mime: js.Any = js.native
+  var mime: serveDashStaticLib.Anon_Defaulttype = js.native
   def apply(root: java.lang.String): expressDashServeDashStaticDashCoreLib.expressDashServeDashStaticDashCoreMod.Handler = js.native
   def apply(
     root: java.lang.String,

--- a/importer/src/test/resources/serve-static/check/s/serve-static/src/main/scala/typings/serveDashStaticLib/serveDashStaticMod/serveStaticNs/ServeStaticOptions.scala
+++ b/importer/src/test/resources/serve-static/check/s/serve-static/src/main/scala/typings/serveDashStaticLib/serveDashStaticMod/serveStaticNs/ServeStaticOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ServeStaticOptions extends js.Object {
   var setHeaders: js.UndefOr[
     js.Function3[

--- a/importer/src/test/resources/serve-static/check/s/std/build.sbt
+++ b/importer/src/test/resources/serve-static/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-20654c"
+version := "0.0-unknown-f6c17e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/serve-static/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/serve-static/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/stylis/check/s/std/build.sbt
+++ b/importer/src/test/resources/stylis/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-20654c"
+version := "0.0-unknown-f6c17e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/stylis/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/stylis/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/stylis/check/s/stylis/build.sbt
+++ b/importer/src/test/resources/stylis/check/s/stylis/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stylis"
-version := "0.0-unknown-998df1"
+version := "0.0-unknown-6fd2d8"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-20654c")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f6c17e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/stylis/check/s/stylis/src/main/scala/typings/stylisLib/stylisStylisMod/Options.scala
+++ b/importer/src/test/resources/stylis/check/s/stylis/src/main/scala/typings/stylisLib/stylisStylisMod/Options.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Options extends js.Object {
   var cascade: js.UndefOr[scala.Boolean] = js.undefined
   var compress: js.UndefOr[scala.Boolean] = js.undefined

--- a/importer/src/test/resources/swiz/check/s/std/build.sbt
+++ b/importer/src/test/resources/swiz/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-20654c"
+version := "0.0-unknown-f6c17e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/swiz/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/swiz/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/swiz/check/s/swiz/build.sbt
+++ b/importer/src/test/resources/swiz/check/s/swiz/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "swiz"
-version := "0.0-unknown-a16b5a"
+version := "0.0-unknown-d816f9"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-20654c")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f6c17e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/swiz/check/s/swiz/src/main/scala/typings/swizLib/swizMod/ISerializable.scala
+++ b/importer/src/test/resources/swiz/check/s/swiz/src/main/scala/typings/swizLib/swizMod/ISerializable.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ISerializable extends js.Object {
   def getSerializerType(): java.lang.String
 }

--- a/importer/src/test/resources/swiz/check/s/swiz/src/main/scala/typings/swizLib/swizMod/ISwizOptions.scala
+++ b/importer/src/test/resources/swiz/check/s/swiz/src/main/scala/typings/swizLib/swizMod/ISwizOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ISwizOptions extends js.Object {
   var `for`: js.UndefOr[java.lang.String] = js.undefined
   var stripNulls: js.UndefOr[scala.Boolean] = js.undefined

--- a/importer/src/test/resources/swiz/check/s/swiz/src/main/scala/typings/swizLib/swizMod/structNs/IField.scala
+++ b/importer/src/test/resources/swiz/check/s/swiz/src/main/scala/typings/swizLib/swizMod/structNs/IField.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait IField extends js.Object
 

--- a/importer/src/test/resources/swiz/check/s/swiz/src/main/scala/typings/swizLib/swizMod/structNs/IObj.scala
+++ b/importer/src/test/resources/swiz/check/s/swiz/src/main/scala/typings/swizLib/swizMod/structNs/IObj.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait IObj extends js.Object
 

--- a/importer/src/test/resources/tstl/check/s/std/build.sbt
+++ b/importer/src/test/resources/tstl/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-ec0634"
+version := "0.0-unknown-ec0d19"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/tstl/check/s/std/src/main/scala/typings/stdLib/foo.scala
+++ b/importer/src/test/resources/tstl/check/s/std/src/main/scala/typings/stdLib/foo.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait foo extends js.Object
 

--- a/importer/src/test/resources/tstl/check/t/tstl/build.sbt
+++ b/importer/src/test/resources/tstl/check/t/tstl/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "tstl"
-version := "0.0-unknown-5d055a"
+version := "0.0-unknown-ed2b79"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ec0634")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-ec0d19")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/type-mappings/check/s/std/build.sbt
+++ b/importer/src/test/resources/type-mappings/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-590491"
+version := "0.0-unknown-d2c6a9"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/type-mappings/check/s/std/src/main/scala/typings/stdLib/package.scala
+++ b/importer/src/test/resources/type-mappings/check/s/std/src/main/scala/typings/stdLib/package.scala
@@ -6,44 +6,44 @@ import scala.scalajs.js.annotation._
 
 package object stdLib {
   /**
-   * Exclude from T those types that are assignable to U
-   */
+    * Exclude from T those types that are assignable to U
+    */
   type Exclude[T, U] = T
   /**
-   * Extract from T those types that are assignable to U
-   */
+    * Extract from T those types that are assignable to U
+    */
   type Extract[T, U] = T
   /**
-   * Obtain the return type of a constructor function type
-   */
+    * Obtain the return type of a constructor function type
+    */
   type InstanceType[T /* <: org.scalablytyped.runtime.Instantiable1[/* args (repeated) */ js.Any, js.Any] */] = js.Any
   /**
-   * Exclude null and undefined from T
-   */
+    * Exclude null and undefined from T
+    */
   type NonNullable[T] = T
   /**
-   * Make all properties in T optional
-   */
+    * Make all properties in T optional
+    */
   type Partial[T] = stdLib.stdLibStrings.Partial with T
   /**
-   * From T pick a set of properties K
-   */
+    * From T pick a set of properties K
+    */
   type Pick[T, K /* <: java.lang.String */] = stdLib.stdLibStrings.Pick with T
   type Proxify[T] = stdLib.stdLibStrings.Proxify with T
   /**
-   * Make all properties in T readonly
-   */
+    * Make all properties in T readonly
+    */
   type Readonly[T] = stdLib.stdLibStrings.Readonly with T
   /**
-   * Construct a type with a set of properties K of type T
-   */
+    * Construct a type with a set of properties K of type T
+    */
   type Record[K /* <: java.lang.String */, T] = org.scalablytyped.runtime.StringDictionary[K]
   /**
-   * Make all properties in T required
-   */
+    * Make all properties in T required
+    */
   type Required[T] = stdLib.stdLibStrings.Required with T
   /**
-   * Obtain the return type of a function type
-   */
-  type ReturnType[T /* <: js.Function1[/* repeated */js.Any, _] */] = js.Any
+    * Obtain the return type of a function type
+    */
+  type ReturnType[T /* <: js.Function1[/* repeated */ js.Any, _] */] = js.Any
 }

--- a/importer/src/test/resources/type-mappings/check/t/type-mappings/build.sbt
+++ b/importer/src/test/resources/type-mappings/check/t/type-mappings/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "type-mappings"
-version := "0.0-unknown-4e307b"
+version := "0.0-unknown-880f5b"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-590491")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d2c6a9")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/type-mappings/check/t/type-mappings/src/main/scala/typings/typeDashMappingsLib/Anon_Age.scala
+++ b/importer/src/test/resources/type-mappings/check/t/type-mappings/src/main/scala/typings/typeDashMappingsLib/Anon_Age.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_Age extends js.Object {
   var age: scala.Double
 }

--- a/importer/src/test/resources/type-mappings/check/t/type-mappings/src/main/scala/typings/typeDashMappingsLib/Anon_Name.scala
+++ b/importer/src/test/resources/type-mappings/check/t/type-mappings/src/main/scala/typings/typeDashMappingsLib/Anon_Name.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_Name extends js.Object {
   var name: java.lang.String
 }

--- a/importer/src/test/resources/type-mappings/check/t/type-mappings/src/main/scala/typings/typeDashMappingsLib/Anon_NameAge.scala
+++ b/importer/src/test/resources/type-mappings/check/t/type-mappings/src/main/scala/typings/typeDashMappingsLib/Anon_NameAge.scala
@@ -1,0 +1,12 @@
+package typings
+package typeDashMappingsLib
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+trait Anon_NameAge extends js.Object {
+  var age: scala.Double
+  var name: java.lang.String
+}
+

--- a/importer/src/test/resources/type-mappings/check/t/type-mappings/src/main/scala/typings/typeDashMappingsLib/CSSProperties.scala
+++ b/importer/src/test/resources/type-mappings/check/t/type-mappings/src/main/scala/typings/typeDashMappingsLib/CSSProperties.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait CSSProperties extends js.Object {
   var color: java.lang.String
   var fontFamily: java.lang.String

--- a/importer/src/test/resources/type-mappings/check/t/type-mappings/src/main/scala/typings/typeDashMappingsLib/Person.scala
+++ b/importer/src/test/resources/type-mappings/check/t/type-mappings/src/main/scala/typings/typeDashMappingsLib/Person.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Person extends js.Object {
   var age: js.UndefOr[scala.Double | scala.Null] = js.undefined
   var name: java.lang.String

--- a/importer/src/test/resources/type-mappings/check/t/type-mappings/src/main/scala/typings/typeDashMappingsLib/package.scala
+++ b/importer/src/test/resources/type-mappings/check/t/type-mappings/src/main/scala/typings/typeDashMappingsLib/package.scala
@@ -39,7 +39,7 @@ package object typeDashMappingsLib {
   ])
   type TypographyStyleOptions = /* InlineNestedIdentityAlias: stdLib.Partial*/ TypographyStyle
   type U = stdLib.Pick[
-    Anon_Name with Anon_Age, 
+    Anon_NameAge, 
     typeDashMappingsLib.typeDashMappingsLibStrings.name | typeDashMappingsLib.typeDashMappingsLibStrings.age
   ]
 }

--- a/importer/src/test/resources/typings-json/check/p/phaser/build.sbt
+++ b/importer/src/test/resources/typings-json/check/p/phaser/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "phaser"
-version := "2.6.2-e11ea8"
+version := "2.6.2-73c946"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-20654c")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f6c17e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/typings-json/check/p/phaser/src/main/scala/typings/phaserLib/Anon_UpperBound.scala
+++ b/importer/src/test/resources/typings-json/check/p/phaser/src/main/scala/typings/phaserLib/Anon_UpperBound.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_UpperBound extends js.Object {
   var lowerBound: js.UndefOr[js.Array[scala.Double]] = js.undefined
   var upperBound: js.UndefOr[js.Array[scala.Double]] = js.undefined

--- a/importer/src/test/resources/typings-json/check/p/phaser/src/main/scala/typings/phaserLib/PhaserNs/Animation.scala
+++ b/importer/src/test/resources/typings-json/check/p/phaser/src/main/scala/typings/phaserLib/PhaserNs/Animation.scala
@@ -6,10 +6,10 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 /**
-     * An Animation instance contains a single animation and the controls to play it.
-     *
-     * It is created by the AnimationManager, consists of Animation.Frame objects and belongs to a single Game Object such as a Sprite.
-     */
+  * An Animation instance contains a single animation and the controls to play it.
+  *
+  * It is created by the AnimationManager, consists of Animation.Frame objects and belongs to a single Game Object such as a Sprite.
+  */
 @JSGlobal("Phaser.Animation")
 @js.native
 class Animation () extends js.Object

--- a/importer/src/test/resources/typings-json/check/p/phaser/src/main/scala/typings/phaserLib/phaserMod/Animation.scala
+++ b/importer/src/test/resources/typings-json/check/p/phaser/src/main/scala/typings/phaserLib/phaserMod/Animation.scala
@@ -6,10 +6,10 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 /**
-     * An Animation instance contains a single animation and the controls to play it.
-     *
-     * It is created by the AnimationManager, consists of Animation.Frame objects and belongs to a single Game Object such as a Sprite.
-     */
+  * An Animation instance contains a single animation and the controls to play it.
+  *
+  * It is created by the AnimationManager, consists of Animation.Frame objects and belongs to a single Game Object such as a Sprite.
+  */
 @JSImport("phaser", "Animation")
 @js.native
 class Animation ()

--- a/importer/src/test/resources/typings-json/check/s/std/build.sbt
+++ b/importer/src/test/resources/typings-json/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-20654c"
+version := "0.0-unknown-f6c17e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/typings-json/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/typings-json/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/virtual-dom/check/s/std/build.sbt
+++ b/importer/src/test/resources/virtual-dom/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-20654c"
+version := "0.0-unknown-f6c17e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/virtual-dom/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/virtual-dom/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/virtual-dom/check/v/virtual-dom/build.sbt
+++ b/importer/src/test/resources/virtual-dom/check/v/virtual-dom/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "virtual-dom"
-version := "0.0-unknown-ffd375"
+version := "0.0-unknown-cb2967"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-20654c")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f6c17e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/void-elements/check/s/std/build.sbt
+++ b/importer/src/test/resources/void-elements/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-ac3264"
+version := "0.0-unknown-2f4a5c"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/void-elements/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/void-elements/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/void-elements/check/v/void-elements/build.sbt
+++ b/importer/src/test/resources/void-elements/check/v/void-elements/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "void-elements"
-version := "3.1-122397"
+version := "3.1-cd57c4"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ac3264")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-2f4a5c")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/vue/check/n/node/build.sbt
+++ b/importer/src/test/resources/vue/check/n/node/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "0.0-unknown-1dbf0a"
+version := "0.0-unknown-0d2e2c"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-470dfe")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f91e6a")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/vue/check/n/node/src/main/scala/typings/nodeLib/NodeJSNs/Process.scala
+++ b/importer/src/test/resources/vue/check/n/node/src/main/scala/typings/nodeLib/NodeJSNs/Process.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Process extends js.Object
 

--- a/importer/src/test/resources/vue/check/s/std/build.sbt
+++ b/importer/src/test/resources/vue/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-470dfe"
+version := "0.0-unknown-f91e6a"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/Blob.scala
+++ b/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/Blob.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Blob extends js.Object
 

--- a/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/Error.scala
+++ b/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/Error.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Error extends js.Object
 

--- a/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/Node.scala
+++ b/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/Node.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Node extends js.Object
 

--- a/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/Object.scala
+++ b/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/Object.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Object extends js.Object
 

--- a/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/Promise.scala
+++ b/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/Promise.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Promise[T] extends js.Object
 

--- a/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/PromiseLike.scala
+++ b/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/PromiseLike.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait PromiseLike[T] extends js.Object
 

--- a/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/RegExp.scala
+++ b/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/RegExp.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait RegExp extends js.Object
 

--- a/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/ThisType.scala
+++ b/importer/src/test/resources/vue/check/s/std/src/main/scala/typings/stdLib/ThisType.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ThisType[T] extends js.Object
 

--- a/importer/src/test/resources/vue/check/s/storybook__vue/build.sbt
+++ b/importer/src/test/resources/vue/check/s/storybook__vue/build.sbt
@@ -1,15 +1,15 @@
 organization := "org.scalablytyped"
 name := "storybook__vue"
-version := "3.3-e7313f"
+version := "3.3-3daa7a"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "node" % "0.0-unknown-1dbf0a",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-470dfe",
-  "org.scalablytyped" %%% "vue" % "2.5.13-8a870a",
-  "org.scalablytyped" %%% "webpack-env" % "1.13-8db096")
+  "org.scalablytyped" %%% "node" % "0.0-unknown-0d2e2c",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f91e6a",
+  "org.scalablytyped" %%% "vue" % "2.5.13-e557d0",
+  "org.scalablytyped" %%% "webpack-env" % "1.13-232ae8")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/vue/check/s/storybook__vue/src/main/scala/typings/atStorybookVueLib/Anon_Kind.scala
+++ b/importer/src/test/resources/vue/check/s/storybook__vue/src/main/scala/typings/atStorybookVueLib/Anon_Kind.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_Kind extends js.Object {
   var kind: java.lang.String
   var story: java.lang.String

--- a/importer/src/test/resources/vue/check/s/storybook__vue/src/main/scala/typings/atStorybookVueLib/vueMod/Addon.scala
+++ b/importer/src/test/resources/vue/check/s/storybook__vue/src/main/scala/typings/atStorybookVueLib/vueMod/Addon.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Addon
   extends /* addonName */ org.scalablytyped.runtime.StringDictionary[
       js.Function2[/* storyName */ java.lang.String, /* storyFn */ StoryFunction, scala.Unit]

--- a/importer/src/test/resources/vue/check/s/storybook__vue/src/main/scala/typings/atStorybookVueLib/vueMod/Story.scala
+++ b/importer/src/test/resources/vue/check/s/storybook__vue/src/main/scala/typings/atStorybookVueLib/vueMod/Story.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Story extends js.Object {
   val kind: java.lang.String
   def add(storyName: java.lang.String, getStory: StoryFunction): this.type

--- a/importer/src/test/resources/vue/check/s/storybook__vue/src/main/scala/typings/atStorybookVueLib/vueMod/StoryStore.scala
+++ b/importer/src/test/resources/vue/check/s/storybook__vue/src/main/scala/typings/atStorybookVueLib/vueMod/StoryStore.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait StoryStore extends js.Object {
   var fileName: js.UndefOr[java.lang.String]
   var kind: java.lang.String

--- a/importer/src/test/resources/vue/check/v/vue-resource/build.sbt
+++ b/importer/src/test/resources/vue/check/v/vue-resource/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "vue-resource"
-version := "0.9.3-6a089f"
+version := "0.9.3-135eaa"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-470dfe",
-  "org.scalablytyped" %%% "vue" % "2.5.13-8a870a")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f91e6a",
+  "org.scalablytyped" %%% "vue" % "2.5.13-e557d0")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/Anon_Key.scala
+++ b/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/Anon_Key.scala
@@ -5,8 +5,8 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
-trait Anon_Headers extends js.Object {
+trait Anon_Key
+  extends /* key */ org.scalablytyped.runtime.StringDictionary[js.Any] {
   var headers: js.UndefOr[vueDashResourceLib.vuejsNs.HttpHeaders] = js.undefined
 }
 

--- a/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/Anon_Method.scala
+++ b/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/Anon_Method.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_Method extends js.Object {
   var method: java.lang.String
 }

--- a/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/Anon_Root.scala
+++ b/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/Anon_Root.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_Root extends js.Object {
   var root: java.lang.String
 }

--- a/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/vuejsNs/ComponentOption.scala
+++ b/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/vuejsNs/ComponentOption.scala
@@ -5,10 +5,7 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ComponentOption extends js.Object {
-  var http: js.UndefOr[
-    HttpOptions with vueDashResourceLib.Anon_Headers with org.scalablytyped.runtime.StringDictionary[js.Any]
-  ] = js.undefined
+  var http: js.UndefOr[vueDashResourceLib.Anon_Key with HttpOptions] = js.undefined
 }
 

--- a/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/vuejsNs/HttpHeaders.scala
+++ b/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/vuejsNs/HttpHeaders.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait HttpHeaders
   extends /* key */ org.scalablytyped.runtime.StringDictionary[js.Any] {
   var common: js.UndefOr[org.scalablytyped.runtime.StringDictionary[java.lang.String]] = js.undefined

--- a/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/vuejsNs/HttpInterceptor.scala
+++ b/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/vuejsNs/HttpInterceptor.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait HttpInterceptor extends js.Object {
   var request: js.UndefOr[js.Function1[/* request */ HttpOptions, HttpOptions]] = js.undefined
   var response: js.UndefOr[js.Function1[/* response */ HttpResponse, HttpResponse]] = js.undefined

--- a/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/vuejsNs/HttpOptions.scala
+++ b/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/vuejsNs/HttpOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait HttpOptions extends js.Object {
   var before: js.UndefOr[js.Function1[/* request */ js.Any, _]] = js.undefined
   var body: js.UndefOr[js.Any] = js.undefined

--- a/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/vuejsNs/HttpResponse.scala
+++ b/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/vuejsNs/HttpResponse.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait HttpResponse extends js.Object {
   var data: js.Object
   var headers: js.Function

--- a/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/vuejsNs/ResourceActions.scala
+++ b/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/vuejsNs/ResourceActions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ResourceActions extends js.Object {
   var delete: vueDashResourceLib.Anon_Method
   var get: vueDashResourceLib.Anon_Method

--- a/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/vuejsNs/VueStatic.scala
+++ b/importer/src/test/resources/vue/check/v/vue-resource/src/main/scala/typings/vueDashResourceLib/vuejsNs/VueStatic.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait VueStatic extends js.Object {
   var http: Http
   var resource: Resource

--- a/importer/src/test/resources/vue/check/v/vue-scrollto/build.sbt
+++ b/importer/src/test/resources/vue/check/v/vue-scrollto/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "vue-scrollto"
-version := "2.7-fbf249"
+version := "2.7-399556"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-470dfe",
-  "org.scalablytyped" %%% "vue" % "2.5.13-8a870a")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f91e6a",
+  "org.scalablytyped" %%% "vue" % "2.5.13-e557d0")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/vue/check/v/vue-scrollto/src/main/scala/typings/vueDashScrolltoLib/vueDashScrolltoMod/VueScrollToNs/Options.scala
+++ b/importer/src/test/resources/vue/check/v/vue-scrollto/src/main/scala/typings/vueDashScrolltoLib/vueDashScrolltoMod/VueScrollToNs/Options.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Options extends js.Object {
   // Indicates if user can cancel the scroll or not. Default: true
   var cancelable: js.UndefOr[scala.Boolean] = js.undefined

--- a/importer/src/test/resources/vue/check/v/vue/build.sbt
+++ b/importer/src/test/resources/vue/check/v/vue/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "vue"
-version := "2.5.13-8a870a"
+version := "2.5.13-e557d0"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-470dfe")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f91e6a")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/Anon_From.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/Anon_From.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_From extends js.Object {
   var default: js.UndefOr[js.Any] = js.undefined
   var from: js.UndefOr[vueLib.typesOptionsMod.InjectKey] = js.undefined

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/Anon_Object.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/Anon_Object.scala
@@ -1,0 +1,13 @@
+package typings
+package vueLib
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait Anon_Object extends js.Object {
+  def apply[T](array: js.Array[T], key: scala.Double, value: T): T = js.native
+  def apply[T](`object`: js.Object, key: java.lang.String, value: T): T = js.native
+}
+

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/Anon_ObjectKey.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/Anon_ObjectKey.scala
@@ -1,0 +1,13 @@
+package typings
+package vueLib
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait Anon_ObjectKey extends js.Object {
+  def apply(`object`: js.Object, key: java.lang.String): scala.Unit = js.native
+  def apply[T](array: js.Array[T], key: scala.Double): scala.Unit = js.native
+}
+

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/Anon_Prop.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/Anon_Prop.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_Prop extends js.Object {
   var event: js.UndefOr[java.lang.String] = js.undefined
   var prop: js.UndefOr[java.lang.String] = js.undefined

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/Anon_StaticRenderFns.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/Anon_StaticRenderFns.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_StaticRenderFns extends js.Object {
   var render: js.Function
   var staticRenderFns: js.Array[js.Function]

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/Anon_StaticRenderFnsRender.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/Anon_StaticRenderFnsRender.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Anon_StaticRenderFnsRender extends js.Object {
   var staticRenderFns: js.Array[js.Function0[vueLib.typesVnodeMod.VNode]]
   def render(createElement: vueLib.typesVueMod.CreateElement): vueLib.typesVnodeMod.VNode

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/ComponentOptions.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/ComponentOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ComponentOptions[V /* <: vueLib.typesVueMod.Vue */, Data, Methods, Computed, PropsDef] extends js.Object {
   var activated: js.UndefOr[js.Function0[scala.Unit]] = js.undefined
   var beforeCreate: js.UndefOr[js.ThisFunction0[/* this */ V, scala.Unit]] = js.undefined

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/ComputedOptions.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/ComputedOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ComputedOptions[T] extends js.Object {
   var cache: js.UndefOr[scala.Boolean] = js.undefined
   var get: js.UndefOr[js.Function0[T]] = js.undefined

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/DefaultComputed.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/DefaultComputed.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait DefaultComputed
   extends /* key */ org.scalablytyped.runtime.StringDictionary[js.Any]
 

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/DefaultMethods.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/DefaultMethods.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait DefaultMethods[V]
-  extends /* key */ org.scalablytyped.runtime.StringDictionary[js.ThisFunction1[/* this */ V, /* repeated */js.Any, _]]
+  extends /* key */ org.scalablytyped.runtime.StringDictionary[js.ThisFunction1[/* this */ V, /* repeated */ js.Any, _]]
 

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/DirectiveOptions.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/DirectiveOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait DirectiveOptions extends js.Object {
   var bind: js.UndefOr[DirectiveFunction] = js.undefined
   var componentUpdated: js.UndefOr[DirectiveFunction] = js.undefined

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/EsModuleComponent.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/EsModuleComponent.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait EsModuleComponent extends js.Object {
   var default: Component[
     DefaultData[vueLib.typesVueMod.Vue], 

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/FunctionalComponentOptions.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/FunctionalComponentOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait FunctionalComponentOptions[Props, PropDefs] extends js.Object {
   var functional: scala.Boolean
   var inject: js.UndefOr[InjectOptions] = js.undefined

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/PropOptions.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/PropOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait PropOptions[T] extends js.Object {
   var default: js.UndefOr[T | scala.Null | js.Function0[js.Object]] = js.undefined
   var required: js.UndefOr[scala.Boolean] = js.undefined

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/RenderContext.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/RenderContext.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait RenderContext[Props] extends js.Object {
   var children: js.Array[vueLib.typesVnodeMod.VNode]
   var data: vueLib.typesVnodeMod.VNodeData

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/WatchOptions.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesOptionsMod/WatchOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait WatchOptions extends js.Object {
   var deep: js.UndefOr[scala.Boolean] = js.undefined
   var immediate: js.UndefOr[scala.Boolean] = js.undefined

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVnodeMod/VNode.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVnodeMod/VNode.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait VNode extends js.Object {
   var children: js.UndefOr[js.Array[VNode]] = js.undefined
   var componentInstance: js.UndefOr[vueLib.typesVueMod.Vue] = js.undefined

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVnodeMod/VNodeChildrenArrayContents.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVnodeMod/VNodeChildrenArrayContents.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait VNodeChildrenArrayContents
   extends /* x */ org.scalablytyped.runtime.NumberDictionary[VNode | java.lang.String | VNodeChildren]
 

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVnodeMod/VNodeComponentOptions.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVnodeMod/VNodeComponentOptions.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait VNodeComponentOptions extends js.Object {
   var Ctor: vueLib.typesVueMod.VueConstructor[vueLib.typesVueMod.Vue]
   var children: js.UndefOr[VNodeChildren] = js.undefined

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVnodeMod/VNodeData.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVnodeMod/VNodeData.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait VNodeData extends js.Object {
   var attrs: js.UndefOr[org.scalablytyped.runtime.StringDictionary[js.Any]] = js.undefined
   var `class`: js.UndefOr[js.Any] = js.undefined

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVnodeMod/VNodeDirective.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVnodeMod/VNodeDirective.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait VNodeDirective extends js.Object {
   val arg: java.lang.String
   val expression: js.Any

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVueMod/Vue.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVueMod/Vue.scala
@@ -16,7 +16,7 @@ trait Vue extends js.Object {
   @JSName("$data")
   val $data: stdLib.Record[java.lang.String, _] = js.native
   @JSName("$delete")
-  var $delete_Original: js.Function2[/* object */ js.Object, /* key */ java.lang.String, scala.Unit] = js.native
+  var $delete_Original: vueLib.Anon_ObjectKey = js.native
   @JSName("$el")
   val $el: stdLib.HTMLElement = js.native
   @JSName("$isServer")
@@ -42,7 +42,7 @@ trait Vue extends js.Object {
   @JSName("$scopedSlots")
   val $scopedSlots: org.scalablytyped.runtime.StringDictionary[vueLib.typesVnodeMod.ScopedSlot] = js.native
   @JSName("$set")
-  var $set_Original: js.Function3[/* object */ js.Object, /* key */ java.lang.String, /* value */ js.Any, _] = js.native
+  var $set_Original: vueLib.Anon_Object = js.native
   @JSName("$slots")
   val $slots: org.scalablytyped.runtime.StringDictionary[js.Array[vueLib.typesVnodeMod.VNode]] = js.native
   @JSName("$ssrContext")
@@ -140,6 +140,8 @@ trait Vue extends js.Object {
   ): vueLib.typesVnodeMod.VNode = js.native
   @JSName("$delete")
   def $delete(`object`: js.Object, key: java.lang.String): scala.Unit = js.native
+  @JSName("$delete")
+  def $delete[T](array: js.Array[T], key: scala.Double): scala.Unit = js.native
   @JSName("$destroy")
   def $destroy(): scala.Unit = js.native
   @JSName("$emit")
@@ -176,6 +178,8 @@ trait Vue extends js.Object {
   def $on(event: js.Array[java.lang.String], callback: js.Function): this.type = js.native
   @JSName("$once")
   def $once(event: java.lang.String, callback: js.Function): this.type = js.native
+  @JSName("$set")
+  def $set[T](array: js.Array[T], key: scala.Double, value: T): T = js.native
   @JSName("$set")
   def $set[T](`object`: js.Object, key: java.lang.String, value: T): T = js.native
   @JSName("$watch")

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVueMod/VueConfiguration.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVueMod/VueConfiguration.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait VueConfiguration extends js.Object {
   var devtools: scala.Boolean
   var ignoredElements: js.Array[java.lang.String | stdLib.RegExp]

--- a/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVueMod/VueConstructor.scala
+++ b/importer/src/test/resources/vue/check/v/vue/src/main/scala/typings/vueLib/typesVueMod/VueConstructor.scala
@@ -11,8 +11,7 @@ trait VueConstructor[V /* <: Vue */]
 org.scalablytyped.runtime.Instantiable0[
       CombinedVueInstance[V, js.Object, js.Object, js.Object, stdLib.Record[java.lang.String, js.Any]]
     ]
-     with // ideally, the return type should just contains Props, not Record<keyof Props, any>. But TS requires Base constructors must all have the same return type.
-org.scalablytyped.runtime.Instantiable1[
+     with org.scalablytyped.runtime.Instantiable1[
       (/* options */ vueLib.typesOptionsMod.ComponentOptions[
         V, 
         vueLib.typesOptionsMod.DefaultData[V], 

--- a/importer/src/test/resources/vue/check/w/webpack-env/build.sbt
+++ b/importer/src/test/resources/vue/check/w/webpack-env/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "webpack-env"
-version := "1.13-8db096"
+version := "1.13-232ae8"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "node" % "0.0-unknown-1dbf0a",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-470dfe")
+  "org.scalablytyped" %%% "node" % "0.0-unknown-0d2e2c",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f91e6a")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/vue/check/w/webpack-env/src/main/scala/typings/webpackDashEnvLib/underscoreUnderscoreWebpackModuleApiNs/AcceptOptions.scala
+++ b/importer/src/test/resources/vue/check/w/webpack-env/src/main/scala/typings/webpackDashEnvLib/underscoreUnderscoreWebpackModuleApiNs/AcceptOptions.scala
@@ -5,15 +5,14 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait AcceptOptions extends js.Object {
   /**
-           * Indicates that apply() is automatically called by check function
-           */
+    * Indicates that apply() is automatically called by check function
+    */
   var autoApply: js.UndefOr[scala.Boolean] = js.undefined
   /**
-           * If true the update process continues even if some modules are not accepted (and would bubble to the entry point).
-           */
+    * If true the update process continues even if some modules are not accepted (and would bubble to the entry point).
+    */
   var ignoreUnaccepted: js.UndefOr[scala.Boolean] = js.undefined
 }
 

--- a/importer/src/test/resources/vue/check/w/webpack-env/src/main/scala/typings/webpackDashEnvLib/underscoreUnderscoreWebpackModuleApiNs/Hot.scala
+++ b/importer/src/test/resources/vue/check/w/webpack-env/src/main/scala/typings/webpackDashEnvLib/underscoreUnderscoreWebpackModuleApiNs/Hot.scala
@@ -10,126 +10,120 @@ trait Hot extends js.Object {
   var active: scala.Boolean = js.native
   var data: js.Any = js.native
   /**
-           * Accept code updates for this module without notification of parents.
-           * This should only be used if the module doesn’t export anything.
-           * The errHandler can be used to handle errors that occur while loading the updated module.
-           * @param errHandler
-           */
+    * Accept code updates for this module without notification of parents.
+    * This should only be used if the module doesn’t export anything.
+    * The errHandler can be used to handle errors that occur while loading the updated module.
+    * @param errHandler
+    */
   def accept(): scala.Unit = js.native
   /**
-           * Accept code updates for the specified dependencies. The callback is called when dependencies were replaced.
-           * @param dependencies
-           * @param callback
-           */
+    * Accept code updates for the specified dependencies. The callback is called when dependencies were replaced.
+    * @param dependencies
+    * @param callback
+    */
   def accept(
     dependencies: js.Array[java.lang.String],
     callback: js.Function1[/* updatedDependencies */ js.Array[ModuleId], scala.Unit]
   ): scala.Unit = js.native
   /**
-           * Accept code updates for the specified dependencies. The callback is called when dependencies were replaced.
-           * @param dependency
-           * @param callback
-           */
+    * Accept code updates for the specified dependencies. The callback is called when dependencies were replaced.
+    * @param dependency
+    * @param callback
+    */
   def accept(dependency: java.lang.String, callback: js.Function0[scala.Unit]): scala.Unit = js.native
-  /**
-           * Accept code updates for this module without notification of parents.
-           * This should only be used if the module doesn’t export anything.
-           * The errHandler can be used to handle errors that occur while loading the updated module.
-           * @param errHandler
-           */
   def accept(errHandler: js.Function1[/* err */ stdLib.Error, scala.Unit]): scala.Unit = js.native
   /**
-           * Add a one time handler, which is executed when the current module code is replaced.
-           * Here you should destroy/remove any persistent resource you have claimed/created.
-           * If you want to transfer state to the new module, add it to data object.
-           * The data will be available at module.hot.data on the new module.
-           * @param callback
-           */
+    * Add a one time handler, which is executed when the current module code is replaced.
+    * Here you should destroy/remove any persistent resource you have claimed/created.
+    * If you want to transfer state to the new module, add it to data object.
+    * The data will be available at module.hot.data on the new module.
+    * @param callback
+    */
   def addDisposeHandler(callback: js.Function1[/* data */ js.Any, scala.Unit]): scala.Unit = js.native
   @JSName("addDisposeHandler")
   def addDisposeHandler_T[T](callback: js.Function1[/* data */ T, scala.Unit]): scala.Unit = js.native
   /** Register a callback on status change. */
   def addStatusHandler(callback: js.Function1[/* status */ java.lang.String, scala.Unit]): scala.Unit = js.native
   /**
-           * If status() != "ready" it throws an error.
-           * Continue the update process.
-           * @param callback
-           */
+    * If status() != "ready" it throws an error.
+    * Continue the update process.
+    * @param callback
+    */
   @JSName("apply")
   def apply(
     callback: js.Function2[/* err */ stdLib.Error, /* outdatedModules */ js.Array[ModuleId], scala.Unit]
   ): scala.Unit = js.native
   /**
-           * If status() != "ready" it throws an error.
-           * Continue the update process.
-           * @param options
-           * @param callback
-           */
+    * If status() != "ready" it throws an error.
+    * Continue the update process.
+    * @param options
+    * @param callback
+    */
   @JSName("apply")
   def apply(
     options: AcceptOptions,
     callback: js.Function2[/* err */ stdLib.Error, /* outdatedModules */ js.Array[ModuleId], scala.Unit]
   ): scala.Unit = js.native
   /**
-           * Throws an exceptions if status() is not idle.
-           * Check all currently loaded modules for updates and apply updates if found.
-           * If no update was found, the callback is called with null.
-           * If autoApply is truthy the callback will be called with all modules that were disposed.
-           * apply() is automatically called with autoApply as options parameter.
-           * If autoApply is not set the callback will be called with all modules that will be disposed on apply().
-           * @param autoApply
-           * @param callback
-           */
+    * Throws an exceptions if status() is not idle.
+    * Check all currently loaded modules for updates and apply updates if found.
+    * If no update was found, the callback is called with null.
+    * If autoApply is truthy the callback will be called with all modules that were disposed.
+    * apply() is automatically called with autoApply as options parameter.
+    * If autoApply is not set the callback will be called with all modules that will be disposed on apply().
+    * @param autoApply
+    * @param callback
+    */
   def check(
     autoApply: scala.Boolean,
     callback: js.Function2[/* err */ stdLib.Error, /* outdatedModules */ js.Array[ModuleId], scala.Unit]
   ): scala.Unit = js.native
   /**
-           * Throws an exceptions if status() is not idle.
-           * Check all currently loaded modules for updates and apply updates if found.
-           * If no update was found, the callback is called with null.
-           * The callback will be called with all modules that will be disposed on apply().
-           * @param callback
-           */
+    * Throws an exceptions if status() is not idle.
+    * Check all currently loaded modules for updates and apply updates if found.
+    * If no update was found, the callback is called with null.
+    * The callback will be called with all modules that will be disposed on apply().
+    * @param callback
+    */
   def check(
     callback: js.Function2[/* err */ stdLib.Error, /* outdatedModules */ js.Array[ModuleId], scala.Unit]
   ): scala.Unit = js.native
   /**
-           * Flag the current module as not update-able. If updated the update code would fail with code "decline".
-           */
+    * Flag the current module as not update-able. If updated the update code would fail with code "decline".
+    */
   def decline(): scala.Unit = js.native
   /**
-           * Do not accept updates for the specified dependencies. If any dependencies is updated, the code update fails with code "decline".
-           */
+    * Do not accept updates for the specified dependencies. If any dependencies is updated, the code update fails with code "decline".
+    */
   def decline(dependencies: js.Array[java.lang.String]): scala.Unit = js.native
   /**
-           * Do not accept updates for the specified dependencies. If any dependencies is updated, the code update fails with code "decline".
-           */
+    * Do not accept updates for the specified dependencies. If any dependencies is updated, the code update fails with code "decline".
+    */
   def decline(dependency: java.lang.String): scala.Unit = js.native
   /**
-           * Add a one time handler, which is executed when the current module code is replaced.
-           * Here you should destroy/remove any persistent resource you have claimed/created.
-           * If you want to transfer state to the new module, add it to data object.
-           * The data will be available at module.hot.data on the new module.
-           * @param callback
-           */
+    * Add a one time handler, which is executed when the current module code is replaced.
+    * Here you should destroy/remove any persistent resource you have claimed/created.
+    * If you want to transfer state to the new module, add it to data object.
+    * The data will be available at module.hot.data on the new module.
+    * @param callback
+    */
   def dispose(callback: js.Function1[/* data */ js.Any, scala.Unit]): scala.Unit = js.native
   /**
-           * Remove a handler.
-           * This can useful to add a temporary dispose handler. You could i. e. replace code while in the middle of a multi-step async function.
-           * @param callback
-           */
+    * Remove a handler.
+    * This can useful to add a temporary dispose handler. You could i. e. replace code while in the middle of a multi-step async function.
+    * @param callback
+    */
   def removeDisposeHandler(callback: js.Function1[/* data */ js.Any, scala.Unit]): scala.Unit = js.native
   @JSName("removeDisposeHandler")
   def removeDisposeHandler_T[T](callback: js.Function1[/* data */ T, scala.Unit]): scala.Unit = js.native
   /**
-           * Remove a registered status change handler.
-           * @param callback
-           */
+    * Remove a registered status change handler.
+    * @param callback
+    */
   def removeStatusHandler(callback: js.Function1[/* status */ java.lang.String, scala.Unit]): scala.Unit = js.native
   /**
-           * Return one of idle, check, watch, watch-delay, prepare, ready, dispose, apply, abort or fail.
-           */
+    * Return one of idle, check, watch, watch-delay, prepare, ready, dispose, apply, abort or fail.
+    */
   def status(): java.lang.String = js.native
   /** Register a callback on status change. */
   def status(callback: js.Function1[/* status */ java.lang.String, scala.Unit]): scala.Unit = js.native

--- a/importer/src/test/resources/vue/check/w/webpack-env/src/main/scala/typings/webpackDashEnvLib/underscoreUnderscoreWebpackModuleApiNs/NodeProcess.scala
+++ b/importer/src/test/resources/vue/check/w/webpack-env/src/main/scala/typings/webpackDashEnvLib/underscoreUnderscoreWebpackModuleApiNs/NodeProcess.scala
@@ -6,9 +6,8 @@ import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
 /**
-    * Inside env you can pass any variable
-    */
-
+  * Inside env you can pass any variable
+  */
 trait NodeProcess extends js.Object {
   var env: js.UndefOr[js.Any] = js.undefined
 }

--- a/importer/src/test/resources/vue/check/w/webpack-env/src/main/scala/typings/webpackDashEnvLib/underscoreUnderscoreWebpackModuleApiNs/RequireFunction.scala
+++ b/importer/src/test/resources/vue/check/w/webpack-env/src/main/scala/typings/webpackDashEnvLib/underscoreUnderscoreWebpackModuleApiNs/RequireFunction.scala
@@ -8,52 +8,47 @@ import scala.scalajs.js.annotation._
 @js.native
 trait RequireFunction extends js.Object {
   /**
-           * Multiple requires to the same module result in only one module execution and only one export. Therefore a cache in the runtime exists. Removing values from this cache cause new module execution and a new export. This is only needed in rare cases (for compatibility!).
-           */
+    * Multiple requires to the same module result in only one module execution and only one export. Therefore a cache in the runtime exists. Removing values from this cache cause new module execution and a new export. This is only needed in rare cases (for compatibility!).
+    */
   var cache: org.scalablytyped.runtime.StringDictionary[js.Any] = js.native
   /**
-           * Returns the exports from a dependency. The call is sync. No request to the server is fired. The compiler ensures that the dependency is available.
-           */
+    * Returns the exports from a dependency. The call is sync. No request to the server is fired. The compiler ensures that the dependency is available.
+    */
   def apply(path: java.lang.String): js.Any = js.native
   /**
-           * Behaves similar to require.ensure, but the callback is called with the exports of each dependency in the paths array. There is no option to provide a chunk name.
-           */
-  def apply(paths: js.Array[java.lang.String], callback: js.Function1[/* repeated */js.Any, scala.Unit]): scala.Unit = js.native
+    * Behaves similar to require.ensure, but the callback is called with the exports of each dependency in the paths array. There is no option to provide a chunk name.
+    */
+  def apply(paths: js.Array[java.lang.String], callback: js.Function1[/* repeated */ js.Any, scala.Unit]): scala.Unit = js.native
   def context(path: java.lang.String): RequireContext = js.native
   def context(path: java.lang.String, deep: scala.Boolean): RequireContext = js.native
   def context(path: java.lang.String, deep: scala.Boolean, filter: stdLib.RegExp): RequireContext = js.native
   /**
-           * Download additional dependencies on demand. The paths array lists modules that should be available. When they are, callback is called. If the callback is a function expression, dependencies in that source part are extracted and also loaded on demand. A single request is fired to the server, except if all modules are already available.
-           *
-           * This creates a chunk. The chunk can be named. If a chunk with this name already exists, the dependencies are merged into that chunk and that chunk is used.
-           */
+    * Download additional dependencies on demand. The paths array lists modules that should be available. When they are, callback is called. If the callback is a function expression, dependencies in that source part are extracted and also loaded on demand. A single request is fired to the server, except if all modules are already available.
+    *
+    * This creates a chunk. The chunk can be named. If a chunk with this name already exists, the dependencies are merged into that chunk and that chunk is used.
+    */
   def ensure(
     paths: js.Array[java.lang.String],
     callback: js.Function1[/* require */ webpackDashEnvLib.NodeRequire, scala.Unit]
   ): scala.Unit = js.native
-  /**
-           * Download additional dependencies on demand. The paths array lists modules that should be available. When they are, callback is called. If the callback is a function expression, dependencies in that source part are extracted and also loaded on demand. A single request is fired to the server, except if all modules are already available.
-           *
-           * This creates a chunk. The chunk can be named. If a chunk with this name already exists, the dependencies are merged into that chunk and that chunk is used.
-           */
   def ensure(
     paths: js.Array[java.lang.String],
     callback: js.Function1[/* require */ webpackDashEnvLib.NodeRequire, scala.Unit],
     chunkName: java.lang.String
   ): scala.Unit = js.native
   /**
-           * Ensures that the dependency is available, but don’t execute it. This can be use for optimizing the position of a module in the chunks.
-           */
+    * Ensures that the dependency is available, but don’t execute it. This can be use for optimizing the position of a module in the chunks.
+    */
   def include(path: java.lang.String): scala.Unit = js.native
   /**
-           * Returns the module id of a dependency. The call is sync. No request to the server is fired. The compiler ensures that the dependency is available.
-           *
-           * The module id is a number in webpack (in contrast to node.js where it is a string, the filename).
-           */
+    * Returns the module id of a dependency. The call is sync. No request to the server is fired. The compiler ensures that the dependency is available.
+    *
+    * The module id is a number in webpack (in contrast to node.js where it is a string, the filename).
+    */
   def resolve(path: java.lang.String): scala.Double | java.lang.String = js.native
   /**
-           * Like require.resolve, but doesn’t include the module into the bundle. It’s a weak dependency.
-           */
+    * Like require.resolve, but doesn’t include the module into the bundle. It’s a weak dependency.
+    */
   def resolveWeak(path: java.lang.String): scala.Double | java.lang.String = js.native
 }
 

--- a/importer/src/test/resources/vue/check/w/webpack-env/src/main/scala/typings/webpackDashEnvLib/webpackDashEnvLibMembers.scala
+++ b/importer/src/test/resources/vue/check/w/webpack-env/src/main/scala/typings/webpackDashEnvLib/webpackDashEnvLibMembers.scala
@@ -9,25 +9,25 @@ import scala.scalajs.js.annotation._
 @js.native
 object webpackDashEnvLibMembers extends js.Object {
   /**
-   * Equals the config option debug
-   */
+    * Equals the config option debug
+    */
   var DEBUG: scala.Boolean = js.native
   /**
-   * Generates a require function that is not parsed by webpack. Can be used to do cool stuff with a global require function if available.
-   */
+    * Generates a require function that is not parsed by webpack. Can be used to do cool stuff with a global require function if available.
+    */
   var `__non_webpack_require__`: js.Any = js.native
   /**
-   * The resource query of the current module.
-   *
-   * e.g. __resourceQuery === "?test" // Inside "file.js?test"
-   */
+    * The resource query of the current module.
+    *
+    * e.g. __resourceQuery === "?test" // Inside "file.js?test"
+    */
   var __resourceQuery: java.lang.String = js.native
   /**
-   * The internal chunk loading function
-   *
-   * @param chunkId The id for the chunk to load.
-   * @param callback A callback function called once the chunk is loaded.
-   */
+    * The internal chunk loading function
+    *
+    * @param chunkId The id for the chunk to load.
+    * @param callback A callback function called once the chunk is loaded.
+    */
   var `__webpack_chunk_load__`: js.Function2[
     /* chunkId */ js.Any, 
     /* callback */ js.Function1[
@@ -37,22 +37,22 @@ object webpackDashEnvLibMembers extends js.Object {
     scala.Unit
   ] = js.native
   /**
-   * Access to the hash of the compilation.
-   *
-   * Only available with the HotModuleReplacementPlugin or the ExtendedAPIPlugin
-   */
+    * Access to the hash of the compilation.
+    *
+    * Only available with the HotModuleReplacementPlugin or the ExtendedAPIPlugin
+    */
   var `__webpack_hash__`: js.Any = js.native
   /**
-   * Access to the internal object of all modules.
-   */
+    * Access to the internal object of all modules.
+    */
   var `__webpack_modules__`: js.Array[js.Any] = js.native
   /**
-   * Equals the config options output.publicPath.
-   */
+    * Equals the config options output.publicPath.
+    */
   var `__webpack_public_path__`: java.lang.String = js.native
   /**
-   * The raw require function. This expression isn’t parsed by the Parser for dependencies.
-   */
+    * The raw require function. This expression isn’t parsed by the Parser for dependencies.
+    */
   var `__webpack_require__`: js.Any = js.native
   var module: NodeModule = js.native
   var process: webpackDashEnvLib.NodeJSNs.Process = js.native

--- a/importer/src/test/resources/winston/check/s/std/build.sbt
+++ b/importer/src/test/resources/winston/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-20654c"
+version := "0.0-unknown-f6c17e"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/winston/check/s/std/src/main/scala/typings/stdLib/Array.scala
+++ b/importer/src/test/resources/winston/check/s/std/src/main/scala/typings/stdLib/Array.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Array[T] extends js.Object
 

--- a/importer/src/test/resources/winston/check/w/winston/build.sbt
+++ b/importer/src/test/resources/winston/check/w/winston/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "winston"
-version := "3.0.0-a4635b"
+version := "3.0.0-2e6745"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-20654c")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f6c17e")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/winston/check/w/winston/src/main/scala/typings/winstonLib/libWinstonConfigMod/winstonNs/AbstractConfigSetLevels.scala
+++ b/importer/src/test/resources/winston/check/w/winston/src/main/scala/typings/winstonLib/libWinstonConfigMod/winstonNs/AbstractConfigSetLevels.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait AbstractConfigSetLevels
   extends /* key */ org.scalablytyped.runtime.StringDictionary[scala.Double]
 

--- a/importer/src/test/resources/winston/check/w/winston/src/main/scala/typings/winstonLib/libWinstonConfigMod/winstonNs/Config.scala
+++ b/importer/src/test/resources/winston/check/w/winston/src/main/scala/typings/winstonLib/libWinstonConfigMod/winstonNs/Config.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Config extends js.Object {
   var foo: winstonLib.winstonLibStrings.bar
 }

--- a/importer/src/test/resources/winston/check/w/winston/src/main/scala/typings/winstonLib/winstonMod/winstonNs.scala
+++ b/importer/src/test/resources/winston/check/w/winston/src/main/scala/typings/winstonLib/winstonMod/winstonNs.scala
@@ -8,7 +8,6 @@ import scala.scalajs.js.annotation._
 @JSImport("winston", "winston")
 @js.native
 object winstonNs extends js.Object {
-  
   trait LoggerOptions extends js.Object {
     var levels: js.UndefOr[winstonLib.libWinstonConfigMod.winstonNs.AbstractConfigSetLevels] = js.undefined
   }
@@ -20,10 +19,8 @@ object winstonNs extends js.Object {
     @JSName("winston")
     @js.native
     object winstonNs extends js.Object {
-      
       trait AbstractConfigSetLevels
         extends /* key */ org.scalablytyped.runtime.StringDictionary[scala.Double]
-      
       
       trait Config extends js.Object {
         var foo: winstonLib.winstonLibStrings.bar

--- a/importer/src/test/resources/with-theme/check/r/react/build.sbt
+++ b/importer/src/test/resources/with-theme/check/r/react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-66a538"
+version := "0.0-unknown-b86956"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-0e42ea")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-3460cb")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/with-theme/check/r/react/src/main/scala/typings/reactLib/ReactNs/ComponentClass.scala
+++ b/importer/src/test/resources/with-theme/check/r/react/src/main/scala/typings/reactLib/ReactNs/ComponentClass.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ComponentClass[P] extends js.Object
 

--- a/importer/src/test/resources/with-theme/check/r/react/src/main/scala/typings/reactLib/ReactNs/ComponentType.scala
+++ b/importer/src/test/resources/with-theme/check/r/react/src/main/scala/typings/reactLib/ReactNs/ComponentType.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait ComponentType[P] extends js.Object
 

--- a/importer/src/test/resources/with-theme/check/s/std/build.sbt
+++ b/importer/src/test/resources/with-theme/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-0e42ea"
+version := "0.0-unknown-3460cb"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/importer/src/test/resources/with-theme/check/s/std/src/main/scala/typings/stdLib/Foo.scala
+++ b/importer/src/test/resources/with-theme/check/s/std/src/main/scala/typings/stdLib/Foo.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait Foo extends js.Object {
   var f: js.UndefOr[js.Function1[/* n */ scala.Double, java.lang.String]] = js.undefined
 }

--- a/importer/src/test/resources/with-theme/check/s/std/src/main/scala/typings/stdLib/SomethingHasToBeHereApparently.scala
+++ b/importer/src/test/resources/with-theme/check/s/std/src/main/scala/typings/stdLib/SomethingHasToBeHereApparently.scala
@@ -5,6 +5,5 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait SomethingHasToBeHereApparently extends js.Object
 

--- a/importer/src/test/resources/with-theme/check/w/with-theme/build.sbt
+++ b/importer/src/test/resources/with-theme/check/w/with-theme/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "with-theme"
-version := "0.0-unknown-d35289"
+version := "0.0-unknown-61ab88"
 scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "1.0.0",
   "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-66a538",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-0e42ea")
+  "org.scalablytyped" %%% "react" % "0.0-unknown-b86956",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-3460cb")
 publishArtifact in packageDoc := false
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/importer/src/test/resources/with-theme/check/w/with-theme/src/main/scala/typings/withDashThemeLib/withDashThemeMod/WithTheme.scala
+++ b/importer/src/test/resources/with-theme/check/w/with-theme/src/main/scala/typings/withDashThemeLib/withDashThemeMod/WithTheme.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
 
-
 trait WithTheme extends js.Object {
   var innerRef: js.UndefOr[reactLib.ReactNs.Ref[_] | reactLib.ReactNs.RefObject[_]] = js.undefined
   var theme: java.lang.String

--- a/scalajs/src/main/scala/com/olvind/tso/scalajs/transforms/LimitUnionLength.scala
+++ b/scalajs/src/main/scala/com/olvind/tso/scalajs/transforms/LimitUnionLength.scala
@@ -12,7 +12,7 @@ object LimitUnionLength extends TreeTransformation {
       case TypeRef.Union(types) if types.length > 50 =>
         val base =
           if (types.forall(x => TypeRef.Literal.unapply(x).exists(_.startsWith("\"")))) TypeRef.String else TypeRef.Any
-        base.withComments(Comments(s"/* LimitUnionLength: was union type with length ${types.length} */"))
+        base.withComments(Comments(Comment.warning(s"Was union type with length ${types.length}")))
       case other => other
     }
 }

--- a/ts/src/main/scala/com/olvind/tso/ts/AllMembersFor.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/AllMembersFor.scala
@@ -4,6 +4,51 @@ package ts
 import com.olvind.tso.ts.TsTreeScope.LoopDetector
 
 object AllMembersFor {
+  def forType(scope: TsTreeScope, loopDetector: LoopDetector)(tpe: TsType): Seq[TsMember] =
+    tpe match {
+      case x: TsTypeRef => apply(scope, loopDetector)(x)
+      case x: TsTypeIntersect =>
+        x.types.flatMap(forType(scope, loopDetector))
+      case _: TsTypeUnion =>
+        Nil
+      case x: TsTypeObject =>
+        x.members match {
+//          case Seq(TsMemberTypeMapped(cs, level, isReadOnly, key, TsTypeKeyOf(from: TsTypeRef), opt, to)) =>
+//            AllMembersFor(scope, loopDetector)(from)
+//              .map {
+//                case TsMemberProperty(cs0, level0, name0, Some(tpe0), lit, isStatic, isReadOnly0, wasOptional) =>
+//                  TsMemberProperty(
+//                    cs ++ cs0,
+//                    if (level =/= Default) level else level0,
+//                    name0,
+//                    Some(
+//                      new TypeRewriter(to)
+//                        .visitTsType(Map(TsTypeLookup(from, TsTypeRef.of(key)) -> tpe0))(to)
+//                    ),
+//                    lit,
+//                    isStatic,
+//                    isReadOnly || isReadOnly0,
+//                    opt(wasOptional)
+//                  )
+//
+//                case other => scope.logger.fatal(s"Unexpected non member property: $other")
+//              }
+          case other => other
+        }
+
+      case _: TsTypeLiteral     => Nil
+      case _: TsTypeFunction    => Nil
+      case _: TsTypeConstructor => Nil
+      case _: TsTypeIs          => Nil
+      case _: TsTypeTuple       => Nil
+      case _: TsTypeQuery       => Nil
+      case _: TsTypeRepeated    => Nil
+      case _: TsTypeKeyOf       => Nil
+      case _: TsTypeLookup      => Nil
+      case _: TsTypeThis        => Nil
+      case _: TsTypePredicate   => Nil
+    }
+
   def apply(scope: TsTreeScope, loopDetector: LoopDetector)(typeRef: TsTypeRef): Seq[TsMember] =
     scope lookupInternal (Picker.Types, typeRef.name.parts, loopDetector) flatMap {
       case (x: TsDeclInterface, newScope) =>
@@ -14,12 +59,10 @@ object AllMembersFor {
           case TsDeclClass(_, _, _, _, _, parent, implements, members, _, _) =>
             members ++ (implements ++ parent flatMap apply(newScope, loopDetector))
         }
+
       case (x: TsDeclTypeAlias, newScope) =>
-        FillInTParams(x, typeRef.tparams).alias match {
-          case tr: TsTypeRef if tr.name =/= typeRef.name => apply(newScope, loopDetector)(tr)
-          case TsTypeObject(members) => members
-          case _                     => Nil
-        }
+        forType(newScope, loopDetector)(FillInTParams(x, typeRef.tparams).alias)
+
       case _ => Nil
     }
 

--- a/ts/src/main/scala/com/olvind/tso/ts/Hoisting.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/Hoisting.scala
@@ -6,12 +6,17 @@ import com.olvind.tso.ts.TsTreeScope.LoopDetector
 object Hoisting {
   val declared = false
 
-  def hoistedMembersFrom(scope: TsTreeScope, cp: CodePath, ld: LoopDetector)(
-      typeRef:                  TsTypeRef
-  ): Seq[TsNamedValueDecl] =
+  def fromType(scope: TsTreeScope, cp: CodePath, ld: LoopDetector, tpe: TsType): Seq[TsNamedValueDecl] =
+    tpe match {
+      case ref: TsTypeRef => fromRef(scope, cp, ld, ref)
+      case TsTypeObject(ms) => ms.flatMap(memberToDecl(cp))
+      case _                => Nil
+    }
+
+  def fromRef(scope: TsTreeScope, cp: CodePath, ld: LoopDetector, typeRef: TsTypeRef): Seq[TsNamedValueDecl] =
     AllMembersFor(scope, ld)(typeRef) flatMap memberToDecl(cp)
 
-  def add(codePath: CodePath, ident: TsIdent) =
+  private def add(codePath: CodePath, ident: TsIdent): CodePath =
     codePath match {
       case x: CodePath.HasPath => x + ident
       case noPath => noPath

--- a/ts/src/main/scala/com/olvind/tso/ts/ParentsResolver.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/ParentsResolver.scala
@@ -52,13 +52,13 @@ object ParentsResolver {
                 allParents += TsDeclInterface(NoComments, declared = false, TsIdent.dummy, Nil, Nil, x.members, NoPath)
               case TsTypeUnion(types) =>
                 types foreach {
-                  case TsTypeRef(tpe, targs) => innerRecurse(scope, tpe, targs)
-                  case _                     => ()
+                  case TsTypeRef(_, tpe, targs) => innerRecurse(scope, tpe, targs)
+                  case _                        => ()
                 }
               case TsTypeIntersect(types) =>
                 types foreach {
-                  case TsTypeRef(tpe, targs) => innerRecurse(scope, tpe, targs)
-                  case _                     => ()
+                  case TsTypeRef(_, tpe, targs) => innerRecurse(scope, tpe, targs)
+                  case _                        => ()
                 }
               case _: TsTypeConstructor => ()
               case _: TsTypeTuple       => ()
@@ -78,7 +78,7 @@ object ParentsResolver {
         }
 
       parentRefs.foreach {
-        case TsTypeRef(tpe, targs) => innerRecurse(scope, tpe, targs)
+        case TsTypeRef(_, tpe, targs) => innerRecurse(scope, tpe, targs)
       }
     }
 

--- a/ts/src/main/scala/com/olvind/tso/ts/Picker.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/Picker.scala
@@ -59,6 +59,6 @@ object Picker {
       }
   }
 
-  def ButNot[T <: TsNamedDecl](picker: Picker[T], exclude: T): Picker[T] =
-    (t: TsNamedDecl) => picker.unapply(t).filter(_ ne exclude)
+  def ButNot[T <: TsNamedDecl](picker: Picker[T], excludes: T*): Picker[T] =
+    (decl: TsNamedDecl) => picker.unapply(decl).filter(t => excludes.exists(_ ne t))
 }

--- a/ts/src/main/scala/com/olvind/tso/ts/RemoveComment.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/RemoveComment.scala
@@ -1,0 +1,19 @@
+package com.olvind.tso
+package ts
+
+trait RemoveComment[T] {
+  def remove(t: T): T
+}
+
+object RemoveComment {
+  implicit val r0: RemoveComment[TsMemberCtor]     = _.copy(comments = NoComments)
+  implicit val r1: RemoveComment[TsMemberFunction] = _.copy(comments = NoComments)
+  implicit val r2: RemoveComment[TsMemberCall]     = _.copy(comments = NoComments)
+  implicit val r3: RemoveComment[TsDeclFunction]   = _.copy(comments = NoComments)
+
+  def keepFirstOnly[T: RemoveComment](fs: Seq[T]): Seq[T] =
+    fs.zipWithIndex.map {
+      case (f, 0) => f
+      case (f, _) => implicitly[RemoveComment[T]].remove(f)
+    }
+}

--- a/ts/src/main/scala/com/olvind/tso/ts/TreeTransformation.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/TreeTransformation.scala
@@ -365,7 +365,7 @@ trait TreeTransformation[T] { self =>
       case TsTypeFunction(_1) => TsTypeFunction(visitTsFunSig(tt)(_1))
     }
   }
-  final def visitTsTypeIndexedQuery(t: T)(x: TsTypeKeyOf): TsTypeKeyOf = {
+  final def visitTsTypeKeyOf(t: T)(x: TsTypeKeyOf): TsTypeKeyOf = {
     val xx = enterTsTypeKeyOf(withTree(t, x))(x)
     val tt = withTree(t, xx)
     xx match {
@@ -408,7 +408,7 @@ trait TreeTransformation[T] { self =>
     val tt = withTree(t, xx)
     xx match {
       case TsTypeLookup(_1, _2) =>
-        TsTypeLookup(visitTsType(tt)(_1), _2.right.map(visitTsTypeIndexedQuery(tt)))
+        TsTypeLookup(visitTsType(tt)(_1), visitTsType(tt)(_2))
     }
   }
   final def visitTsTypeObject(t: T)(x: TsTypeObject): TsTypeObject = {
@@ -437,7 +437,7 @@ trait TreeTransformation[T] { self =>
     val xx = enterTsTypeRef(withTree(t, x))(x)
     val tt = withTree(t, xx)
     val xxx = xx match {
-      case TsTypeRef(_1, _2) => TsTypeRef(visitTsQIdent(tt)(_1), _2 map visitTsType(tt))
+      case TsTypeRef(_1, _2, _3) => TsTypeRef(_1, visitTsQIdent(tt)(_2), _3 map visitTsType(tt))
     }
     leaveTsTypeRef(tt)(xxx)
   }
@@ -544,7 +544,7 @@ trait TreeTransformation[T] { self =>
       case x: TsTypeConditional => visitTsTypeConditional(t)(x)
       case x: TsTypeExtends     => visitTsTypeExtends(t)(x)
       case x: TsTypeFunction    => visitTsTypeFunction(t)(x)
-      case x: TsTypeKeyOf       => visitTsTypeIndexedQuery(t)(x)
+      case x: TsTypeKeyOf       => visitTsTypeKeyOf(t)(x)
       case x: TsTypeIntersect   => visitTsTypeIntersect(t)(x)
       case x: TsTypeIs          => visitTsTypeIs(t)(x)
       case x: TsTypeInfer       => visitTsTypeInfer(t)(x)

--- a/ts/src/main/scala/com/olvind/tso/ts/TreeTraverse.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/TreeTraverse.scala
@@ -91,12 +91,6 @@ object TreeTraverse {
           true
         }
       }
-
-      object Either {
-        @inline def unapply[L, R](lr: Either[L, R]): Some[(Option[L], Option[R])] =
-          Some((lr.left.toOption, lr.right.toOption))
-      }
-
     }
 
     tree match {
@@ -146,11 +140,11 @@ object TreeTraverse {
       case TsTypeIntersect(Yes())                                                       =>
       case TsTypeIs(Yes(), Yes())                                                       =>
       case TsTypeLiteral(Yes())                                                         =>
-      case TsTypeLookup(Yes(), Yes.Either(Yes(), Yes()))                                =>
+      case TsTypeLookup(Yes(), Yes())                                                   =>
       case TsTypeObject(Yes())                                                          =>
       case TsTypeParam(No(), Yes(), Yes(), Yes())                                       =>
       case TsTypeQuery(Yes())                                                           =>
-      case TsTypeRef(Yes(), Yes())                                                      =>
+      case TsTypeRef(No(), Yes(), Yes())                                                =>
       case TsTypeRepeated(Yes())                                                        =>
       case TsTypeThis()                                                                 =>
       case TsTypeTuple(Yes())                                                           =>

--- a/ts/src/main/scala/com/olvind/tso/ts/TsTreeScope.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/TsTreeScope.scala
@@ -134,6 +134,10 @@ object TsTreeScope {
     }
   }
 
+  object LoopDetector {
+    val initial = new LoopDetector()
+  }
+
   final class Root private[TsTreeScope] (val libName:  TsIdentLibrary,
                                          val pedantic: Boolean,
                                          _deps:        Map[TsIdentLibrary, TsParsedFile],
@@ -358,10 +362,11 @@ object TsTreeScope {
               case None        => Nil
             }
 
-          case TsDeclVar(_, _, _, _, Some(tr: TsTypeRef), _, _, cp: CodePath.HasPath, false) =>
-            Hoisting.hoistedMembersFrom(scope, cp, loopDetector)(tr).collect {
+          case TsDeclVar(_, _, _, _, Some(tpe), _, _, cp: CodePath.HasPath, false) =>
+            Hoisting.fromType(scope, cp, loopDetector, tpe).collect {
               case Pick(x) if one === x.name => x -> scope
             }
+
           case _ => Nil
         }
 
@@ -376,8 +381,8 @@ object TsTreeScope {
                     (scope / x).lookupInternal(Pick, t, loopDetector)
                   case TsDeclVar(_, _, _, _, Some(_: TsTypeThis), _, _, _, false) =>
                     search(scope, Pick, c, t, loopDetector)
-                  case TsDeclVar(_, _, _, _, Some(tr: TsTypeRef), _, _, cp: CodePath.HasPath, false) =>
-                    Hoisting.hoistedMembersFrom(scope, cp, loopDetector)(tr).collect {
+                  case TsDeclVar(_, _, _, _, Some(tpe), _, _, cp: CodePath.HasPath, false) =>
+                    Hoisting.fromType(scope, cp, loopDetector, tpe).collect {
                       case Pick(x) if t.headOption.contains(x.name) => x -> scope
                     }
 

--- a/ts/src/main/scala/com/olvind/tso/ts/TsTypeFormatter.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/TsTypeFormatter.scala
@@ -1,0 +1,104 @@
+package com.olvind.tso
+package ts
+
+object TsTypeFormatter {
+  def qident(q: TsQIdent): String =
+    q.parts.map(_.value).mkString(".")
+
+  def sig(sig: TsFunSig): String =
+    List[Option[String]](
+      Some(tparams(sig.tparams)(tparam)),
+      Some(sig.params.map(param).mkString("(", ", ", ")")),
+      sig.resultType.map(apply).map(": " + _)
+    ).mkString("")
+
+  def tparam(tparam: TsTypeParam): String =
+    tparam match {
+      case TsTypeParam(_, name, bound, default) =>
+        List[Option[String]](
+          Some(name.value),
+          bound.map(b   => s"extends ${apply(b)}"),
+          default.map(d => s"= " + apply(d))
+        ).flatten.mkString(" ")
+    }
+
+  def param(p: TsFunParam): String =
+    p match {
+      case TsFunParam(_, name, tpe, isOptional) =>
+        List[Option[String]](
+          Some(name.value),
+          Some(if (isOptional) "?" else ""),
+          tpe.map(x => s": ${apply(x)}"),
+        ).flatten.mkString(" ")
+    }
+
+  def tparams[T](ts: Seq[T])(f: T => String): String =
+    if (ts.isEmpty) "" else "<" + ts.map(f).mkString(", ") + ">"
+
+  def level(l: ProtectionLevel): String =
+    l match {
+      case Default   => ""
+      case Private   => "private"
+      case Protected => "protected"
+    }
+
+  def member(m: TsMember): String = m match {
+    case TsMemberCall(_, l, s) =>
+      s"${level(l)} ${sig(s)}"
+    case TsMemberCtor(_, _, s) =>
+      s"new ${sig(s)}"
+    case TsMemberFunction(_, l, name, s, isStatic, isReadOnly, isOptional) =>
+      List[String](
+        level(l),
+        if (isStatic) "static" else "",
+        if (isReadOnly) "readonly" else "",
+        name.value,
+        if (isOptional) "?" else "",
+        sig(s)
+      ).mkString(" ")
+
+    case TsMemberProperty(_, l, name, tpe, literal, isStatic, isReadOnly, isOptional) =>
+      List[Option[String]](
+        Some(level(l)),
+        Some(if (isStatic) "static" else ""),
+        Some(if (isReadOnly) "readonly" else ""),
+        Some(name.value),
+        Some(if (isOptional) "?" else ""),
+        tpe.map(apply).map(":" + _),
+        literal.map(l => "= " + lit(l))
+      ).flatten.mkString(" ")
+
+    // lazy
+    case TsMemberIndex(_, isReadOnly, l, indexing, isOptional, valueType) =>
+      "indexed"
+    case TsMemberTypeMapped(_, l, isReadOnly, key, from, optionalize, to) =>
+      "typemapped"
+  }
+
+  def lit(lit: TsLiteral): String = lit match {
+    case TsLiteralString(str)   => s"'$str'"
+    case TsLiteralBoolean(bool) => bool.toString
+    case TsLiteralNumber(num)   => num
+  }
+
+  def apply(tpe: TsType): String =
+    tpe match {
+      case TsTypeRef(_, name, ts)                   => qident(name) + tparams(ts)(apply)
+      case TsTypeLiteral(l)                         => lit(l)
+      case TsTypeObject(members)                    => s"{${members.map(member).mkString(", ")}}"
+      case TsTypeFunction(s)                        => s"${sig(s)}"
+      case TsTypeConstructor(f)                     => s"new ${apply(f)}"
+      case TsTypeIs(ident, x)                       => s"${ident.value} is ${apply(x)}"
+      case TsTypeTuple(tparams)                     => s"[${tparams.map(apply).mkString(", ")}]"
+      case TsTypeQuery(expr)                        => s"typeof ${qident(expr)}"
+      case TsTypeRepeated(underlying)               => s"...${apply(underlying)}"
+      case TsTypeKeyOf(key)                         => s"keyof ${apply(key)}"
+      case TsTypeLookup(from, key)                  => s"${apply(from)}[${apply(key)}]"
+      case TsTypeThis()                             => "this"
+      case TsTypeUnion(types)                       => types map apply mkString " | "
+      case TsTypeIntersect(types)                   => types map apply mkString " & "
+      case TsTypeConditional(pred, ifTrue, ifFalse) => s"${apply(pred)} ? ${apply(ifTrue)} : ${apply(ifFalse)}"
+      case TsTypeExtends(one, two)                  => s"${apply(one)} extends ${apply(two)}"
+      case TsTypeInfer(tparam)                      => s"infer ${tparam.name.value}"
+    }
+}

--- a/ts/src/main/scala/com/olvind/tso/ts/TypeParamsReferencedInTree.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/TypeParamsReferencedInTree.scala
@@ -14,7 +14,7 @@ object TypeParamsReferencedInTree {
     val referencedInTree: Set[TsIdent] =
       TreeTraverse
         .collect(tree) {
-          case TsTypeRef(TsQIdent(List(unprefixedName)), _) if inScope.contains(unprefixedName) => unprefixedName
+          case TsTypeRef(_, TsQIdent(List(unprefixedName)), _) if inScope.contains(unprefixedName) => unprefixedName
         }
         .to[Set]
 

--- a/ts/src/main/scala/com/olvind/tso/ts/modules/DeriveCopy.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/modules/DeriveCopy.scala
@@ -20,7 +20,7 @@ object DeriveCopy {
           },
           declared   = true,
           implements = Nil,
-          parent     = Some(TsTypeRef(origin, TsTypeParam.asTypeArgs(x.tparams)))
+          parent     = Some(TsTypeRef(NoComments, origin, TsTypeParam.asTypeArgs(x.tparams)))
         )
 
         List(`class`)
@@ -32,7 +32,7 @@ object DeriveCopy {
             declared = true,
             name     = rename getOrElse x.name,
             tparams  = x.tparams,
-            alias    = TsTypeRef(origin, TsTypeParam.asTypeArgs(x.tparams)),
+            alias    = TsTypeRef(NoComments, origin, TsTypeParam.asTypeArgs(x.tparams)),
             codePath = x.codePath
           )
         )
@@ -42,7 +42,7 @@ object DeriveCopy {
           x.copy(
             name         = rename getOrElse x.name,
             isValue      = true,
-            exportedFrom = x.exportedFrom orElse Some(TsTypeRef(origin, Nil)),
+            exportedFrom = x.exportedFrom orElse Some(TsTypeRef(NoComments, origin, Nil)),
           )
         )
 
@@ -100,7 +100,7 @@ object DeriveCopy {
             declared = false,
             rename getOrElse x.name,
             x.tparams,
-            TsTypeRef(x.codePath.forceHasPath.codePath, TsTypeParam.asTypeArgs(x.tparams)),
+            TsTypeRef(NoComments, x.codePath.forceHasPath.codePath, TsTypeParam.asTypeArgs(x.tparams)),
             x.codePath
           )
         )

--- a/ts/src/main/scala/com/olvind/tso/ts/parser/ParserHelpers.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/parser/ParserHelpers.scala
@@ -4,7 +4,7 @@ import scala.util.parsing.combinator.Parsers
 
 trait ParserHelpers { self: Parsers =>
 
-  @inline protected final implicit class ToParserOpt[P](private val p: P) {
+  @inline protected final implicit class ToParserOps[P](private val p: P) {
     def isDefined[Q](implicit ev: P => Parser[Q]): Parser[Boolean] =
       p.? ^^ (_.isDefined)
   }

--- a/ts/src/main/scala/com/olvind/tso/ts/parser/package.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/parser/package.scala
@@ -5,12 +5,13 @@ package object parser {
   def parseFile(inFile: InFile): Either[String, TsParsedFile] = {
     val content   = files content inFile
     val rewritten = Patches(inFile, content)
+    val p         = new TsParser(Some((inFile.path, rewritten.length)))
 
-    TsParser(rewritten) match {
-      case TsParser.Success(t, _) =>
+    p(rewritten) match {
+      case p.Success(t, _) =>
         Right(t)
 
-      case TsParser.NoSuccess(msg, next) =>
+      case p.NoSuccess(msg, next) =>
         val errorMsg = s"$inFile: Parse error at ${next.pos} $msg"
         Left(errorMsg)
     }

--- a/ts/src/main/scala/com/olvind/tso/ts/transforms/ExpandKeyOfTypeParams.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/transforms/ExpandKeyOfTypeParams.scala
@@ -1,16 +1,17 @@
 package com.olvind.tso
 package ts
 package transforms
+import com.olvind.tso.ts.TsTreeScope.LoopDetector
 
 object ExpandKeyOfTypeParams extends TreeTransformationScopedChanges {
 
-  case class IndexedTypeParam(cs: Comments, typeParam: TsIdent, map: TsQIdent)
+  case class IndexedTypeParam(cs: Comments, typeParam: TsIdent, ref: TsTypeRef)
 
   private object IndexedTypeParams {
     def unapply(ts: Seq[TsTypeParam]): Option[(IndexedTypeParam, Seq[TsTypeParam])] =
       ts.collectFirst {
-        case TsTypeParam(cs, name, Some(TsTypeKeyOf(TsTypeRef(map, Nil))), None) =>
-          (IndexedTypeParam(cs, name, map), ts.filterNot(_.name === name))
+        case TsTypeParam(cs, name, Some(TsTypeKeyOf(ref: TsTypeRef)), None) =>
+          (IndexedTypeParam(cs, name, ref), ts.filterNot(_.name === name))
       }
   }
 
@@ -32,23 +33,26 @@ object ExpandKeyOfTypeParams extends TreeTransformationScopedChanges {
   def newClassMembers(scope: TsTreeScope, members: Seq[TsMember]): Seq[TsMember] =
     members.flatMap {
       case m @ TsMemberFunction(_, _, name, sig @ TsFunSig(_, IndexedTypeParams(indexed, rest), _, _), _, _, _) =>
-        lookupMemberPropertiesFrom(scope / m, indexed.map) match {
+        lazy val mm = m.copy(signature = sig.copy(tparams = rest))
+
+        val members = AllMembersFor(scope / m, LoopDetector.initial)(indexed.ref)
+        val fs = members
+          .collect {
+            case TsMemberProperty(_, _, TsIdentSimple(n), Some(tpe), _, false, _, _) =>
+              val rewrites = Map[TsType, TsType](
+                TsTypeRef.of(indexed.typeParam) -> TsTypeLiteral(TsLiteralString(n)),
+                TsTypeLookup(indexed.ref, TsTypeLiteral(TsLiteralString(n))) -> tpe
+              )
+
+              val mmm = new TypeRewriter(mm).visitTsMemberFunction(rewrites)(mm)
+              mmm
+          }
+
+        fs match {
           case Nil => Seq(m)
           case nonEmpty =>
             scope.logger.info(s"Expanding ${nonEmpty.size} members for $name")
-
-            nonEmpty collect {
-              case TsMemberProperty(_, Default, TsIdentSimple(n), Some(tpe), _, false, false, false) =>
-                val mm = m.copy(signature = sig.copy(tparams = rest))
-
-                new TypeRewriter(mm).visitTsMemberFunction(
-                  Map(
-                    TsTypeRef.of(indexed.typeParam) -> TsTypeLiteral(TsLiteralString(n)),
-                    TsTypeLookup(TsTypeRef(indexed.map, Nil), Left(indexed.typeParam)) -> tpe
-                  )
-                )(mm)
-
-            }
+            nonEmpty
         }
       case other => Seq(other)
     }
@@ -56,70 +60,24 @@ object ExpandKeyOfTypeParams extends TreeTransformationScopedChanges {
   def newContainerMembers(scope: TsTreeScope, members: Seq[TsContainerOrDecl]): Seq[TsContainerOrDecl] =
     members flatMap {
       case m @ TsDeclFunction(_, _, name, sig @ TsFunSig(_, IndexedTypeParams(indexed, rest), _, _), _, _) =>
-        lookupMemberPropertiesFrom(scope / m, indexed.map) match {
+        lazy val mm = m.copy(signature = sig.copy(tparams = rest))
+
+        val fs = AllMembersFor(scope / m, new LoopDetector())(indexed.ref).collect {
+          case TsMemberProperty(_, Default, TsIdentSimple(n), Some(tpe), _, false, false, false) =>
+            val rewrites = Map[TsType, TsType](
+              TsTypeRef.of(indexed.typeParam) -> TsTypeLiteral(TsLiteralString(n)),
+              TsTypeLookup(indexed.ref, TsTypeRef.of(indexed.typeParam)) -> tpe
+            )
+
+            new TypeRewriter(mm).visitTsDeclFunction(rewrites)(mm)
+        }
+
+        fs match {
           case Nil => Seq(m)
           case nonEmpty =>
             scope.logger.info(s"Expanding ${nonEmpty.size} members for $name")
-
-            nonEmpty collect {
-              case TsMemberProperty(_, Default, TsIdentSimple(n), Some(tpe), _, false, false, false) =>
-                val mm = m.copy(signature = sig.copy(tparams = rest))
-                new TypeRewriter(mm).visitTsDeclFunction(
-                  Map(
-                    TsTypeRef.of(indexed.typeParam) -> TsTypeLiteral(TsLiteralString(n)),
-                    TsTypeLookup(TsTypeRef(indexed.map, Nil), Left(indexed.typeParam)) -> tpe
-                  )
-                )(mm)
-            }
+            nonEmpty
         }
       case other => Seq(other)
-    }
-
-  def lookupMemberPropertiesFrom(scope: TsTreeScope, name: TsQIdent): Seq[TsMemberProperty] =
-    scope
-      .lookupBase(Picker.Types, name)
-      .flatMap {
-        case (i: TsDeclInterface, newScope) =>
-          val thisMemberProperties = i.members.collect {
-            case x: TsMemberProperty => x
-          }
-
-          thisMemberProperties ++ i.inheritance.flatMap(tpe => mpsFromType(newScope, tpe))
-
-        case (TsDeclTypeAlias(_, _, _, Nil, tpe, _), newScope) => mpsFromType(newScope, tpe)
-        case other =>
-          scope.fatalMaybe(s"Unexpected not interface or type alias $other")
-          Nil
-      }
-
-  def mpsFromType(scope: TsTreeScope, tpe: TsType): Seq[TsMemberProperty] =
-    tpe match {
-      case TsTypeRef(parent, Nil) => lookupMemberPropertiesFrom(scope, parent)
-      case TsTypeObject(
-          Seq(TsMemberTypeMapped(cs, level, isReadOnly, key, TsTypeKeyOf(TsTypeRef(from, Nil)), opt, to))
-          ) =>
-        lookupMemberPropertiesFrom(scope, from)
-          .map {
-            case TsMemberProperty(cs0, level0, name0, Some(tpe0), lit, isStatic, isReadOnly0, wasOptional) =>
-              TsMemberProperty(
-                cs ++ cs0,
-                if (level =/= Default) level else level0,
-                name0,
-                Some(new TypeRewriter(to).visitTsType(Map(TsTypeLookup(TsTypeRef(from, Nil), Left(key)) -> tpe0))(to)),
-                lit,
-                isStatic,
-                isReadOnly || isReadOnly0,
-                opt(wasOptional)
-              )
-
-            case other => scope.logger.fatal(s"Unexpected non member property: $other")
-          }
-
-      case TsTypeIntersect(types) =>
-        types flatMap (tpe => mpsFromType(scope, tpe))
-
-      case other =>
-        scope.logger.warn(s"Doesnt know how to handle $other")
-        Nil
     }
 }

--- a/ts/src/main/scala/com/olvind/tso/ts/transforms/ExtractInterfaces.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/transforms/ExtractInterfaces.scala
@@ -60,9 +60,10 @@ object ExtractInterfaces {
     override def leaveTsType(scope: TsTreeScope)(x: TsType): TsType =
       x match {
         case obj: TsTypeObject
-            if obj.members.nonEmpty && !isDictionary(obj) && !partOfTypeMapping(scope.stack, obj) && shouldBeExtracted(
-              scope
-            ) =>
+            if obj.members.nonEmpty &&
+              !isDictionary(obj) &&
+              !partOfTypeMapping(scope.stack, obj) &&
+              shouldBeExtracted(scope) =>
           val referencedTparams: Seq[TsTypeParam] =
             TypeParamsReferencedInTree(scope.tparams, obj)
 
@@ -71,7 +72,6 @@ object ExtractInterfaces {
             "Anon_",
             obj.members,
             name =>
-//              visitTsDeclInterface(scope.root)(
               TsDeclInterface(
                 NoComments,
                 declared = true,
@@ -80,11 +80,10 @@ object ExtractInterfaces {
                 Nil,
                 obj.members,
                 CodePath.NoPath
-//                )
             )
           )
 
-          TsTypeRef(codePath.codePath, TsTypeParam.asTypeArgs(referencedTparams))
+          TsTypeRef(NoComments, codePath.codePath, TsTypeParam.asTypeArgs(referencedTparams))
 
         case _ => x
       }

--- a/ts/src/main/scala/com/olvind/tso/ts/transforms/InlineTrivialTypeAlias.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/transforms/InlineTrivialTypeAlias.scala
@@ -15,7 +15,7 @@ object InlineTrivialTypeAlias extends TreeTransformationScopedChanges {
   /* changing this? also change `Cleanup`. We need to do it in two stages */
   def followTrivialAliases(scope: TsTreeScope)(cur: TsDeclTypeAlias): Option[TsQIdent] =
     cur match {
-      case TsDeclTypeAlias(cs, _, _, _, currentAlias @ TsTypeRef(nextName, _), codePath)
+      case TsDeclTypeAlias(cs, _, _, _, currentAlias @ TsTypeRef(_, nextName, _), codePath)
           if cs.cs.exists(_ === constants.MagicComments.TrivialTypeAlias) =>
         scope
           .lookupTypeIncludeScope(nextName)
@@ -37,7 +37,7 @@ object InlineTrivialTypeAlias extends TreeTransformationScopedChanges {
 
   private def handleRef(scope: TsTreeScope, x: TsTypeRef): TsTypeRef = {
     val simplifiedOpt = x match {
-      case ref @ TsTypeRef(target: TsQIdent, tparams) if !TsQIdent.Primitive(target) =>
+      case ref @ TsTypeRef(_, target: TsQIdent, tparams) if !TsQIdent.Primitive(target) =>
         val ret: Option[Option[TsTypeRef]] =
           scope lookupTypeIncludeScope target collectFirst {
             case (TsDeclEnum(_, _, _, _, _, Some(exportedFrom), _, _), _) if tparams.isEmpty =>

--- a/ts/src/main/scala/com/olvind/tso/ts/transforms/RewriteTypeThis.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/transforms/RewriteTypeThis.scala
@@ -42,9 +42,9 @@ object RewriteTypeThis extends TreeTransformationScopedChanges {
       case x: TsTypeThis if isReferencedInConstructor(scope.stack) || isReferencedInIndexType(scope.stack) =>
         scope.stack.collectFirst {
           case owner: TsDeclClass =>
-            TsTypeRef(owner.codePath.forceHasPath.codePath, TsTypeParam.asTypeArgs(owner.tparams))
+            TsTypeRef(NoComments, owner.codePath.forceHasPath.codePath, TsTypeParam.asTypeArgs(owner.tparams))
           case owner: TsDeclInterface =>
-            TsTypeRef(owner.codePath.forceHasPath.codePath, TsTypeParam.asTypeArgs(owner.tparams))
+            TsTypeRef(NoComments, owner.codePath.forceHasPath.codePath, TsTypeParam.asTypeArgs(owner.tparams))
         } getOrElse x
 
       case other => other

--- a/ts/src/main/scala/com/olvind/tso/ts/transforms/SplitMethodsOnOptionalParams.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/transforms/SplitMethodsOnOptionalParams.scala
@@ -35,11 +35,11 @@ object SplitMethodsOnOptionalParams extends TreeTransformationScopedChanges {
         case (_, members: Seq[TsMember]) =>
           members flatMap {
             case x: TsMemberCtor =>
-              split(x.signature).map(sig => x.copy(signature = sig))
+              RemoveComment.keepFirstOnly(split(x.signature).map(sig => x.copy(signature = sig)))
             case x: TsMemberFunction if !x.isOptional =>
-              split(x.signature).map(sig => x.copy(signature = sig))
+              RemoveComment.keepFirstOnly(split(x.signature).map(sig => x.copy(signature = sig)))
             case x: TsMemberCall =>
-              split(x.signature).map(sig => x.copy(signature = sig))
+              RemoveComment.keepFirstOnly(split(x.signature).map(sig => x.copy(signature = sig)))
             case other => Seq(other)
           }
       }
@@ -50,10 +50,10 @@ object SplitMethodsOnOptionalParams extends TreeTransformationScopedChanges {
   private def newMembers(x: TsContainer): Seq[TsContainerOrDecl] = {
     val newMembers: Iterable[TsNamedDecl] =
       x.membersByName flatMap {
-        case (name @ _, members: Seq[TsNamedDecl]) =>
+        case (_, members: Seq[TsNamedDecl]) =>
           members flatMap {
             case x: TsDeclFunction =>
-              split(x.signature).map(sig => x.copy(signature = sig))
+              RemoveComment.keepFirstOnly(split(x.signature).map(sig => x.copy(signature = sig)))
             case other => Seq(other)
           }
       }

--- a/ts/src/main/scala/com/olvind/tso/ts/transforms/SplitMethodsOnUnionTypes.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/transforms/SplitMethodsOnUnionTypes.scala
@@ -33,11 +33,11 @@ object SplitMethodsOnUnionTypes extends TreeTransformationScopedChanges {
         case (_, members: Seq[TsMember]) =>
           members flatMap {
             case x: TsMemberFunction if !x.isOptional && x.name =/= TsIdent.Apply =>
-              split(x.signature).map(sig => x.copy(signature = sig))
+              RemoveComment.keepFirstOnly(split(x.signature).map(sig => x.copy(signature = sig)))
             case x: TsMemberCall =>
-              split(x.signature).map(sig => x.copy(signature = sig))
+              RemoveComment.keepFirstOnly(split(x.signature).map(sig => x.copy(signature = sig)))
             case x: TsMemberCtor =>
-              split(x.signature).map(sig => x.copy(signature = sig))
+              RemoveComment.keepFirstOnly(split(x.signature).map(sig => x.copy(signature = sig)))
             case other => Seq(other)
           }
       }
@@ -51,7 +51,7 @@ object SplitMethodsOnUnionTypes extends TreeTransformationScopedChanges {
         case (_, members: Seq[TsNamedDecl]) =>
           members flatMap {
             case x: TsDeclFunction if x.name =/= TsIdent.namespaced =>
-              split(x.signature).map(sig => x.copy(signature = sig))
+              RemoveComment.keepFirstOnly(split(x.signature).map(sig => x.copy(signature = sig)))
             case other => Seq(other)
           }
       }

--- a/ts/src/main/scala/com/olvind/tso/ts/transforms/TypeRewriter.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/transforms/TypeRewriter.scala
@@ -14,8 +14,8 @@ class TypeRewriter(base: TsTree) extends TreeTransformation[Map[TsType, TsType]]
         /* Handle if the current tree introduces a new type parameter which shadows what we are trying to inline */
         case HasTParams(tparams) =>
           t.filterKeys {
-            case TsTypeRef(TsQIdent(Seq(one)), _) if tparams.exists(_.name === one) => false
-            case _                                                                  => true
+            case TsTypeRef(_, TsQIdent(Seq(one)), _) if tparams.exists(_.name === one) => false
+            case _                                                                     => true
           }
         case _ => t
       }

--- a/ts/src/main/scala/com/olvind/tso/ts/transforms/UnionTypesFromKeyOf.scala
+++ b/ts/src/main/scala/com/olvind/tso/ts/transforms/UnionTypesFromKeyOf.scala
@@ -5,7 +5,7 @@ package transforms
 object UnionTypesFromKeyOf extends TreeTransformationScopedChanges {
   override def enterTsType(scope: TsTreeScope)(x: TsType): TsType =
     x match {
-      case TsTypeKeyOf(TsTypeRef(key, Nil)) if !scope.isAbstract(key) =>
+      case TsTypeKeyOf(TsTypeRef(_, key, Nil)) if !scope.isAbstract(key) =>
         scope.lookup(key).headOption match {
           case Some(TsDeclInterface(_, _, _, _, _, members, _)) =>
             scope.logger.info(s"Expanded keyof $key")

--- a/ts/src/test/scala/com/olvind/tso/ts/parser/CommentTests.scala
+++ b/ts/src/test/scala/com/olvind/tso/ts/parser/CommentTests.scala
@@ -211,7 +211,7 @@ final class CommentTests extends FunSuite with Matchers {
           TsMemberProperty(NoComments,
                            Default,
                            TsIdent("size"),
-                           Some(TsTypeRef(TsQIdent.number, Nil)),
+                           Some(TsTypeRef(NoComments, TsQIdent.number, Nil)),
                            None,
                            isStatic   = false,
                            isReadOnly = false,
@@ -241,18 +241,21 @@ final class CommentTests extends FunSuite with Matchers {
                   NoComments,
                   TsIdent("iter"),
                   Some(
-                    TsTypeRef(
-                      TsQIdent(List(TsIdent("Iterable"))),
-                      List(TsTypeRef.any, TsTypeRef(TsQIdent(List(TsIdent("Array"))), List(TsTypeRef.any)))
-                    )
+                    TsTypeRef(NoComments,
+                              TsQIdent(List(TsIdent("Iterable"))),
+                              List(TsTypeRef.any,
+                                   TsTypeRef(NoComments, TsQIdent(List(TsIdent("Array"))), List(TsTypeRef.any))))
                   ),
                   isOptional = false
                 )
               ),
               Some(
-                TsTypeRef(TsQIdent(List(TsIdent("Map"))),
-                          List(TsTypeRef(TsQIdent(List(TsIdent("K"))), Nil),
-                               TsTypeRef(TsQIdent(List(TsIdent("V"))), Nil)))
+                TsTypeRef(
+                  NoComments,
+                  TsQIdent(List(TsIdent("Map"))),
+                  List(TsTypeRef(NoComments, TsQIdent(List(TsIdent("K"))), Nil),
+                       TsTypeRef(NoComments, TsQIdent(List(TsIdent("V"))), Nil))
+                )
               )
             ),
             JsLocation.Zero,
@@ -355,11 +358,14 @@ final class CommentTests extends FunSuite with Matchers {
     shouldParseAs(
       """F<A, /* foo */
         B>""",
-      TsParser.typeRef
+      TsParser.tsTypeRef
     )(
-      TsTypeRef(TsQIdent(List(TsIdentSimple("F"))),
-                List(TsTypeRef(TsQIdent(List(TsIdentSimple("A"))), List()),
-                     TsTypeRef(TsQIdent(List(TsIdentSimple("B"))), List())))
+      TsTypeRef(
+        NoComments,
+        TsQIdent(List(TsIdentSimple("F"))),
+        List(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("A"))), List()),
+             TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("B"))), List()))
+      )
     )
   }
 

--- a/ts/src/test/scala/com/olvind/tso/ts/parser/ImportExportParseTests.scala
+++ b/ts/src/test/scala/com/olvind/tso/ts/parser/ImportExportParseTests.scala
@@ -207,18 +207,18 @@ final class ImportExportParseTests extends FunSuite with Matchers {
               List(
                 TsFunParam(NoComments,
                            TsIdent("engine"),
-                           Some(TsTypeRef(TsQIdent(List(TsIdent("StorageEngine"))), List())),
+                           Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("StorageEngine"))), List())),
                            isOptional = false),
                 TsFunParam(NoComments,
                            TsIdent("whitelist"),
-                           Some(TsTypeRef(TsQIdent(List(TsIdent("FilterList"))), List())),
+                           Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("FilterList"))), List())),
                            isOptional = true),
                 TsFunParam(NoComments,
                            TsIdent("blacklist"),
-                           Some(TsTypeRef(TsQIdent(List(TsIdent("FilterList"))), List())),
+                           Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("FilterList"))), List())),
                            isOptional = true)
               ),
-              Some(TsTypeRef(TsQIdent(List(TsIdent("StorageEngine"))), List()))
+              Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("StorageEngine"))), List()))
             ),
             Zero,
             CodePath.NoPath
@@ -257,6 +257,7 @@ final class ImportExportParseTests extends FunSuite with Matchers {
             List(),
             Some(
               TsTypeRef(
+                NoComments,
                 TsQIdent(List(TsIdent("React"), TsIdent("Component"))),
                 List(
                   TsTypeObject(
@@ -265,7 +266,7 @@ final class ImportExportParseTests extends FunSuite with Matchers {
                         NoComments,
                         Default,
                         TsIdent("statusCode"),
-                        Some(TsTypeRef(TsQIdent(List(TsIdent("number"))), List())),
+                        Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("number"))), List())),
                         None,
                         isStatic   = false,
                         isReadOnly = false,

--- a/ts/src/test/scala/com/olvind/tso/ts/parser/ParserTests.scala
+++ b/ts/src/test/scala/com/olvind/tso/ts/parser/ParserTests.scala
@@ -2,14 +2,13 @@ package com.olvind.tso
 package ts
 package parser
 
-import com.olvind.tso.ts
 import com.olvind.tso.ts.JsLocation.Zero
 import com.olvind.tso.ts.OptionalModifier.Noop
 import org.scalatest.Matchers._
 import org.scalatest._
 
 final class ParserTests extends FunSuite {
-  private val T = TsTypeRef(TsQIdent(List(TsIdentSimple("T"))), List())
+  private val T = TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("T"))), List())
 
   import ParserHarness._
 
@@ -65,6 +64,12 @@ final class ParserTests extends FunSuite {
       shouldParseAs(content, TsParser.parsedTsFile)(expected)
     }
   }
+
+//  test("foo") {
+//    withTsFileAbs(Path("/home/olvind/tmp/tso-cache/DefinitelyTyped/types/echarts/options/series/candlestick.d.ts")) { content =>
+//      TsParser.parsedTsFile(content).force
+//    }
+//  }
 
   test("handle byte order mark") {
     withTsFile("adm-zip.d.ts") { content =>
@@ -206,7 +211,7 @@ final class ParserTests extends FunSuite {
               NoComments,
               tparams    = Nil,
               params     = Nil,
-              resultType = Some(TsTypeRef(name = TsQIdent.void, tparams = Nil))
+              resultType = Some(TsTypeRef(NoComments, name = TsQIdent.void, tparams = Nil))
             ),
             isStatic   = false,
             isReadOnly = false,
@@ -360,7 +365,7 @@ final class ParserTests extends FunSuite {
                        _,
                        _,
                        TsIdent(name),
-                       Some(TsTypeRef(TsQIdent(List(TsIdent("BrorandStatic"))), _)),
+                       Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("BrorandStatic"))), _)),
                        None,
                        _,
                        _,
@@ -389,10 +394,10 @@ final class ParserTests extends FunSuite {
               List(
                 TsFunParam(NoComments,
                            TsIdentSimple("alt"),
-                           Some(TsTypeRef(TsQIdent(List(TsIdentSimple("Alt"))), List())),
+                           Some(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("Alt"))), List())),
                            isOptional = false)
               ),
-              Some(TsTypeRef(TsQIdent(List(TsIdentSimple("AltJS"), TsIdentSimple("ActionsClass"))), List()))
+              Some(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("AltJS"), TsIdentSimple("ActionsClass"))), List()))
             )
           )
         ),
@@ -414,8 +419,8 @@ final class ParserTests extends FunSuite {
         TsTypeUnion(
           Seq(
             TsTypeRef.string,
-            TsTypeRef(TsQIdent.of("CanvasGradient"), Nil),
-            TsTypeRef(TsQIdent.of("CanvasPattern"), Nil)
+            TsTypeRef(NoComments, TsQIdent.of("CanvasGradient"), Nil),
+            TsTypeRef(NoComments, TsQIdent.of("CanvasPattern"), Nil)
           )
         ),
         CodePath.NoPath
@@ -464,10 +469,10 @@ final class ParserTests extends FunSuite {
               ),
               params = Nil,
               resultType = Some(
-                TsTypeRef(
-                  name    = TsQIdent.of("Ordinal"),
-                  tparams = List(TsTypeRef(TsQIdent.of("Domain"), Nil), TsTypeRef(TsQIdent.of("Range"), Nil))
-                )
+                TsTypeRef(NoComments,
+                          name = TsQIdent.of("Ordinal"),
+                          tparams = List(TsTypeRef(NoComments, TsQIdent.of("Domain"), Nil),
+                                         TsTypeRef(NoComments, TsQIdent.of("Range"), Nil)))
               )
             ),
             Zero,
@@ -507,8 +512,10 @@ final class ParserTests extends FunSuite {
                     Some(
                       TsTypeUnion(
                         Seq(
-                          TsTypeRef(TsQIdent.boolean, Nil),
-                          TsTypeRef(TsQIdent.of("PromiseLike"), List(TsTypeRef(TsQIdent.boolean, Nil)))
+                          TsTypeRef(NoComments, TsQIdent.boolean, Nil),
+                          TsTypeRef(NoComments,
+                                    TsQIdent.of("PromiseLike"),
+                                    List(TsTypeRef(NoComments, TsQIdent.boolean, Nil)))
                         )
                       )
                     )
@@ -521,10 +528,9 @@ final class ParserTests extends FunSuite {
                       level = Default,
                       name  = TsIdent("errors"),
                       tpe = Some(
-                        TsTypeRef(
-                          name    = TsQIdent.Array,
-                          tparams = List(TsTypeRef(TsQIdent.of("ValidationError"), Nil))
-                        )
+                        TsTypeRef(NoComments,
+                                  name    = TsQIdent.Array,
+                                  tparams = List(TsTypeRef(NoComments, TsQIdent.of("ValidationError"), Nil)))
                       ),
                       literal    = None,
                       isStatic   = false,
@@ -577,7 +583,7 @@ final class ParserTests extends FunSuite {
             Seq(
               TsTypeLiteral(TsLiteralNumber("0")),
               TsTypeLiteral(TsLiteralNumber("1")),
-              TsTypeRef(TsQIdent.boolean, Nil)
+              TsTypeRef(NoComments, TsQIdent.boolean, Nil)
             )
           )
         ),
@@ -621,7 +627,7 @@ final class ParserTests extends FunSuite {
       TsMemberProperty(NoComments,
                        Default,
                        TsIdent("static"),
-                       Some(TsTypeRef(TsQIdent.boolean, Nil)),
+                       Some(TsTypeRef(NoComments, TsQIdent.boolean, Nil)),
                        literal    = None,
                        isStatic   = false,
                        isReadOnly = false,
@@ -666,9 +672,12 @@ final class ParserTests extends FunSuite {
                 TsTypeParam(NoComments, TsIdent("T"), Some(TsTypeQuery(TsQIdent(List(TsIdent("FormComponent"))))), None)
               ),
               List(
-                TsFunParam(NoComments, TsIdent("component"), Some(TsTypeRef(TsQIdent.of("T"), Nil)), isOptional = false)
+                TsFunParam(NoComments,
+                           TsIdent("component"),
+                           Some(TsTypeRef(NoComments, TsQIdent.of("T"), Nil)),
+                           isOptional = false)
               ),
-              Some(TsTypeRef(TsQIdent.of("T"), Nil))
+              Some(TsTypeRef(NoComments, TsQIdent.of("T"), Nil))
             )
           )
         ),
@@ -690,7 +699,10 @@ final class ParserTests extends FunSuite {
             TsFunParam(NoComments, TsIdent("object"), Some(TsTypeObject(Nil)), isOptional = false)
           ),
           Some(
-            TsTypeIs(TsIdent("object"), TsTypeRef(TsQIdent.of("ReactElement"), List(TsTypeRef(TsQIdent.of("P"), Nil))))
+            TsTypeIs(TsIdent("object"),
+                     TsTypeRef(NoComments,
+                               TsQIdent.of("ReactElement"),
+                               List(TsTypeRef(NoComments, TsQIdent.of("P"), Nil))))
           )
         ),
         Zero,
@@ -719,8 +731,10 @@ final class ParserTests extends FunSuite {
                 TsTypeRepeated(
                   TsTypeUnion(
                     Seq(
-                      TsTypeRef(TsQIdent.of("T"), Nil),
-                      TsTypeRef(TsQIdent.of("JQueryPromise"), List(TsTypeRef(TsQIdent.of("T"), Nil)))
+                      TsTypeRef(NoComments, TsQIdent.of("T"), Nil),
+                      TsTypeRef(NoComments,
+                                TsQIdent.of("JQueryPromise"),
+                                List(TsTypeRef(NoComments, TsQIdent.of("T"), Nil)))
                     )
                   )
                 )
@@ -728,7 +742,7 @@ final class ParserTests extends FunSuite {
               isOptional = false
             )
           ),
-          Some(TsTypeRef(TsQIdent.of("JQueryPromise"), List(TsTypeRef(TsQIdent.of("T"), Nil))))
+          Some(TsTypeRef(NoComments, TsQIdent.of("JQueryPromise"), List(TsTypeRef(NoComments, TsQIdent.of("T"), Nil))))
         ),
         isStatic   = false,
         isReadOnly = false,
@@ -755,12 +769,15 @@ final class ParserTests extends FunSuite {
               Some(
                 TsTypeUnion(
                   Seq(
-                    TsTypeRef(TsQIdent.of("React", "ComponentClass"), List(TsTypeRef(TsQIdent.any, Nil))),
-                    TsTypeRef(TsQIdent.of("React", "StatelessComponent"), List(TsTypeRef(TsQIdent.any, Nil))),
-                    TsTypeRef(
-                      TsQIdent.of("React", "PureComponent"),
-                      List(TsTypeRef(TsQIdent.any, Nil), TsTypeRef(TsQIdent.any, Nil))
-                    )
+                    TsTypeRef(NoComments,
+                              TsQIdent.of("React", "ComponentClass"),
+                              List(TsTypeRef(NoComments, TsQIdent.any, Nil))),
+                    TsTypeRef(NoComments,
+                              TsQIdent.of("React", "StatelessComponent"),
+                              List(TsTypeRef(NoComments, TsQIdent.any, Nil))),
+                    TsTypeRef(NoComments,
+                              TsQIdent.of("React", "PureComponent"),
+                              List(TsTypeRef(NoComments, TsQIdent.any, Nil), TsTypeRef(NoComments, TsQIdent.any, Nil)))
                   )
                 )
               ),
@@ -768,9 +785,12 @@ final class ParserTests extends FunSuite {
             )
           ),
           List(
-            TsFunParam(NoComments, TsIdent("component"), Some(TsTypeRef(TsQIdent.of("C"), Nil)), isOptional = false)
+            TsFunParam(NoComments,
+                       TsIdent("component"),
+                       Some(TsTypeRef(NoComments, TsQIdent.of("C"), Nil)),
+                       isOptional = false)
           ),
-          Some(TsTypeRef(TsQIdent.of("C"), Nil))
+          Some(TsTypeRef(NoComments, TsQIdent.of("C"), Nil))
         ),
         Zero,
         CodePath.NoPath
@@ -781,8 +801,8 @@ final class ParserTests extends FunSuite {
   test("keyword identifiers are apparently legal") {
     shouldParseAs("module|module[]", TsParser.tsType)(
       TsTypeUnion(
-        Seq(TsTypeRef(TsQIdent.of("module"), Nil),
-            TsTypeRef(TsQIdent.Array, List(TsTypeRef(TsQIdent.of("module"), Nil))))
+        Seq(TsTypeRef(NoComments, TsQIdent.of("module"), Nil),
+            TsTypeRef(NoComments, TsQIdent.Array, List(TsTypeRef(NoComments, TsQIdent.of("module"), Nil))))
       )
     )
 
@@ -794,7 +814,7 @@ final class ParserTests extends FunSuite {
       TsMemberProperty(NoComments,
                        Default,
                        TsIdent("public"),
-                       Some(TsTypeRef(TsQIdent.boolean, Nil)),
+                       Some(TsTypeRef(NoComments, TsQIdent.boolean, Nil)),
                        literal    = None,
                        isStatic   = false,
                        isReadOnly = false,
@@ -802,14 +822,16 @@ final class ParserTests extends FunSuite {
     )
 
     shouldParseAs("static public?: private", TsParser.tsMemberNamed)(
-      TsMemberProperty(NoComments,
-                       Default,
-                       TsIdent("public"),
-                       Some(TsTypeRef(TsQIdent.of("private"), Nil)),
-                       literal    = None,
-                       isStatic   = true,
-                       isReadOnly = false,
-                       isOptional = true)
+      TsMemberProperty(
+        NoComments,
+        Default,
+        TsIdent("public"),
+        Some(TsTypeRef(NoComments, TsQIdent.of("private"), Nil)),
+        literal    = None,
+        isStatic   = true,
+        isReadOnly = false,
+        isOptional = true
+      )
     )
   }
 
@@ -833,7 +855,7 @@ final class ParserTests extends FunSuite {
       TsMemberProperty(NoComments,
                        Default,
                        TsIdent("i"),
-                       Some(TsTypeRef(TsQIdent.number, Nil)),
+                       Some(TsTypeRef(NoComments, TsQIdent.number, Nil)),
                        literal    = None,
                        isStatic   = false,
                        isReadOnly = false,
@@ -874,7 +896,7 @@ final class ParserTests extends FunSuite {
       TsIdent("Element"),
       Nil,
       List(
-        TsTypeRef(TsQIdent.of("React", "ReactElement"), List(TsTypeRef(TsQIdent.any, Nil)))
+        TsTypeRef(NoComments, TsQIdent.of("React", "ReactElement"), List(TsTypeRef(NoComments, TsQIdent.any, Nil)))
       ),
       Nil,
       CodePath.NoPath
@@ -1008,7 +1030,7 @@ final class ParserTests extends FunSuite {
           comments   = NoComments,
           isReadOnly = true,
           level      = Default,
-          indexing   = IndexingDict(TsIdent("index"), TsTypeRef(TsQIdent.number, Nil)),
+          indexing   = IndexingDict(TsIdent("index"), TsTypeRef(NoComments, TsQIdent.number, Nil)),
           valueType  = TsTypeRef.string,
           isOptional = false
         )
@@ -1031,11 +1053,14 @@ final class ParserTests extends FunSuite {
           List(
             TsTypeParam(NoComments,
                         TsIdent("K"),
-                        Some(TsTypeKeyOf(TsTypeRef(TsQIdent.of("MSBaseReaderEventMap"), Nil))),
+                        Some(TsTypeKeyOf(TsTypeRef(NoComments, TsQIdent.of("MSBaseReaderEventMap"), Nil))),
                         None)
           ),
           List(
-            TsFunParam(NoComments, TsIdent("type"), Some(TsTypeRef(TsQIdent.of("K"), Nil)), isOptional = false),
+            TsFunParam(NoComments,
+                       TsIdent("type"),
+                       Some(TsTypeRef(NoComments, TsQIdent.of("K"), Nil)),
+                       isOptional = false),
             TsFunParam(
               NoComments,
               TsIdent("listener"),
@@ -1047,24 +1072,30 @@ final class ParserTests extends FunSuite {
                     List(
                       TsFunParam(NoComments,
                                  TsIdent("this"),
-                                 Some(TsTypeRef(TsQIdent.of("FileReader"), Nil)),
+                                 Some(TsTypeRef(NoComments, TsQIdent.of("FileReader"), Nil)),
                                  isOptional = false),
-                      TsFunParam(NoComments,
-                                 TsIdent("ev"),
-                                 Some(
-                                   TsTypeLookup(TsTypeRef(TsQIdent.of("MSBaseReaderEventMap"), Nil), Left(TsIdent("K")))
-                                 ),
-                                 isOptional = false)
+                      TsFunParam(
+                        NoComments,
+                        TsIdent("ev"),
+                        Some(
+                          TsTypeLookup(TsTypeRef(NoComments, TsQIdent.of("MSBaseReaderEventMap"), Nil),
+                                       TsTypeRef.of(TsIdent("K")))
+                        ),
+                        isOptional = false
+                      )
                     ),
-                    Some(TsTypeRef(TsQIdent.any, Nil))
+                    Some(TsTypeRef(NoComments, TsQIdent.any, Nil))
                   )
                 )
               ),
               isOptional = false
             ),
-            TsFunParam(NoComments, TsIdent("useCapture"), Some(TsTypeRef(TsQIdent.boolean, Nil)), isOptional = true)
+            TsFunParam(NoComments,
+                       TsIdent("useCapture"),
+                       Some(TsTypeRef(NoComments, TsQIdent.boolean, Nil)),
+                       isOptional = true)
           ),
-          Some(TsTypeRef(TsQIdent.void, Nil))
+          Some(TsTypeRef(NoComments, TsQIdent.void, Nil))
         ),
         isStatic   = false,
         isReadOnly = false,
@@ -1090,9 +1121,9 @@ final class ParserTests extends FunSuite {
               level       = Default,
               isReadOnly  = false,
               key         = TsIdent("P"),
-              from        = TsTypeKeyOf(TsTypeRef(TsQIdent.of("T"), Nil)),
+              from        = TsTypeKeyOf(TsTypeRef(NoComments, TsQIdent.of("T"), Nil)),
               optionalize = OptionalModifier.Optionalize,
-              to          = TsTypeLookup(TsTypeRef(TsQIdent.of("T"), Nil), Left(TsIdent("P")))
+              to          = TsTypeLookup(TsTypeRef(NoComments, TsQIdent.of("T"), Nil), TsTypeRef.of(TsIdent("P")))
             )
           )
         ),
@@ -1112,7 +1143,7 @@ final class ParserTests extends FunSuite {
         TsIdent("Pick"),
         List(
           TsTypeParam(NoComments, TsIdent("T"), None, None),
-          TsTypeParam(NoComments, TsIdent("K"), Some(TsTypeKeyOf(TsTypeRef(TsQIdent.of("T"), Nil))), None)
+          TsTypeParam(NoComments, TsIdent("K"), Some(TsTypeKeyOf(TsTypeRef(NoComments, TsQIdent.of("T"), Nil))), None)
         ),
         TsTypeObject(
           List(
@@ -1121,9 +1152,9 @@ final class ParserTests extends FunSuite {
               level       = Default,
               isReadOnly  = false,
               key         = TsIdent("P"),
-              from        = TsTypeRef(TsQIdent.of("K"), Nil),
+              from        = TsTypeRef(NoComments, TsQIdent.of("K"), Nil),
               optionalize = OptionalModifier.Noop,
-              to          = TsTypeLookup(TsTypeRef(TsQIdent.of("T"), Nil), Left(TsIdent("P")))
+              to          = TsTypeLookup(TsTypeRef(NoComments, TsQIdent.of("T"), Nil), TsTypeRef.of(TsIdent("P")))
             )
           )
         ),
@@ -1161,7 +1192,7 @@ final class ParserTests extends FunSuite {
                       NoComments,
                       Nil,
                       Nil,
-                      Some(TsTypeLookup(TsTypeRef(TsQIdent.of("T"), Nil), Left(TsIdent("P"))))
+                      Some(TsTypeLookup(TsTypeRef(NoComments, TsQIdent.of("T"), Nil), TsTypeRef.of(TsIdent("P"))))
                     ),
                     isStatic   = false,
                     isReadOnly = false,
@@ -1178,11 +1209,11 @@ final class ParserTests extends FunSuite {
                         TsFunParam(
                           NoComments,
                           TsIdent("v"),
-                          Some(TsTypeLookup(TsTypeRef(TsQIdent.of("T"), Nil), Left(TsIdent("P")))),
+                          Some(TsTypeLookup(TsTypeRef(NoComments, TsQIdent.of("T"), Nil), TsTypeRef.of(TsIdent("P")))),
                           isOptional = false
                         )
                       ),
-                      Some(TsTypeRef(TsQIdent.void, Nil))
+                      Some(TsTypeRef(NoComments, TsQIdent.void, Nil))
                     ),
                     isStatic   = false,
                     isReadOnly = false,
@@ -1216,7 +1247,7 @@ type Readonly<T> = {
               key         = TsIdentSimple("P"),
               from        = TsTypeKeyOf(T),
               optionalize = Noop,
-              to          = TsTypeLookup(T, Left(TsIdentSimple("P")))
+              to          = TsTypeLookup(T, TsTypeRef.of(TsIdentSimple("P")))
             )
           )
         ),
@@ -1270,7 +1301,7 @@ type Readonly<T> = {
             List(),
             Some(
               TsTypeUnion(
-                List(TsTypeRef(TsQIdent(List(TsIdentSimple("TResult"))), List()), TsTypeRef.void)
+                List(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("TResult"))), List()), TsTypeRef.void)
               )
             )
           )
@@ -1294,30 +1325,39 @@ type Readonly<T> = {
         TsIdent("cloneElement"),
         TsFunSig(
           NoComments,
-          List(TsTypeParam(NoComments, TsIdent("P"), Some(TsTypeRef(TsQIdent(List(TsIdent("Q"))), List())), None),
-               TsTypeParam(NoComments, TsIdent("Q"), None, None)),
+          List(
+            TsTypeParam(NoComments,
+                        TsIdent("P"),
+                        Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("Q"))), List())),
+                        None),
+            TsTypeParam(NoComments, TsIdent("Q"), None, None)
+          ),
           List(
             TsFunParam(
               NoComments,
               TsIdent("element"),
               Some(
-                TsTypeRef(TsQIdent(List(TsIdent("SFCElement"))), List(TsTypeRef(TsQIdent(List(TsIdent("P"))), List())))
+                TsTypeRef(NoComments,
+                          TsQIdent(List(TsIdent("SFCElement"))),
+                          List(TsTypeRef(NoComments, TsQIdent(List(TsIdent("P"))), List())))
               ),
               isOptional = false
             ),
             TsFunParam(NoComments,
                        TsIdent("props"),
-                       Some(TsTypeRef(TsQIdent(List(TsIdent("Q"))), List())),
+                       Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("Q"))), List())),
                        isOptional = true),
             TsFunParam(
               NoComments,
               TsIdent("children"),
-              Some(TsTypeRepeated(TsTypeRef(TsQIdent(List(TsIdent("ReactNode"))), List()))),
+              Some(TsTypeRepeated(TsTypeRef(NoComments, TsQIdent(List(TsIdent("ReactNode"))), List()))),
               isOptional = false
             )
           ),
           Some(
-            TsTypeRef(TsQIdent(List(TsIdent("SFCElement"))), List(TsTypeRef(TsQIdent(List(TsIdent("P"))), List())))
+            TsTypeRef(NoComments,
+                      TsQIdent(List(TsIdent("SFCElement"))),
+                      List(TsTypeRef(NoComments, TsQIdent(List(TsIdent("P"))), List())))
           )
         ),
         Zero,
@@ -1331,14 +1371,14 @@ type Readonly<T> = {
     shouldParseAs("true", TsParser.tsLiteral)(TsLiteralBoolean(true))
     shouldParseAs("false", TsParser.tsLiteral)(TsLiteralBoolean(false))
     shouldParseAs("boolean", TsParser.tsType)(
-      TsTypeRef(TsQIdent(List(TsIdent("boolean"))), List())
+      TsTypeRef(NoComments, TsQIdent(List(TsIdent("boolean"))), List())
     )
     shouldParseAs("trueSpeed: boolean", TsParser.tsMember)(
       TsMemberProperty(
         NoComments,
         Default,
         TsIdent("trueSpeed"),
-        Some(TsTypeRef(TsQIdent(List(TsIdent("boolean"))), List())),
+        Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("boolean"))), List())),
         literal    = None,
         isStatic   = false,
         isReadOnly = false,
@@ -1359,10 +1399,10 @@ type Readonly<T> = {
           List(
             TsFunParam(NoComments,
                        TsIdent("hasToken"),
-                       Some(TsTypeRef(TsQIdent(List(TsIdent("TokenAuthData"))), List())),
+                       Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("TokenAuthData"))), List())),
                        isOptional = false)
           ),
-          Some(TsTypeRef(TsQIdent(List(TsIdent("TokenHandshake"))), List()))
+          Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("TokenHandshake"))), List()))
         ),
         isStatic   = true,
         isReadOnly = false,
@@ -1380,9 +1420,12 @@ type Readonly<T> = {
         List(TsTypeParam(NoComments, TsIdent("P"), None, Some(TsTypeObject(List()))),
              TsTypeParam(NoComments, TsIdent("S"), None, Some(TsTypeObject(List())))),
         List(
-          TsTypeRef(TsQIdent(List(TsIdent("ComponentLifecycle"))),
-                    List(TsTypeRef(TsQIdent(List(TsIdent("P"))), List()),
-                         TsTypeRef(TsQIdent(List(TsIdent("S"))), List())))
+          TsTypeRef(
+            NoComments,
+            TsQIdent(List(TsIdent("ComponentLifecycle"))),
+            List(TsTypeRef(NoComments, TsQIdent(List(TsIdent("P"))), List()),
+                 TsTypeRef(NoComments, TsQIdent(List(TsIdent("S"))), List()))
+          )
         ),
         List(),
         CodePath.NoPath
@@ -1402,7 +1445,7 @@ type Readonly<T> = {
           List(
             TsFunParam(NoComments,
                        TsIdent("obj"),
-                       Some(TsTypeRef(TsQIdent(List(TsIdent("any"))), List())),
+                       Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("any"))), List())),
                        isOptional = false)
           ),
           Some(TsTypeIs(TsIdent("obj"), TsTypeObject(List())))
@@ -1435,14 +1478,13 @@ type Readonly<T> = {
                   List(
                     TsFunParam(NoComments,
                                TsIdent("input"),
-                               Some(TsTypeRef(TsQIdent(List(TsIdent("string"))), List())),
+                               Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("string"))), List())),
                                isOptional = false)
                   ),
                   Some(
-                    TsTypeRef(
-                      TsQIdent(List(TsIdent("Promise"))),
-                      List(TsTypeRef(TsQIdent(List(TsIdent("AutocompleteResult"))), List()))
-                    )
+                    TsTypeRef(NoComments,
+                              TsQIdent(List(TsIdent("Promise"))),
+                              List(TsTypeRef(NoComments, TsQIdent(List(TsIdent("AutocompleteResult"))), List())))
                   )
                 )
               ),
@@ -1453,7 +1495,7 @@ type Readonly<T> = {
                   List(
                     TsFunParam(NoComments,
                                TsIdent("input"),
-                               Some(TsTypeRef(TsQIdent(List(TsIdent("string"))), List())),
+                               Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("string"))), List())),
                                isOptional = false),
                     TsFunParam(
                       NoComments,
@@ -1466,23 +1508,23 @@ type Readonly<T> = {
                             List(
                               TsFunParam(NoComments,
                                          TsIdent("err"),
-                                         Some(TsTypeRef(TsQIdent(List(TsIdent("any"))), List())),
+                                         Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("any"))), List())),
                                          isOptional = false),
                               TsFunParam(NoComments,
                                          TsIdent("result"),
                                          Some(
-                                           TsTypeRef(TsQIdent(List(TsIdent("AutocompleteResult"))), List())
+                                           TsTypeRef(NoComments, TsQIdent(List(TsIdent("AutocompleteResult"))), List())
                                          ),
                                          isOptional = false)
                             ),
-                            Some(TsTypeRef(TsQIdent(List(TsIdent("void"))), List()))
+                            Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("void"))), List()))
                           )
                         )
                       ),
                       isOptional = false
                     )
                   ),
-                  Some(TsTypeRef(TsQIdent(List(TsIdent("void"))), List()))
+                  Some(TsTypeRef(NoComments, TsQIdent(List(TsIdent("void"))), List()))
                 )
               )
             )
@@ -1499,10 +1541,11 @@ type Readonly<T> = {
   test("keyof 1") {
     shouldParseAs("LoDashImplicitArrayWrapper<T[keyof T]>", TsParser.tsType)(
       TsTypeRef(
+        NoComments,
         TsQIdent(List(TsIdent("LoDashImplicitArrayWrapper"))),
         List(
-          TsTypeLookup(TsTypeRef(TsQIdent(List(TsIdent("T"))), List()),
-                       Right(TsTypeKeyOf(TsTypeRef(TsQIdent(List(TsIdent("T"))), Nil))))
+          TsTypeLookup(TsTypeRef(NoComments, TsQIdent(List(TsIdent("T"))), List()),
+                       TsTypeKeyOf(TsTypeRef(NoComments, TsQIdent(List(TsIdent("T"))), Nil)))
         )
       )
     )
@@ -1510,7 +1553,8 @@ type Readonly<T> = {
 
   test("type lookup") {
     shouldParseAs("KeywordTypeNode[\"kind\"]", TsParser.tsType)(
-      TsTypeLookup(TsTypeRef(TsQIdent(List(TsIdent("KeywordTypeNode"))), List()), Left(TsIdent("kind")))
+      TsTypeLookup(TsTypeRef(NoComments, TsQIdent(List(TsIdent("KeywordTypeNode"))), List()),
+                   TsTypeLiteral(TsLiteralString("kind")))
     )
   }
 
@@ -1615,7 +1659,7 @@ type Readonly<T> = {
                           NoComments,
                           Default,
                           TsIdentSimple("facetName"),
-                          Some(TsTypeRef(TsQIdent(List(TsIdentSimple("string"))), List())),
+                          Some(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("string"))), List())),
                           literal    = None,
                           isStatic   = false,
                           isReadOnly = false,
@@ -1625,7 +1669,7 @@ type Readonly<T> = {
                           NoComments,
                           Default,
                           TsIdentSimple("facetQuery"),
-                          Some(TsTypeRef(TsQIdent(List(TsIdentSimple("string"))), List())),
+                          Some(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("string"))), List())),
                           literal    = None,
                           isStatic   = false,
                           isReadOnly = false,
@@ -1633,7 +1677,7 @@ type Readonly<T> = {
                         )
                       )
                     ),
-                    TsTypeRef(TsQIdent(List(TsIdentSimple("AlgoliaQueryParameters"))), List())
+                    TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("AlgoliaQueryParameters"))), List())
                   )
                 )
               ),
@@ -1641,7 +1685,7 @@ type Readonly<T> = {
             )
           ),
           Some(
-            TsTypeRef(TsQIdent(List(TsIdentSimple("Promise"))), List(TsTypeRef.any))
+            TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("Promise"))), List(TsTypeRef.any))
           )
         ),
         isStatic   = false,
@@ -1664,7 +1708,7 @@ type Readonly<T> = {
         isAbstract = false,
         TsIdentSimple("PartialValueApplicator"),
         List(),
-        Some(TsTypeRef(TsQIdent(List(TsIdentSimple("Applicator"))), List())),
+        Some(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("Applicator"))), List())),
         List(),
         List(
           TsMemberFunction(
@@ -1675,10 +1719,12 @@ type Readonly<T> = {
               NoComments,
               List(),
               List(
-                TsFunParam(NoComments,
-                           TsIdentSimple("hasArgsTargetValueConfig"),
-                           Some(TsTypeRef(TsQIdent(List(TsIdentSimple("ApplicateOptions"))), List())),
-                           isOptional = false)
+                TsFunParam(
+                  NoComments,
+                  TsIdentSimple("hasArgsTargetValueConfig"),
+                  Some(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("ApplicateOptions"))), List())),
+                  isOptional = false
+                )
               ),
               Some(TsTypeRef.any)
             ),
@@ -1707,7 +1753,7 @@ type Readonly<T> = {
             NoComments,
             TsIdentSimple("E"),
             Some(
-              TsTypeRef(TsQIdent(List(TsIdentSimple("SyntheticEvent"))), List(TsTypeRef.any))
+              TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("SyntheticEvent"))), List(TsTypeRef.any))
             ),
             None
           )
@@ -1725,10 +1771,10 @@ type Readonly<T> = {
                   List(
                     TsFunParam(NoComments,
                                TsIdentSimple("event"),
-                               Some(TsTypeRef(TsQIdent(List(TsIdentSimple("E"))), List())),
+                               Some(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("E"))), List())),
                                isOptional = false)
                   ),
-                  Some(TsTypeRef(TsQIdent(List(TsIdentSimple("void"))), List()))
+                  Some(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("void"))), List()))
                 ),
                 isStatic   = false,
                 isReadOnly = false,
@@ -1736,7 +1782,7 @@ type Readonly<T> = {
               )
             )
           ),
-          Left(TsIdentSimple("bivarianceHack"))
+          TsTypeLiteral(TsLiteralString("bivarianceHack"))
         ),
         CodePath.NoPath
       )
@@ -1744,15 +1790,16 @@ type Readonly<T> = {
   }
 
   test("double type lookup") {
-    val RTS = TsTypeRef(TsQIdent(List(TsIdentSimple("RTS"))), List())
+    val RTS = TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("RTS"))), List())
     shouldParseAs("""UnionType<RTS, RTS["_A"]["_A"], RTS["_A"]["_O"], mixed>""", TsParser.tsType)(
       TsTypeRef(
+        NoComments,
         TsQIdent(List(TsIdentSimple("UnionType"))),
         List(
           RTS,
-          TsTypeLookup(TsTypeLookup(RTS, Left(TsIdentSimple("_A"))), Left(TsIdentSimple("_A"))),
-          TsTypeLookup(TsTypeLookup(RTS, Left(TsIdentSimple("_A"))), Left(TsIdentSimple("_O"))),
-          TsTypeRef(TsQIdent(List(TsIdentSimple("mixed"))), List())
+          TsTypeLookup(TsTypeLookup(RTS, TsTypeLiteral(TsLiteralString("_A"))), TsTypeLiteral(TsLiteralString("_A"))),
+          TsTypeLookup(TsTypeLookup(RTS, TsTypeLiteral(TsLiteralString("_A"))), TsTypeLiteral(TsLiteralString("_O"))),
+          TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("mixed"))), List())
         )
       )
     )
@@ -1789,8 +1836,8 @@ type Readonly<T> = {
         List(TsTypeParam(NoComments, TsIdentSimple("T"), None, None),
              TsTypeParam(NoComments, TsIdentSimple("U"), None, None)),
         TsTypeConditional(
-          TsTypeExtends(T, TsTypeRef(TsQIdent(List(TsIdentSimple("U"))), List())),
-          TsTypeRef(TsQIdent(List(TsIdentSimple("never"))), List()),
+          TsTypeExtends(T, TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("U"))), List())),
+          TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("never"))), List()),
           T
         ),
         CodePath.NoPath
@@ -1807,9 +1854,9 @@ type Readonly<T> = {
         List(TsTypeParam(NoComments, TsIdentSimple("T"), None, None),
              TsTypeParam(NoComments, TsIdentSimple("U"), None, None)),
         TsTypeConditional(
-          TsTypeExtends(T, TsTypeRef(TsQIdent(List(TsIdentSimple("U"))), List())),
+          TsTypeExtends(T, TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("U"))), List())),
           T,
-          TsTypeRef(TsQIdent(List(TsIdentSimple("never"))), List())
+          TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("never"))), List())
         ),
         CodePath.NoPath
       )
@@ -1827,11 +1874,11 @@ type Readonly<T> = {
           TsTypeExtends(
             T,
             TsTypeUnion(
-              List(TsTypeRef(TsQIdent(List(TsIdentSimple("null"))), List()),
-                   TsTypeRef(TsQIdent(List(TsIdentSimple("undefined"))), List()))
+              List(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("null"))), List()),
+                   TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("undefined"))), List()))
             )
           ),
-          TsTypeRef(TsQIdent(List(TsIdentSimple("never"))), List()),
+          TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("never"))), List()),
           T
         ),
         CodePath.NoPath
@@ -1881,7 +1928,7 @@ type Readonly<T> = {
               )
             )
           ),
-          TsTypeRef(TsQIdent(List(TsIdentSimple("R"))), List()),
+          TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("R"))), List()),
           TsTypeRef.any
         ),
         CodePath.NoPath
@@ -1939,7 +1986,7 @@ type Readonly<T> = {
               )
             )
           ),
-          TsTypeRef(TsQIdent(List(TsIdentSimple("R"))), List()),
+          TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("R"))), List()),
           TsTypeRef.any
         ),
         CodePath.NoPath
@@ -1966,7 +2013,7 @@ type Readonly<T> = {
               TsIdentSimple("P"),
               TsTypeKeyOf(T),
               OptionalModifier.Deoptionalize,
-              TsTypeLookup(T, Left(TsIdentSimple("P")))
+              TsTypeLookup(T, TsTypeRef.of(TsIdentSimple("P")))
             )
           )
         ),
@@ -1999,17 +2046,16 @@ type Readonly<T> = {
             TsFunParam(
               NoComments,
               TsIdentSimple("hasOptimisticResponseUpdateQueriesRefetchQueriesUpdateErrorPolicy"),
-              Some(TsTypeRef(TsQIdent(List(TsIdentSimple("Fpp"))), List())),
+              Some(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("Fpp"))), List())),
               isOptional = false
             )
           ),
           Some(
-            TsTypeRef(
-              TsQIdent(List(TsIdentSimple("Promise"))),
-              List(
-                TsTypeRef(TsQIdent(List(TsIdentSimple("Bar"))), List(T))
-              )
-            )
+            TsTypeRef(NoComments,
+                      TsQIdent(List(TsIdentSimple("Promise"))),
+                      List(
+                        TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("Bar"))), List(T))
+                      ))
           )
         ),
         isStatic   = false,
@@ -2029,7 +2075,7 @@ type Readonly<T> = {
         declared = false,
         readOnly = true,
         TsIdentSimple("foo"),
-        Some(TsTypeRef(TsQIdent(List(TsIdentSimple("symbol"))), List())),
+        Some(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("symbol"))), List())),
         None,
         Zero,
         CodePath.NoPath,
@@ -2140,9 +2186,53 @@ type Readonly<T> = {
         false,
         TsIdentSimple("foo"),
         Some(
-          TsTypeRef(TsQIdent(List(TsIdentImport(TsIdentModule(Some("babel"), List("types"))), TsIdentSimple("Foo"))),
+          TsTypeRef(NoComments,
+                    TsQIdent(List(TsIdentImport(TsIdentModule(Some("babel"), List("types"))), TsIdentSimple("Foo"))),
                     List())
         ),
+        None,
+        Zero,
+        CodePath.NoPath,
+        false
+      )
+    )
+  }
+
+  test("tuple optional") {
+    shouldParseAs(
+      "[number, number?]",
+      TsParser.tsType
+    )(
+      TsTypeTuple(List(TsTypeRef.number, TsTypeUnion(List(TsTypeRef.number, TsTypeRef.undefined))))
+    )
+  }
+
+  test("tuple variable") {
+    shouldParseAs(
+      "[number, number, ...T[]]",
+      TsParser.tsType
+    )(
+      TsTypeTuple(
+        List(
+          TsTypeRef(NoComments, TsQIdent.number, Nil),
+          TsTypeRef(NoComments, TsQIdent.number, Nil),
+          TsTypeRepeated(TsTypeRef(NoComments, TsQIdent.of("T"), Nil))
+        )
+      )
+    )
+  }
+
+  test("typeof import()") {
+    shouldParseAs(
+      "const sdk: typeof import(\"aws-sdk\")",
+      TsParser.tsDeclVar
+    )(
+      TsDeclVar(
+        NoComments,
+        false,
+        true,
+        TsIdentSimple("sdk"),
+        Some(TsTypeQuery(TsQIdent(List(TsIdentImport(TsIdentModule(None, List("aws-sdk"))))))),
         None,
         Zero,
         CodePath.NoPath,

--- a/ts/src/test/scala/com/olvind/tso/ts/transforms/DefaultedHasTParamsTest.scala
+++ b/ts/src/test/scala/com/olvind/tso/ts/transforms/DefaultedHasTParamsTest.scala
@@ -43,9 +43,12 @@ class DefaultedHasTParamsTest extends FunSuite with DiffingAssertions {
           List(TsTypeParam(NoComments, TsIdent("P"), None, Some(TsTypeObject(List()))),
                TsTypeParam(NoComments, TsIdent("S"), None, Some(TsTypeObject(List())))),
           List(
-            TsTypeRef(TsQIdent(List(TsIdent("ComponentLifecycle"))),
-                      List(TsTypeRef(TsQIdent(List(TsIdent("P"))), List()),
-                           TsTypeRef(TsQIdent(List(TsIdent("S"))), List())))
+            TsTypeRef(
+              NoComments,
+              TsQIdent(List(TsIdent("ComponentLifecycle"))),
+              List(TsTypeRef(NoComments, TsQIdent(List(TsIdent("P"))), List()),
+                   TsTypeRef(NoComments, TsQIdent(List(TsIdent("S"))), List()))
+            )
           ),
           List(),
           CodePath.NoPath
@@ -57,9 +60,10 @@ class DefaultedHasTParamsTest extends FunSuite with DiffingAssertions {
           List(),
           TsTypeUnion(
             List(
-              TsTypeRef(TsQIdent(List(TsIdent("Component"))),
-                        List(TsTypeRef(TsQIdent(List(TsIdent("any"))), List()), TsTypeObject(List()))),
-              TsTypeRef(TsQIdent(List(TsIdent("Element"))), List())
+              TsTypeRef(NoComments,
+                        TsQIdent(List(TsIdent("Component"))),
+                        List(TsTypeRef(NoComments, TsQIdent(List(TsIdent("any"))), List()), TsTypeObject(List()))),
+              TsTypeRef(NoComments, TsQIdent(List(TsIdent("Element"))), List())
             )
           ),
           CodePath.NoPath

--- a/ts/src/test/scala/com/olvind/tso/ts/transforms/ExpandKeyOfTypeParamsTest.scala
+++ b/ts/src/test/scala/com/olvind/tso/ts/transforms/ExpandKeyOfTypeParamsTest.scala
@@ -27,18 +27,16 @@ class ExpandKeyOfTypeParamsTest extends FunSuite with DiffingAssertions {
   interface NodeSelector {
       querySelector<K extends keyof ElementTagNameMap>(selectors: K): ElementTagNameMap[K] | null;
       querySelector(selectors: string): Element | null;
-      querySelectorAll<K extends keyof ElementListTagNameMap>(selectors: K): ElementListTagNameMap[K];
-      querySelectorAll(selectors: string): NodeListOf<Element>;
+//      querySelectorAll<K extends keyof ElementListTagNameMap>(selectors: K): ElementListTagNameMap[K];
+//      querySelectorAll(selectors: string): NodeListOf<Element>;
   }
   """).force
 
-    val rewritten =
-      ExpandKeyOfTypeParams.visitTsParsedFile(TsTreeScope(TsIdent.dummy, pedantic = true, Map.empty, logging.stdout))(
-        original
-      )
+    val scope     = TsTreeScope(TsIdent.dummy, pedantic = true, Map.empty, logging.stdout)
+    val rewritten = ExpandKeyOfTypeParams.visitTsParsedFile(scope)(original)
 
     val NodeSelectorActual = rewritten.members.collectFirst {
-      case x: TsDeclInterface if x.name === TsIdentSimple("NodeSelector") => x
+      case x: TsDeclInterface if x.name.value === "NodeSelector" => x
     }.get
 
     val NodeSelectorExpected =
@@ -61,8 +59,8 @@ class ExpandKeyOfTypeParamsTest extends FunSuite with DiffingAssertions {
               ),
               Some(
                 TsTypeUnion(
-                  List(TsTypeRef(TsQIdent(List(TsIdentSimple("HTMLElement"))), List()),
-                       TsTypeRef(TsQIdent(List(TsIdentSimple("null"))), List()))
+                  List(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("HTMLElement"))), List()),
+                       TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("null"))), List()))
                 )
               )
             ),
@@ -82,8 +80,8 @@ class ExpandKeyOfTypeParamsTest extends FunSuite with DiffingAssertions {
               ),
               Some(
                 TsTypeUnion(
-                  List(TsTypeRef(TsQIdent(List(TsIdentSimple("HTMLAnchorElement"))), List()),
-                       TsTypeRef(TsQIdent(List(TsIdentSimple("null"))), List()))
+                  List(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("HTMLAnchorElement"))), List()),
+                       TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("null"))), List()))
                 )
               )
             ),
@@ -101,13 +99,13 @@ class ExpandKeyOfTypeParamsTest extends FunSuite with DiffingAssertions {
               List(
                 TsFunParam(NoComments,
                            TsIdentSimple("selectors"),
-                           Some(TsTypeRef(TsQIdent(List(TsIdentSimple("string"))), List())),
+                           Some(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("string"))), List())),
                            false)
               ),
               Some(
                 TsTypeUnion(
-                  List(TsTypeRef(TsQIdent(List(TsIdentSimple("Element"))), List()),
-                       TsTypeRef(TsQIdent(List(TsIdentSimple("null"))), List()))
+                  List(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("Element"))), List()),
+                       TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("null"))), List()))
                 )
               )
             ),
@@ -115,66 +113,69 @@ class ExpandKeyOfTypeParamsTest extends FunSuite with DiffingAssertions {
             false,
             false
           ),
-          TsMemberFunction(
-            NoComments,
-            Default,
-            TsIdentSimple("querySelectorAll"),
-            TsFunSig(
-              NoComments,
-              List(),
-              List(
-                TsFunParam(NoComments, TsIdentSimple("selectors"), Some(TsTypeLiteral(TsLiteralString("abbr"))), false)
-              ),
-              Some(
-                TsTypeRef(TsQIdent(List(TsIdentSimple("NodeListOf"))),
-                          List(TsTypeRef(TsQIdent(List(TsIdentSimple("HTMLElement"))), List())))
-              )
-            ),
-            false,
-            false,
-            false
-          ),
-          TsMemberFunction(
-            NoComments,
-            Default,
-            TsIdentSimple("querySelectorAll"),
-            TsFunSig(
-              NoComments,
-              List(),
-              List(
-                TsFunParam(NoComments, TsIdentSimple("selectors"), Some(TsTypeLiteral(TsLiteralString("a"))), false)
-              ),
-              Some(
-                TsTypeRef(TsQIdent(List(TsIdentSimple("NodeListOf"))),
-                          List(TsTypeRef(TsQIdent(List(TsIdentSimple("HTMLAnchorElement"))), List())))
-              )
-            ),
-            false,
-            false,
-            false
-          ),
-          TsMemberFunction(
-            NoComments,
-            Default,
-            TsIdentSimple("querySelectorAll"),
-            TsFunSig(
-              NoComments,
-              List(),
-              List(
-                TsFunParam(NoComments,
-                           TsIdentSimple("selectors"),
-                           Some(TsTypeRef(TsQIdent(List(TsIdentSimple("string"))), List())),
-                           false)
-              ),
-              Some(
-                TsTypeRef(TsQIdent(List(TsIdentSimple("NodeListOf"))),
-                          List(TsTypeRef(TsQIdent(List(TsIdentSimple("Element"))), List())))
-              )
-            ),
-            false,
-            false,
-            false
-          )
+//          TsMemberFunction(
+//            NoComments,
+//            Default,
+//            TsIdentSimple("querySelectorAll"),
+//            TsFunSig(
+//              NoComments,
+//              List(),
+//              List(
+//                TsFunParam(NoComments, TsIdentSimple("selectors"), Some(TsTypeLiteral(TsLiteralString("abbr"))), false)
+//              ),
+//              Some(
+//                TsTypeRef(NoComments,
+//                          TsQIdent(List(TsIdentSimple("NodeListOf"))),
+//                          List(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("HTMLElement"))), List())))
+//              )
+//            ),
+//            false,
+//            false,
+//            false
+//          ),
+//          TsMemberFunction(
+//            NoComments,
+//            Default,
+//            TsIdentSimple("querySelectorAll"),
+//            TsFunSig(
+//              NoComments,
+//              List(),
+//              List(
+//                TsFunParam(NoComments, TsIdentSimple("selectors"), Some(TsTypeLiteral(TsLiteralString("a"))), false)
+//              ),
+//              Some(
+//                TsTypeRef(NoComments,
+//                          TsQIdent(List(TsIdentSimple("NodeListOf"))),
+//                          List(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("HTMLAnchorElement"))), List())))
+//              )
+//            ),
+//            false,
+//            false,
+//            false
+//          ),
+//          TsMemberFunction(
+//            NoComments,
+//            Default,
+//            TsIdentSimple("querySelectorAll"),
+//            TsFunSig(
+//              NoComments,
+//              List(),
+//              List(
+//                TsFunParam(NoComments,
+//                           TsIdentSimple("selectors"),
+//                           Some(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("string"))), List())),
+//                           false)
+//              ),
+//              Some(
+//                TsTypeRef(NoComments,
+//                          TsQIdent(List(TsIdentSimple("NodeListOf"))),
+//                          List(TsTypeRef(NoComments, TsQIdent(List(TsIdentSimple("Element"))), List())))
+//              )
+//            ),
+//            false,
+//            false,
+//            false
+//          )
         ),
         CodePath.NoPath
       )

--- a/utils/src/main/scala/com/olvind/tso/comments.scala
+++ b/utils/src/main/scala/com/olvind/tso/comments.scala
@@ -5,8 +5,8 @@ import scala.collection.mutable
 final case class Comment(raw: String) extends AnyVal
 
 object Comment {
-  def warning(s: String): Comment =
-    Comment(s"/* import warning: $s */")
+  def warning(s: String)(implicit e: sourcecode.Enclosing): Comment =
+    Comment(s"/* import warning: ${e.value.split("\\.").takeRight(2).mkString(".")} $s */")
 }
 
 sealed class Comments(val cs: List[Comment]) {
@@ -72,7 +72,4 @@ object Comments {
     ts.foreach(t => buf ++= f(t).cs)
     apply(buf.distinct.toList)
   }
-
-  def unapply(cs: Comments): Option[Int] =
-    Some(cs.cs.length)
 }

--- a/utils/src/main/scala/com/olvind/tso/stringUtils.scala
+++ b/utils/src/main/scala/com/olvind/tso/stringUtils.scala
@@ -1,4 +1,5 @@
 package com.olvind.tso
+import scala.annotation.switch
 
 object stringUtils {
   val Quote = '"'
@@ -10,7 +11,7 @@ object stringUtils {
     s.replaceAllLiterally(Quote.toString, "")
 
   /**
-    * pff, scala apparently cares about nested comments, especially when theyre not balanced
+    * pff, scala apparently cares about nested comments, especially when they're not balanced
     */
   def escapeNestedComments(s: String): String =
     (s.indexOf("/*"), s.lastIndexOf("*/")) match {
@@ -23,6 +24,43 @@ object stringUtils {
           s.substring(start + 2, end).replaceAll("/\\*", "/ *").replaceAll("\\*/", "* /")
         `/*` + escaped + `*/`
     }
+
+  def formatComment(s: String): String = {
+    val sb  = new StringBuilder
+    var idx = 0
+
+    while (idx < s.length) {
+      (s(idx): @switch) match {
+        case '\n' =>
+          /* don't output consecutive newlines */
+          if (sb.isEmpty || sb(sb.length - 1) =/= '\n') {
+            sb.append('\n')
+          }
+
+          /* replace spaces (if any) after newline with exactly two spaces */
+          var hasStrippedSpace = false
+          idx += 1
+          while (idx < s.length && s(idx) === ' ') {
+            hasStrippedSpace = true
+            idx += 1
+          }
+          if (hasStrippedSpace) {
+            sb.append("  ")
+          }
+
+        case other =>
+          sb.append(other)
+          idx += 1
+      }
+    }
+
+    /* if the comment doesn't end with a newline, add a singular space */
+    if (sb.endsWith("*/")) {
+      sb.append(" ")
+    }
+
+    sb.toString()
+  }
 
   /**
     * Apparently scala cares and typescript doesn't


### PR DESCRIPTION
- Memoize parser to make it faster. The hopeless implementation of operator precedence still needs to be properly fixed
- Improve type lookups and type queries
- Retain info about things we couldnt qualify/lookup/translate as comments
- Format typescript code in warnings in code so we don't leak the AST to users
- Get rid of some excess whitespace
- Format comments better