### PR TITLE
React flavour improvements

### DIFF
--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/JapgollyFlavour.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/JapgollyFlavour.scala
@@ -27,7 +27,7 @@ case class JapgollyFlavour(outputPkg: Name, scalaVersion: Versions.Scala, enable
         val ret = Adapter(scope)((t, s) => genComponents(s, t, components))(withCompanions)
 
         if (isReact(scope))
-          ret.copy(members = ret.members ++ IArray(genStBuildingComponent.Trait, genStBuildingComponent.Object))
+          ret.copy(members = ret.members ++ IArray(genStBuildingComponent.Trait, genStBuildingComponent.Object.tree))
         else ret
 
       } else withCompanions

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/JapgollyGenStBuildingComponent.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/JapgollyGenStBuildingComponent.scala
@@ -111,36 +111,58 @@ class JapgollyGenStBuildingComponent(val outputPkg: Name, val scalaVersion: Vers
     )
   }
 
-  val unsafeSpread = {
-    val param = ParamTree(Name("obj"), false, false, TypeRef.Any, NotImplemented, NoComments)
-    val name  = Name("unsafeSpread")
-    val assign = Call(
-      Ref(QualifiedName.Object + Name("assign")),
-      IArray(
-        IArray(
-          Cast(Call(Ref(args.name), IArray(IArray(NumberLit("1")))), TypeRef.Object),
-          Cast(Ref(param.name), TypeRef.Object),
-        ),
-      ),
-    )
-
-    MethodTree(
-      IArray(Annotation.Inline),
-      ProtectionLevel.Default,
-      name,
-      Empty,
-      IArray(IArray(param)),
-      Block(assign, Ref(QualifiedName.THIS)),
-      TypeRef(QualifiedName.THIS),
-      false,
-      NoComments,
-      builderCp + name,
-      false,
-    )
-  }
-
   val Trait: ClassTree = {
-//    @scala.inline
+    val unsafeSpread = {
+      val param = ParamTree(Name("obj"), false, false, TypeRef.Any, NotImplemented, NoComments)
+      val name  = Name("unsafeSpread")
+      val assign = Call(
+        Ref(QualifiedName.Object + Name("assign")),
+        IArray(
+          IArray(
+            Cast(Call(Ref(args.name), IArray(IArray(NumberLit("1")))), TypeRef.Object),
+            Cast(Ref(param.name), TypeRef.Object),
+          ),
+        ),
+      )
+
+      MethodTree(
+        IArray(Annotation.Inline),
+        ProtectionLevel.Default,
+        name,
+        Empty,
+        IArray(IArray(param)),
+        Block(assign, Ref(QualifiedName.THIS)),
+        TypeRef(QualifiedName.THIS),
+        false,
+        NoComments,
+        builderCp + name,
+        false,
+      )
+    }
+
+    val build = {
+      val name = Name("build")
+
+      MethodTree(
+        IArray(Annotation.Inline),
+        ProtectionLevel.Default,
+        name,
+        Empty,
+        Empty,
+        Call(Ref(Object.make.codePath), IArray(IArray(Ref(QualifiedName.THIS)))),
+        Object.make.resultType,
+        false,
+        Comments(
+          Comment(
+            "/* You typically shouldnt call this yourself, but it can be useful if you're for instance mapping a sequence and you need types to infer properly */\n",
+          ),
+        ),
+        builderCp + name,
+        false,
+      )
+    }
+
+    //    @scala.inline
 //    def applyTagMod(t: TagMod): Unit =
 //      if (t.isInstanceOf[TagMod.Composite]) {
 //        val tt = t.asInstanceOf[TagMod.Composite]
@@ -346,7 +368,7 @@ class JapgollyGenStBuildingComponent(val outputPkg: Name, val scalaVersion: Vers
       tparams     = builderTparams,
       parents     = IArray.fromOption(enableAnyVal.map(_ => TypeRef.ScalaAny)),
       ctors       = Empty,
-      members     = IArray(args, set, withComponent, unsafeSpread, applyTagMod, apply, withKey, withRef1, withRef2),
+      members     = IArray(args, set, withComponent, unsafeSpread, build, applyTagMod, apply, withKey, withRef1, withRef2),
       classType   = ClassType.Trait,
       isSealed    = false,
       comments    = NoComments,
@@ -354,7 +376,7 @@ class JapgollyGenStBuildingComponent(val outputPkg: Name, val scalaVersion: Vers
     )
   }
 
-  val Default: ClassTree = {
+  lazy val Default: ClassTree = {
     val ctor = CtorTree(
       ProtectionLevel.Default,
       IArray(
@@ -386,7 +408,7 @@ class JapgollyGenStBuildingComponent(val outputPkg: Name, val scalaVersion: Vers
     )
   }
 
-  val Object: ModuleTree = {
+  object Object {
     //    @js.native
     //    @JSImport("react", JSImport.Namespace, "React")
     //    object ReactRaw extends js.Object {
@@ -485,7 +507,7 @@ class JapgollyGenStBuildingComponent(val outputPkg: Name, val scalaVersion: Vers
       )
     }
 
-    ModuleTree(
+    val tree = ModuleTree(
       Empty,
       StBuildingComponent,
       Empty,

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/JapgollyGenStBuildingComponent.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/JapgollyGenStBuildingComponent.scala
@@ -112,35 +112,127 @@ class JapgollyGenStBuildingComponent(val outputPkg: Name, val scalaVersion: Vers
   }
 
   val Trait: ClassTree = {
+//    @scala.inline
+//    def applyTagMod(t: TagMod): Unit =
+//      if (t.isInstanceOf[TagMod.Composite]) {
+//        val tt = t.asInstanceOf[TagMod.Composite]
+//        tt.mods.foreach(applyTagMod)
+//      } else if (t.isInstanceOf[VdomNode]) {
+//        val tt = t.asInstanceOf[VdomNode]
+//        b.args.push(tt.rawNode.asInstanceOf[js.Any])
+//      } else {
+//        val tt = t.toJs
+//        tt.addClassNameToProps()
+//        tt.addKeyToProps()
+//        tt.addStyleToProps()
+//        tt.nonEmptyChildren.foreach(children => b.args.push(children))
+//        tt.nonEmptyProps.foreach(props => js.Object.assign(b.args(1).asInstanceOf[js.Object], props))
+//      }
+    val applyTagMod = {
+      val TagMod          = TypeRef(JapgollyNames.vdom.TagMod)
+      val VdomNode        = TypeRef(JapgollyNames.vdom.VdomNode)
+      val ReactNode       = TypeRef(JapgollyNames.rawReact.Node)
+      val TagModComposite = TypeRef(JapgollyNames.vdom.TagMod + Name("Composite"))
 
-//  @inline final def apply(children: japgolly.scalajs.react.vdom.VdomNode*): this.type = {
-//    mods.foreach((mod: japgolly.scalajs.react.vdom.VdomNode) => args.push(mod.rawNode))
-//    this
-//  }
+      val tParam = ParamTree(Name("t"), false, false, TagMod, NotImplemented, NoComments)
+      val name   = Name("applyTagMod")
+      val impl = {
+        val ttName = Name("tt")
+        val fallback = {
+          val childrenName = Name("children")
+          val childrenLambda = Lambda(
+            IArray(
+              ParamTree(
+                childrenName,
+                false,
+                false,
+                TypeRef(QualifiedName.Array, IArray(ReactNode), NoComments),
+                NotImplemented,
+                NoComments,
+              ),
+            ),
+            Call(Select(Ref(args.name), Name("push")), IArray(IArray(Ref(childrenName)))),
+          )
+          val propsName = Name("props")
+          val propsLambda = Lambda(
+            IArray(ParamTree(propsName, false, false, TypeRef.Object, NotImplemented, NoComments)),
+            Call(
+              Ref(QualifiedName.Object + Name("assign")),
+              IArray(IArray(Cast(Call(Ref(args.name), IArray(IArray(NumberLit("1")))), TypeRef.Object), Ref(propsName))),
+            ),
+          )
+          Block(
+            Val(ttName, Select(Ref(tParam.name), Name("toJs"))),
+            Call(Ref(QualifiedName(IArray(ttName, Name("addClassNameToProps")))), IArray(Empty)),
+            Call(Ref(QualifiedName(IArray(ttName, Name("addKeyToProps")))), IArray(Empty)),
+            Call(Ref(QualifiedName(IArray(ttName, Name("addStyleToProps")))), IArray(Empty)),
+            Call(
+              Ref(QualifiedName(IArray(ttName, Name("nonEmptyChildren"), Name("foreach")))),
+              IArray(IArray(childrenLambda)),
+            ),
+            Call(
+              Ref(QualifiedName(IArray(ttName, Name("nonEmptyProps"), Name("foreach")))),
+              IArray(IArray(propsLambda)),
+            ),
+          )
+        }
+
+        If(
+          InstanceOf(Ref(tParam.name), TagModComposite),
+          Block(
+            Val(ttName, Cast(Ref(tParam.name), TagModComposite)),
+            Call(Ref(QualifiedName(IArray(ttName, Name("mods"), Name("foreach")))), IArray(IArray(Ref(name)))),
+          ),
+          Some(
+            If(
+              InstanceOf(Ref(tParam.name), VdomNode),
+              Block(
+                Val(ttName, Cast(Ref(tParam.name), VdomNode)),
+                Call(
+                  Select(Ref(args.name), Name("push")),
+                  IArray(IArray(Cast(Select(Ref(ttName), Name("rawNode")), TypeRef.Any))),
+                ),
+              ),
+              Some(fallback),
+            ),
+          ),
+        )
+      }
+
+      MethodTree(
+        IArray(Annotation.Inline),
+        ProtectionLevel.Default,
+        name,
+        Empty,
+        IArray(IArray(tParam)),
+        impl,
+        TypeRef.Unit,
+        false,
+        NoComments,
+        builderCp + Name.APPLY + name,
+        false,
+      )
+    }
+
+//    @scala.inline
+//    def apply(mods: TagMod*): this.type = {
+//      mods.foreach(applyTagMod)
+//      this
+//    }
     val `apply` = {
-      val VdomNode = TypeRef(JapgollyNames.vdom.VdomNode)
       val modsParam = ParamTree(
         name       = Name("mods"),
         isImplicit = false,
         isVal      = false,
-        tpe        = TypeRef.Repeated(VdomNode, NoComments),
+        tpe        = TypeRef.Repeated(TypeRef(JapgollyNames.vdom.TagMod), NoComments),
         default    = NotImplemented,
         comments   = NoComments,
       )
-      val impl = {
-        val modParam = ParamTree(Name("mod"), isImplicit = false, isVal = false, VdomNode, NotImplemented, NoComments)
-        val modRef   = Ref(modParam.name)
-
-        val lambda = Lambda(
-          IArray(modParam),
-          Call(
-            Select(Ref(args.name), Name("push")),
-            IArray(IArray(Cast(Select(modRef, Name("rawNode")), TypeRef.Any))),
-          ),
+      val impl =
+        Block(
+          Call(Select(Ref(modsParam.name), Name("foreach")), IArray(IArray(Ref(applyTagMod.name)))),
+          Ref(Name.THIS),
         )
-
-        Block(Call(Select(Ref(modsParam.name), Name("foreach")), IArray(IArray(lambda))), Ref(Name.THIS))
-      }
 
       MethodTree(
         annotations = IArray(Annotation.Inline),
@@ -155,7 +247,6 @@ class JapgollyGenStBuildingComponent(val outputPkg: Name, val scalaVersion: Vers
         codePath   = builderCp + Name.APPLY,
         isImplicit = false,
       )
-
     }
 
     //  @inline final def withKey(key: japgolly.scalajs.react.Key): this.type = set("key", key)
@@ -235,7 +326,7 @@ class JapgollyGenStBuildingComponent(val outputPkg: Name, val scalaVersion: Vers
       tparams     = builderTparams,
       parents     = IArray.fromOption(enableAnyVal.map(_ => TypeRef.ScalaAny)),
       ctors       = Empty,
-      members     = IArray(args, set, withComponent, apply, withKey, withRef1, withRef2),
+      members     = IArray(args, set, withComponent, applyTagMod, apply, withKey, withRef1, withRef2),
       classType   = ClassType.Trait,
       isSealed    = false,
       comments    = NoComments,

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/SlinkyFlavour.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/SlinkyFlavour.scala
@@ -47,7 +47,7 @@ case class SlinkyFlavour(
       val ret = Adapter(scope)((t, s) => gen(s, t, components))(withCompanions)
 
       if (isReact(scope))
-        ret.copy(members = ret.members ++ IArray(genStBuildingComponent.Trait, genStBuildingComponent.Object))
+        ret.copy(members = ret.members ++ IArray(genStBuildingComponent.Trait, genStBuildingComponent.Object.tree))
       else ret
 
     } else withCompanions

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/SlinkyGenStBuildingComponent.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/SlinkyGenStBuildingComponent.scala
@@ -115,6 +115,27 @@ class SlinkyGenStBuildingComponent(val outputPkg: Name, val scalaVersion: Versio
   }
 
   val Trait: ClassTree = {
+    val build = {
+      val name = Name("build")
+
+      MethodTree(
+        IArray(Annotation.Inline),
+        ProtectionLevel.Default,
+        name,
+        Empty,
+        Empty,
+        Call(Ref(Object.make.codePath), IArray(IArray(Ref(QualifiedName.THIS)))),
+        Object.make.resultType,
+        false,
+        Comments(
+          Comment(
+            "/* You typically shouldnt call this yourself, but it can be useful if you're for instance mapping a sequence and you need types to infer properly */\n",
+          ),
+        ),
+        builderCp + name,
+        false,
+      )
+    }
 
     val unsafeSpread = {
       val param = ParamTree(Name("obj"), false, false, TypeRef.Any, NotImplemented, NoComments)
@@ -296,7 +317,7 @@ class SlinkyGenStBuildingComponent(val outputPkg: Name, val scalaVersion: Versio
       tparams     = builderTparams,
       parents     = IArray.fromOption(enableAnyVal.map(_ => TypeRef.ScalaAny)),
       ctors       = Empty,
-      members     = IArray(args, set, withComponent, unsafeSpread, apply, withKey, withRef1, withRef2),
+      members     = IArray(args, set, withComponent, build, unsafeSpread, apply, withKey, withRef1, withRef2),
       classType   = ClassType.Trait,
       isSealed    = false,
       comments    = NoComments,
@@ -304,7 +325,7 @@ class SlinkyGenStBuildingComponent(val outputPkg: Name, val scalaVersion: Versio
     )
   }
 
-  val Default: ClassTree = {
+  lazy val Default: ClassTree = {
     val ctor = CtorTree(
       ProtectionLevel.Default,
       IArray(
@@ -337,7 +358,7 @@ class SlinkyGenStBuildingComponent(val outputPkg: Name, val scalaVersion: Versio
     )
   }
 
-  val Object: ModuleTree = {
+  object Object {
     //    @js.native
     //    @JSImport("react", JSImport.Namespace, "React")
     //    object ReactRaw extends js.Object {
@@ -437,7 +458,7 @@ class SlinkyGenStBuildingComponent(val outputPkg: Name, val scalaVersion: Versio
       )
     }
 
-    ModuleTree(
+    val tree = ModuleTree(
       Empty,
       StBuildingComponent,
       Empty,

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/SlinkyGenStBuildingComponent.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/SlinkyGenStBuildingComponent.scala
@@ -116,7 +116,35 @@ class SlinkyGenStBuildingComponent(val outputPkg: Name, val scalaVersion: Versio
 
   val Trait: ClassTree = {
 
-//  @inline final def apply(mods: slinky.core.TagMod[E]*): this.type = {
+    val unsafeSpread = {
+      val param = ParamTree(Name("obj"), false, false, TypeRef.Any, NotImplemented, NoComments)
+      val name  = Name("unsafeSpread")
+      val assign = Call(
+        Ref(QualifiedName.Object + Name("assign")),
+        IArray(
+          IArray(
+            Cast(Call(Ref(args.name), IArray(IArray(NumberLit("1")))), TypeRef.Object),
+            Cast(Ref(param.name), TypeRef.Object),
+          ),
+        ),
+      )
+
+      MethodTree(
+        IArray(Annotation.Inline),
+        ProtectionLevel.Default,
+        name,
+        Empty,
+        IArray(IArray(param)),
+        Block(assign, Ref(QualifiedName.THIS)),
+        TypeRef(QualifiedName.THIS),
+        false,
+        NoComments,
+        builderCp + name,
+        false,
+      )
+    }
+
+    //  @inline final def apply(mods: slinky.core.TagMod[E]*): this.type = {
 //    mods.foreach((mod: slinky.core.TagMod[E]) =>
 //      if (mod.isInstanceOf[slinky.core.AttrPair]) {
 //        val a = mod.asInstanceOf[AttrPair]
@@ -268,7 +296,7 @@ class SlinkyGenStBuildingComponent(val outputPkg: Name, val scalaVersion: Versio
       tparams     = builderTparams,
       parents     = IArray.fromOption(enableAnyVal.map(_ => TypeRef.ScalaAny)),
       ctors       = Empty,
-      members     = IArray(args, set, withComponent, apply, withKey, withRef1, withRef2),
+      members     = IArray(args, set, withComponent, unsafeSpread, apply, withKey, withRef1, withRef2),
       classType   = ClassType.Trait,
       isSealed    = false,
       comments    = NoComments,

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/SlinkyNativeFlavour.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/SlinkyNativeFlavour.scala
@@ -29,7 +29,7 @@ case class SlinkyNativeFlavour(outputPkg: Name, scalaVersion: Versions.Scala, en
       val ret = Adapter(scope)((t, s) => gen(s, t, components))(withCompanions)
 
       if (isReact(scope))
-        ret.copy(members = ret.members ++ IArray(genStBuildingComponent.Trait, genStBuildingComponent.Object))
+        ret.copy(members = ret.members ++ IArray(genStBuildingComponent.Trait, genStBuildingComponent.Object.tree))
       else ret
 
     } else withCompanions

--- a/tests/material-ui/check-japgolly/m/material-ui/build.sbt
+++ b/tests/material-ui/check-japgolly/m/material-ui/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "material-ui"
-version := "0.0-unknown-94fe54"
+version := "0.0-unknown-b5eeb1"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-462a97",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-fa9e78",
   "org.scalablytyped" %%% "std" % "0.0-unknown-c6422c")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/material-ui/check-japgolly/m/material-ui/build.sbt
+++ b/tests/material-ui/check-japgolly/m/material-ui/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "material-ui"
-version := "0.0-unknown-0c5ff0"
+version := "0.0-unknown-94fe54"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-906efe",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-462a97",
   "org.scalablytyped" %%% "std" % "0.0-unknown-c6422c")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/material-ui/check-japgolly/m/material-ui/build.sbt
+++ b/tests/material-ui/check-japgolly/m/material-ui/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "material-ui"
-version := "0.0-unknown-b5eeb1"
+version := "0.0-unknown-616235"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-fa9e78",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-9c37cd",
   "org.scalablytyped" %%% "std" % "0.0-unknown-c6422c")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/material-ui/check-japgolly/r/react/build.sbt
+++ b/tests/material-ui/check-japgolly/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-fa9e78"
+version := "0.0-unknown-9c37cd"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/material-ui/check-japgolly/r/react/build.sbt
+++ b/tests/material-ui/check-japgolly/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-906efe"
+version := "0.0-unknown-462a97"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/material-ui/check-japgolly/r/react/build.sbt
+++ b/tests/material-ui/check-japgolly/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-462a97"
+version := "0.0-unknown-fa9e78"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/material-ui/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
+++ b/tests/material-ui/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
@@ -8,6 +8,7 @@ import japgolly.scalajs.react.vdom.TagMod
 import japgolly.scalajs.react.vdom.TagMod.Composite
 import japgolly.scalajs.react.vdom.VdomElement
 import japgolly.scalajs.react.vdom.VdomNode
+import typingsJapgolly.StBuildingComponent.make
 import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
@@ -30,6 +31,9 @@ trait StBuildingComponent[R <: js.Object] extends Any {
     js.Object.assign(args(1).asInstanceOf[js.Object], obj.asInstanceOf[js.Object])
     this
   }
+  /* You typically shouldnt call this yourself, but it can be useful if you're for instance mapping a sequence and you need types to infer properly */
+  @scala.inline
+  def build: VdomElement = make(this)
   @scala.inline
   def applyTagMod(t: TagMod): Unit = if (t.isInstanceOf[Composite]) {
     val tt = t.asInstanceOf[Composite]

--- a/tests/material-ui/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
+++ b/tests/material-ui/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
@@ -3,6 +3,9 @@ package typingsJapgolly
 import japgolly.scalajs.react.Key
 import japgolly.scalajs.react.Ref.Simple
 import japgolly.scalajs.react.raw.React.Element
+import japgolly.scalajs.react.raw.React.Node
+import japgolly.scalajs.react.vdom.TagMod
+import japgolly.scalajs.react.vdom.TagMod.Composite
 import japgolly.scalajs.react.vdom.VdomElement
 import japgolly.scalajs.react.vdom.VdomNode
 import scala.scalajs.js
@@ -23,8 +26,23 @@ trait StBuildingComponent[R <: js.Object] extends Any {
     this
   }
   @scala.inline
-  def apply(mods: VdomNode*): this.type = {
-    mods.foreach((mod: VdomNode) => args.push(mod.rawNode.asInstanceOf[js.Any]))
+  def applyTagMod(t: TagMod): Unit = if (t.isInstanceOf[Composite]) {
+    val tt = t.asInstanceOf[Composite]
+    tt.mods.foreach(applyTagMod)
+  } else if (t.isInstanceOf[VdomNode]) {
+    val tt = t.asInstanceOf[VdomNode]
+    args.push(tt.rawNode.asInstanceOf[js.Any])
+  } else {
+    val tt = t.toJs
+    tt.addClassNameToProps()
+    tt.addKeyToProps()
+    tt.addStyleToProps()
+    tt.nonEmptyChildren.foreach((children: js.Array[Node]) => args.push(children))
+    tt.nonEmptyProps.foreach((props: js.Object) => js.Object.assign(args(1).asInstanceOf[js.Object], props))
+  }
+  @scala.inline
+  def apply(mods: TagMod*): this.type = {
+    mods.foreach(applyTagMod)
     this
   }
   @scala.inline

--- a/tests/material-ui/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
+++ b/tests/material-ui/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
@@ -26,6 +26,11 @@ trait StBuildingComponent[R <: js.Object] extends Any {
     this
   }
   @scala.inline
+  def unsafeSpread(obj: js.Any): this.type = {
+    js.Object.assign(args(1).asInstanceOf[js.Object], obj.asInstanceOf[js.Object])
+    this
+  }
+  @scala.inline
   def applyTagMod(t: TagMod): Unit = if (t.isInstanceOf[Composite]) {
     val tt = t.asInstanceOf[Composite]
     tt.mods.foreach(applyTagMod)
@@ -38,7 +43,7 @@ trait StBuildingComponent[R <: js.Object] extends Any {
     tt.addKeyToProps()
     tt.addStyleToProps()
     tt.nonEmptyChildren.foreach((children: js.Array[Node]) => args.push(children))
-    tt.nonEmptyProps.foreach((props: js.Object) => js.Object.assign(args(1).asInstanceOf[js.Object], props))
+    tt.nonEmptyProps.foreach(unsafeSpread)
   }
   @scala.inline
   def apply(mods: TagMod*): this.type = {

--- a/tests/material-ui/check-slinky/m/material-ui/build.sbt
+++ b/tests/material-ui/check-slinky/m/material-ui/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "material-ui"
-version := "0.0-unknown-4c1521"
+version := "0.0-unknown-5b3c2c"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-2ad8e1",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-63c119",
   "org.scalablytyped" %%% "std" % "0.0-unknown-c86d55")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/material-ui/check-slinky/m/material-ui/build.sbt
+++ b/tests/material-ui/check-slinky/m/material-ui/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "material-ui"
-version := "0.0-unknown-5b3c2c"
+version := "0.0-unknown-de47ff"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-63c119",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-c98387",
   "org.scalablytyped" %%% "std" % "0.0-unknown-c86d55")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/material-ui/check-slinky/r/react/build.sbt
+++ b/tests/material-ui/check-slinky/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-63c119"
+version := "0.0-unknown-c98387"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/material-ui/check-slinky/r/react/build.sbt
+++ b/tests/material-ui/check-slinky/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-2ad8e1"
+version := "0.0-unknown-63c119"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/material-ui/check-slinky/r/react/src/main/scala/typingsSlinky/StBuildingComponent.scala
+++ b/tests/material-ui/check-slinky/r/react/src/main/scala/typingsSlinky/StBuildingComponent.scala
@@ -5,6 +5,7 @@ import slinky.core.OptionalAttrPair
 import slinky.core.TagMod
 import slinky.core.facade.ReactElement
 import slinky.core.facade.ReactRef
+import typingsSlinky.StBuildingComponent.make
 import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
@@ -22,6 +23,9 @@ trait StBuildingComponent[E, R <: js.Object] extends Any {
     args.update(0, f(args(0)))
     this
   }
+  /* You typically shouldnt call this yourself, but it can be useful if you're for instance mapping a sequence and you need types to infer properly */
+  @scala.inline
+  def build: ReactElement = make(this)
   @scala.inline
   def unsafeSpread(obj: js.Any): this.type = {
     js.Object.assign(args(1).asInstanceOf[js.Object], obj.asInstanceOf[js.Object])

--- a/tests/material-ui/check-slinky/r/react/src/main/scala/typingsSlinky/StBuildingComponent.scala
+++ b/tests/material-ui/check-slinky/r/react/src/main/scala/typingsSlinky/StBuildingComponent.scala
@@ -23,6 +23,11 @@ trait StBuildingComponent[E, R <: js.Object] extends Any {
     this
   }
   @scala.inline
+  def unsafeSpread(obj: js.Any): this.type = {
+    js.Object.assign(args(1).asInstanceOf[js.Object], obj.asInstanceOf[js.Object])
+    this
+  }
+  @scala.inline
   def apply(mods: TagMod[E]*): this.type = {
     mods.foreach((mod: TagMod[E]) => if (mod.isInstanceOf[AttrPair[_]]) {
       val a = mod.asInstanceOf[AttrPair[_]]

--- a/tests/react-integration-test/check-japgolly/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-japgolly/c/componentstest/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-177539"
+version := "0.0-unknown-dd1a47"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-7b2586",
+  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-japgolly/c/componentstest/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-ad4484"
+version := "0.0-unknown-343ace"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
+  "org.scalablytyped" %%% "react" % "16.9.2-0196b6",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-japgolly/c/componentstest/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-dd1a47"
+version := "0.0-unknown-ad4484"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
+  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-bootstrap/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-d6462d"
+version := "0.32-fc503a"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
+  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-bootstrap/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-960d35"
+version := "0.32-d6462d"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-7b2586",
+  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-bootstrap/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-fc503a"
+version := "0.32-5520ce"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
+  "org.scalablytyped" %%% "react" % "16.9.2-0196b6",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-contextmenu/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-0e17d6"
+version := "2.13.0-850de1"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
+  "org.scalablytyped" %%% "react" % "16.9.2-0196b6",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-contextmenu/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-3dae0d"
+version := "2.13.0-fa66bd"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-7b2586",
+  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-contextmenu/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-fa66bd"
+version := "2.13.0-0e17d6"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
+  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-dropzone/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-2e9a9b"
+version := "10.1.10-8af0ec"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-7b2586",
+  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-dropzone/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-3d6748"
+version := "10.1.10-7ae171"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
+  "org.scalablytyped" %%% "react" % "16.9.2-0196b6",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-dropzone/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-8af0ec"
+version := "10.1.10-3d6748"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
+  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-select/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-9953ad"
+version := "0.0-unknown-4b01fa"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-7b2586",
+  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-select/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-1a5ed0"
+version := "0.0-unknown-042f1d"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
+  "org.scalablytyped" %%% "react" % "16.9.2-0196b6",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-select/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-4b01fa"
+version := "0.0-unknown-1a5ed0"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
+  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-02fc13"
+version := "16.9.2-f8eebf"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-japgolly/r/react/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-f8eebf"
+version := "16.9.2-0196b6"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-japgolly/r/react/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-7b2586"
+version := "16.9.2-02fc13"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
@@ -8,6 +8,7 @@ import japgolly.scalajs.react.vdom.TagMod
 import japgolly.scalajs.react.vdom.TagMod.Composite
 import japgolly.scalajs.react.vdom.VdomElement
 import japgolly.scalajs.react.vdom.VdomNode
+import typingsJapgolly.StBuildingComponent.make
 import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
@@ -30,6 +31,9 @@ trait StBuildingComponent[R <: js.Object] extends Any {
     js.Object.assign(args(1).asInstanceOf[js.Object], obj.asInstanceOf[js.Object])
     this
   }
+  /* You typically shouldnt call this yourself, but it can be useful if you're for instance mapping a sequence and you need types to infer properly */
+  @scala.inline
+  def build: VdomElement = make(this)
   @scala.inline
   def applyTagMod(t: TagMod): Unit = if (t.isInstanceOf[Composite]) {
     val tt = t.asInstanceOf[Composite]

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
@@ -3,6 +3,9 @@ package typingsJapgolly
 import japgolly.scalajs.react.Key
 import japgolly.scalajs.react.Ref.Simple
 import japgolly.scalajs.react.raw.React.Element
+import japgolly.scalajs.react.raw.React.Node
+import japgolly.scalajs.react.vdom.TagMod
+import japgolly.scalajs.react.vdom.TagMod.Composite
 import japgolly.scalajs.react.vdom.VdomElement
 import japgolly.scalajs.react.vdom.VdomNode
 import scala.scalajs.js
@@ -23,8 +26,23 @@ trait StBuildingComponent[R <: js.Object] extends Any {
     this
   }
   @scala.inline
-  def apply(mods: VdomNode*): this.type = {
-    mods.foreach((mod: VdomNode) => args.push(mod.rawNode.asInstanceOf[js.Any]))
+  def applyTagMod(t: TagMod): Unit = if (t.isInstanceOf[Composite]) {
+    val tt = t.asInstanceOf[Composite]
+    tt.mods.foreach(applyTagMod)
+  } else if (t.isInstanceOf[VdomNode]) {
+    val tt = t.asInstanceOf[VdomNode]
+    args.push(tt.rawNode.asInstanceOf[js.Any])
+  } else {
+    val tt = t.toJs
+    tt.addClassNameToProps()
+    tt.addKeyToProps()
+    tt.addStyleToProps()
+    tt.nonEmptyChildren.foreach((children: js.Array[Node]) => args.push(children))
+    tt.nonEmptyProps.foreach((props: js.Object) => js.Object.assign(args(1).asInstanceOf[js.Object], props))
+  }
+  @scala.inline
+  def apply(mods: TagMod*): this.type = {
+    mods.foreach(applyTagMod)
     this
   }
   @scala.inline

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
@@ -26,6 +26,11 @@ trait StBuildingComponent[R <: js.Object] extends Any {
     this
   }
   @scala.inline
+  def unsafeSpread(obj: js.Any): this.type = {
+    js.Object.assign(args(1).asInstanceOf[js.Object], obj.asInstanceOf[js.Object])
+    this
+  }
+  @scala.inline
   def applyTagMod(t: TagMod): Unit = if (t.isInstanceOf[Composite]) {
     val tt = t.asInstanceOf[Composite]
     tt.mods.foreach(applyTagMod)
@@ -38,7 +43,7 @@ trait StBuildingComponent[R <: js.Object] extends Any {
     tt.addKeyToProps()
     tt.addStyleToProps()
     tt.nonEmptyChildren.foreach((children: js.Array[Node]) => args.push(children))
-    tt.nonEmptyProps.foreach((props: js.Object) => js.Object.assign(args(1).asInstanceOf[js.Object], props))
+    tt.nonEmptyProps.foreach(unsafeSpread)
   }
   @scala.inline
   def apply(mods: TagMod*): this.type = {

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-d8ed64"
+version := "0.0-unknown-96ad54"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
+  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-96ad54"
+version := "0.0-unknown-3e41a7"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
+  "org.scalablytyped" %%% "react" % "16.9.2-0196b6",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-e20e55"
+version := "0.0-unknown-d8ed64"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-7b2586",
+  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-bc03aa"
+version := "0.38.0-c8c6f1"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
+  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-c8c6f1"
+version := "0.38.0-a1e2c1"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
+  "org.scalablytyped" %%% "react" % "16.9.2-0196b6",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-b2ce86"
+version := "0.38.0-bc03aa"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-7b2586",
+  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-49a86d"
+version := "0.38.0-258bb2"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
+  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-258bb2"
+version := "0.38.0-047ea3"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-f8eebf",
+  "org.scalablytyped" %%% "react" % "16.9.2-0196b6",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-cc743f"
+version := "0.38.0-49a86d"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-7b2586",
+  "org.scalablytyped" %%% "react" % "16.9.2-02fc13",
   "org.scalablytyped" %%% "std" % "0.0-unknown-99867a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-slinky/c/componentstest/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-0104bc"
+version := "0.0-unknown-ab29b4"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-fa0162",
+  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-slinky/c/componentstest/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-ab29b4"
+version := "0.0-unknown-269cfa"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
+  "org.scalablytyped" %%% "react" % "16.9.2-abc59e",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-bootstrap/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-4405dc"
+version := "0.32-f01240"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-fa0162",
+  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-bootstrap/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-f01240"
+version := "0.32-adf987"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
+  "org.scalablytyped" %%% "react" % "16.9.2-abc59e",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-contextmenu/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-40c8b5"
+version := "2.13.0-3ee974"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
+  "org.scalablytyped" %%% "react" % "16.9.2-abc59e",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-contextmenu/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-b69d99"
+version := "2.13.0-40c8b5"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-fa0162",
+  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-dropzone/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-e8db4f"
+version := "10.1.10-c97726"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
+  "org.scalablytyped" %%% "react" % "16.9.2-abc59e",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-dropzone/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-fcbb86"
+version := "10.1.10-e8db4f"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-fa0162",
+  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-select/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-4f08b5"
+version := "0.0-unknown-fa4b3b"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
+  "org.scalablytyped" %%% "react" % "16.9.2-abc59e",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-select/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-e4d484"
+version := "0.0-unknown-4f08b5"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-fa0162",
+  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/r/react/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-9d0176"
+version := "16.9.2-abc59e"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-slinky/r/react/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-fa0162"
+version := "16.9.2-9d0176"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/StBuildingComponent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/StBuildingComponent.scala
@@ -5,6 +5,7 @@ import slinky.core.OptionalAttrPair
 import slinky.core.TagMod
 import slinky.core.facade.ReactElement
 import slinky.core.facade.ReactRef
+import typingsSlinky.StBuildingComponent.make
 import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
@@ -22,6 +23,9 @@ trait StBuildingComponent[E, R <: js.Object] extends Any {
     args.update(0, f(args(0)))
     this
   }
+  /* You typically shouldnt call this yourself, but it can be useful if you're for instance mapping a sequence and you need types to infer properly */
+  @scala.inline
+  def build: ReactElement = make(this)
   @scala.inline
   def unsafeSpread(obj: js.Any): this.type = {
     js.Object.assign(args(1).asInstanceOf[js.Object], obj.asInstanceOf[js.Object])

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/StBuildingComponent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/StBuildingComponent.scala
@@ -23,6 +23,11 @@ trait StBuildingComponent[E, R <: js.Object] extends Any {
     this
   }
   @scala.inline
+  def unsafeSpread(obj: js.Any): this.type = {
+    js.Object.assign(args(1).asInstanceOf[js.Object], obj.asInstanceOf[js.Object])
+    this
+  }
+  @scala.inline
   def apply(mods: TagMod[E]*): this.type = {
     mods.foreach((mod: TagMod[E]) => if (mod.isInstanceOf[AttrPair[_]]) {
       val a = mod.asInstanceOf[AttrPair[_]]

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-b6df9d"
+version := "0.0-unknown-d066db"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-fa0162",
+  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-d066db"
+version := "0.0-unknown-d9b99b"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
+  "org.scalablytyped" %%% "react" % "16.9.2-abc59e",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-2d90fb"
+version := "0.38.0-ce8efb"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-fa0162",
+  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-ce8efb"
+version := "0.38.0-182451"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
+  "org.scalablytyped" %%% "react" % "16.9.2-abc59e",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-0e1d01"
+version := "0.38.0-757ab9"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-fa0162",
+  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-757ab9"
+version := "0.38.0-34506c"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "16.9.2-9d0176",
+  "org.scalablytyped" %%% "react" % "16.9.2-abc59e",
   "org.scalablytyped" %%% "std" % "0.0-unknown-6b0173")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-transition-group/check-japgolly/r/react-transition-group/build.sbt
+++ b/tests/react-transition-group/check-japgolly/r/react-transition-group/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-transition-group"
-version := "2.0-19431f"
+version := "2.0-34fde0"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-e421f6",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-ce5899",
   "org.scalablytyped" %%% "std" % "0.0-unknown-fed835")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-transition-group/check-japgolly/r/react-transition-group/build.sbt
+++ b/tests/react-transition-group/check-japgolly/r/react-transition-group/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-transition-group"
-version := "2.0-8f5e0c"
+version := "2.0-5d83fa"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-8a3777",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-1646ad",
   "org.scalablytyped" %%% "std" % "0.0-unknown-fed835")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-transition-group/check-japgolly/r/react-transition-group/build.sbt
+++ b/tests/react-transition-group/check-japgolly/r/react-transition-group/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-transition-group"
-version := "2.0-34fde0"
+version := "2.0-8f5e0c"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.0",
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-ce5899",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-8a3777",
   "org.scalablytyped" %%% "std" % "0.0-unknown-fed835")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-transition-group/check-japgolly/r/react/build.sbt
+++ b/tests/react-transition-group/check-japgolly/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-e421f6"
+version := "0.0-unknown-ce5899"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-transition-group/check-japgolly/r/react/build.sbt
+++ b/tests/react-transition-group/check-japgolly/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-ce5899"
+version := "0.0-unknown-8a3777"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-transition-group/check-japgolly/r/react/build.sbt
+++ b/tests/react-transition-group/check-japgolly/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-8a3777"
+version := "0.0-unknown-1646ad"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-transition-group/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
+++ b/tests/react-transition-group/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
@@ -8,6 +8,7 @@ import japgolly.scalajs.react.vdom.TagMod
 import japgolly.scalajs.react.vdom.TagMod.Composite
 import japgolly.scalajs.react.vdom.VdomElement
 import japgolly.scalajs.react.vdom.VdomNode
+import typingsJapgolly.StBuildingComponent.make
 import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
@@ -30,6 +31,9 @@ trait StBuildingComponent[R <: js.Object] extends Any {
     js.Object.assign(args(1).asInstanceOf[js.Object], obj.asInstanceOf[js.Object])
     this
   }
+  /* You typically shouldnt call this yourself, but it can be useful if you're for instance mapping a sequence and you need types to infer properly */
+  @scala.inline
+  def build: VdomElement = make(this)
   @scala.inline
   def applyTagMod(t: TagMod): Unit = if (t.isInstanceOf[Composite]) {
     val tt = t.asInstanceOf[Composite]

--- a/tests/react-transition-group/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
+++ b/tests/react-transition-group/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
@@ -3,6 +3,9 @@ package typingsJapgolly
 import japgolly.scalajs.react.Key
 import japgolly.scalajs.react.Ref.Simple
 import japgolly.scalajs.react.raw.React.Element
+import japgolly.scalajs.react.raw.React.Node
+import japgolly.scalajs.react.vdom.TagMod
+import japgolly.scalajs.react.vdom.TagMod.Composite
 import japgolly.scalajs.react.vdom.VdomElement
 import japgolly.scalajs.react.vdom.VdomNode
 import scala.scalajs.js
@@ -23,8 +26,23 @@ trait StBuildingComponent[R <: js.Object] extends Any {
     this
   }
   @scala.inline
-  def apply(mods: VdomNode*): this.type = {
-    mods.foreach((mod: VdomNode) => args.push(mod.rawNode.asInstanceOf[js.Any]))
+  def applyTagMod(t: TagMod): Unit = if (t.isInstanceOf[Composite]) {
+    val tt = t.asInstanceOf[Composite]
+    tt.mods.foreach(applyTagMod)
+  } else if (t.isInstanceOf[VdomNode]) {
+    val tt = t.asInstanceOf[VdomNode]
+    args.push(tt.rawNode.asInstanceOf[js.Any])
+  } else {
+    val tt = t.toJs
+    tt.addClassNameToProps()
+    tt.addKeyToProps()
+    tt.addStyleToProps()
+    tt.nonEmptyChildren.foreach((children: js.Array[Node]) => args.push(children))
+    tt.nonEmptyProps.foreach((props: js.Object) => js.Object.assign(args(1).asInstanceOf[js.Object], props))
+  }
+  @scala.inline
+  def apply(mods: TagMod*): this.type = {
+    mods.foreach(applyTagMod)
     this
   }
   @scala.inline

--- a/tests/react-transition-group/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
+++ b/tests/react-transition-group/check-japgolly/r/react/src/main/scala/typingsJapgolly/StBuildingComponent.scala
@@ -26,6 +26,11 @@ trait StBuildingComponent[R <: js.Object] extends Any {
     this
   }
   @scala.inline
+  def unsafeSpread(obj: js.Any): this.type = {
+    js.Object.assign(args(1).asInstanceOf[js.Object], obj.asInstanceOf[js.Object])
+    this
+  }
+  @scala.inline
   def applyTagMod(t: TagMod): Unit = if (t.isInstanceOf[Composite]) {
     val tt = t.asInstanceOf[Composite]
     tt.mods.foreach(applyTagMod)
@@ -38,7 +43,7 @@ trait StBuildingComponent[R <: js.Object] extends Any {
     tt.addKeyToProps()
     tt.addStyleToProps()
     tt.nonEmptyChildren.foreach((children: js.Array[Node]) => args.push(children))
-    tt.nonEmptyProps.foreach((props: js.Object) => js.Object.assign(args(1).asInstanceOf[js.Object], props))
+    tt.nonEmptyProps.foreach(unsafeSpread)
   }
   @scala.inline
   def apply(mods: TagMod*): this.type = {

--- a/tests/react-transition-group/check-slinky/r/react-transition-group/build.sbt
+++ b/tests/react-transition-group/check-slinky/r/react-transition-group/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-transition-group"
-version := "2.0-8a00fe"
+version := "2.0-1bbdb3"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-73ffbe",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-be67df",
   "org.scalablytyped" %%% "std" % "0.0-unknown-d216a0")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-transition-group/check-slinky/r/react-transition-group/build.sbt
+++ b/tests/react-transition-group/check-slinky/r/react-transition-group/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-transition-group"
-version := "2.0-9fdfaf"
+version := "2.0-8a00fe"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
   "me.shadaj" %%% "slinky-web" % "0.6.5",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-adeb40",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-73ffbe",
   "org.scalablytyped" %%% "std" % "0.0-unknown-d216a0")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-transition-group/check-slinky/r/react/build.sbt
+++ b/tests/react-transition-group/check-slinky/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-73ffbe"
+version := "0.0-unknown-be67df"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-transition-group/check-slinky/r/react/build.sbt
+++ b/tests/react-transition-group/check-slinky/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-adeb40"
+version := "0.0-unknown-73ffbe"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-transition-group/check-slinky/r/react/src/main/scala/typingsSlinky/StBuildingComponent.scala
+++ b/tests/react-transition-group/check-slinky/r/react/src/main/scala/typingsSlinky/StBuildingComponent.scala
@@ -5,6 +5,7 @@ import slinky.core.OptionalAttrPair
 import slinky.core.TagMod
 import slinky.core.facade.ReactElement
 import slinky.core.facade.ReactRef
+import typingsSlinky.StBuildingComponent.make
 import scala.scalajs.js
 import scala.scalajs.js.`|`
 import scala.scalajs.js.annotation._
@@ -22,6 +23,9 @@ trait StBuildingComponent[E, R <: js.Object] extends Any {
     args.update(0, f(args(0)))
     this
   }
+  /* You typically shouldnt call this yourself, but it can be useful if you're for instance mapping a sequence and you need types to infer properly */
+  @scala.inline
+  def build: ReactElement = make(this)
   @scala.inline
   def unsafeSpread(obj: js.Any): this.type = {
     js.Object.assign(args(1).asInstanceOf[js.Object], obj.asInstanceOf[js.Object])

--- a/tests/react-transition-group/check-slinky/r/react/src/main/scala/typingsSlinky/StBuildingComponent.scala
+++ b/tests/react-transition-group/check-slinky/r/react/src/main/scala/typingsSlinky/StBuildingComponent.scala
@@ -23,6 +23,11 @@ trait StBuildingComponent[E, R <: js.Object] extends Any {
     this
   }
   @scala.inline
+  def unsafeSpread(obj: js.Any): this.type = {
+    js.Object.assign(args(1).asInstanceOf[js.Object], obj.asInstanceOf[js.Object])
+    this
+  }
+  @scala.inline
   def apply(mods: TagMod[E]*): this.type = {
     mods.foreach((mod: TagMod[E]) => if (mod.isInstanceOf[AttrPair[_]]) {
       val a = mod.asInstanceOf[AttrPair[_]]


### PR DESCRIPTION
## Slinky and scalajs-react

### unsafeSpread

Some react libraries compute parts of props for you, and you're meant to spread them when you use them
```typescript
<button {...ctrl.getToggleButtonProps()} aria-label="toggle menu">toggle menu</button>
```

This is now supported for all generated components like this:

```scala
button.unsafeSpread(ctrl.getToggleButtonProps()).`aria-label`("toggle menu")("toggle menu")
```

It's called unsafe because it accepts `js.Any` and thus provides no compile time checks. The reason is simply that for a long time this operation was untyped in typescript, so a lot of usage is typed as `any`.

### Explicit `build` method

The builder pattern works through implicit conversions. This is all good, except for the cases when it doesn't work, for instance in sequences:

Builders are not completed, and the type will be `Seq[label.Builder]`:
```scala
val labels = (0 to 10).toSeq.map(n => label(n)) 
```

You could force completion with a type annotation
```scala
val labels: Seq[VdomNode] = (0 to 10).toSeq.map(n => label(n)) 
```

Now you also have this option of making the completion explicit
```scala
val labels = (0 to 10).toSeq.map(n => label(n).build)
```

## Scalajs-react

The `apply` method of the builders is now changed to accept `TagMod` instead of `VdomNode`, so it's more general. Before only varargs of `VdomNode` was accepted:
```scala
div(label("foo"), label("foo2"))
``` 
Now you can also use scalajs-react syntax for providing attributes and other things

```scala
div(label("foo", ^.className := "foo"))
div(TagMod.fromTraversableOnce(0 to 9 map (n => label(n))))