### PR TITLE
Fix ts parsing error on export default class <T>

### DIFF
--- a/importer/src/test/scala/org/scalablytyped/converter/internal/ts/parser/ImportExportParseTests.scala
+++ b/importer/src/test/scala/org/scalablytyped/converter/internal/ts/parser/ImportExportParseTests.scala
@@ -306,4 +306,27 @@ final class ImportExportParseTests extends AnyFunSuite with Matchers {
       ),
     )
   }
+
+  test("export default class <T>") {
+    shouldParseAs("export default class <T> {}", TsParser.tsExport)(
+      TsExport(
+        NoComments,
+        ExportType.Defaulted,
+        TsExporteeTree(
+          TsDeclClass(
+            NoComments,
+            declared = false,
+            isAbstract = false,
+            TsIdent("default"),
+            IArray(TsTypeParam(NoComments, TsIdentSimple("T"), None, None)),
+            None,
+            IArray(),
+            IArray(),
+            Zero,
+            CodePath.NoPath,
+          )
+        )
+      )
+    )
+  }
 }

--- a/ts/src/main/scala/org/scalablytyped/converter/internal/ts/parser/TsParser.scala
+++ b/ts/src/main/scala/org/scalablytyped/converter/internal/ts/parser/TsParser.scala
@@ -336,9 +336,9 @@ class TsParser(path: Option[(os.Path, Int)]) extends StdTokenParsers with Parser
     val hack: Parser[TsIdentSimple] =
       tsIdent.filter(_.value =/= "extends")
 
-    comments ~ isDeclared ~ (isAbstract <~ "class") ~ (hack ~ tsTypeParams).? ~ parent ~ implements ~ tsMembers ^^ {
+    comments ~ isDeclared ~ (isAbstract <~ "class") ~ (hack.? ~ tsTypeParams).? ~ parent ~ implements ~ tsMembers ^^ {
       case cs ~ decl ~ abs ~ Some(ident ~ tparams) ~ par ~ impl ~ members =>
-        TsDeclClass(cs, decl, abs, ident, tparams, par, impl, members, JsLocation.Zero, CodePath.NoPath)
+        TsDeclClass(cs, decl, abs, ident.getOrElse(TsIdent.default), tparams, par, impl, members, JsLocation.Zero, CodePath.NoPath)
       case cs ~ decl ~ abs ~ None ~ par ~ impl ~ members =>
         TsDeclClass(cs, decl, abs, TsIdent.default, Empty, par, impl, members, JsLocation.Zero, CodePath.NoPath)
     }


### PR DESCRIPTION
This is an attempt at fixing the issue I just opened, #127. The typescript parser was expecting an identifier before the type parameter even though it doesn't to be always the case.

I'm not sure about the fix (`.?` + `getOrElse`), but all the tests are passing. Let me know (or close this PR) if this isn't the right way to fix it. It now imports correctly `@antv/g6` (and thus `@antv/util`) but I haven't tried using it in Scala yet.