### PR TITLE
Use global resolvers when resolving the ZincCompiler

### DIFF
--- a/sbt-converter06/src/main/scala/org/scalablytyped/converter/internal/ZincCompiler.scala
+++ b/sbt-converter06/src/main/scala/org/scalablytyped/converter/internal/ZincCompiler.scala
@@ -75,7 +75,8 @@ object ZincCompiler {
       Versions.ScalaJs(org.scalajs.sbtplugin.ScalaJSPlugin.autoImport.scalaJSVersion),
     )
 
-    val resolver = DependencyResolution(new CoursierDependencyResolution(CoursierConfiguration()))
+    val resolvers = sbt.coursierint.CoursierRepositoriesTasks.coursierResolversTask.value.toVector
+    val resolver = DependencyResolution(new CoursierDependencyResolution(CoursierConfiguration().withResolvers(resolvers)))
 
     def resolve(dep: Dep): Array[File] =
       resolver.retrieve(


### PR DESCRIPTION
As discussed on gitter.
The solution worked on a node connected to maven central,
and it worked on a node, only connected to an internal repository.