### PR TITLE
[WIP] FIX #113: NoSuchMethodError currentBinaryVersion For ScalaJs 1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,8 @@ lazy val `sbt-converter` = project
   .settings(
     name := "sbt-converter",
     Compile / unmanagedSourceDirectories += (`sbt-converter06` / Compile / sourceDirectory).value,
-    addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.16.0"),
+    //addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.16.0"),
+    addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.16.0+4-65a0c190"), //FIXME wait for https://github.com/scalacenter/scalajs-bundler/pull/324#event-3044771159
   )
 
 lazy val root = project

--- a/sbt-converter06/src/main/scala/org/scalablytyped/converter/plugin/ScalablyTypedConverterExternalNpmPlugin.scala
+++ b/sbt-converter06/src/main/scala/org/scalablytyped/converter/plugin/ScalablyTypedConverterExternalNpmPlugin.scala
@@ -62,7 +62,7 @@ object ScalablyTypedConverterExternalNpmPlugin extends AutoPlugin {
         )
         val ScalaJsVersion = Versions.ScalaJs(
           scalaJsVersion    = org.scalajs.sbtplugin.ScalaJSPlugin.autoImport.scalaJSVersion,
-          scalaJsBinVersion = ScalaJSCrossVersion.currentBinaryVersion,
+          scalaJsBinVersion = org.scalajs.ir.ScalaJSVersions.binaryCross,
         )
 
         val versions = Versions(ScalaVersion, ScalaJsVersion)

--- a/sbt-converter06/src/main/scala/org/scalablytyped/converter/plugin/ScalablyTypedConverterPlugin.scala
+++ b/sbt-converter06/src/main/scala/org/scalablytyped/converter/plugin/ScalablyTypedConverterPlugin.scala
@@ -97,7 +97,7 @@ object ScalablyTypedConverterPlugin extends AutoPlugin {
         )
         val ScalaJsVersion = Versions.ScalaJs(
           scalaJsVersion    = org.scalajs.sbtplugin.ScalaJSPlugin.autoImport.scalaJSVersion,
-          scalaJsBinVersion = ScalaJSCrossVersion.currentBinaryVersion,
+          scalaJsBinVersion = org.scalajs.ir.ScalaJSVersions.binaryCross,
         )
 
         val versions = Versions(ScalaVersion, ScalaJsVersion)


### PR DESCRIPTION
This is just [WIP] because I'm waiting for the new version of scalajs-bundler to be published.
Since https://github.com/scalacenter/scalajs-bundler/pull/324#event-3044771159 is already merged.

With the new version of scalajs-bundler, we use the solution from @gzm0 (https://github.com/ScalablyTyped/Demos/issues/21#issuecomment-587046901) for the ScalaJs versions 0.6 and 1.0 without having to support each version independently.

I published everything local and tested with the ScalablyTyped/Demos and it seems to work with ScalaJs 1.0.0


