### PR TITLE
fix for inheritence with type intersection, basic type lookup support…

### DIFF
--- a/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterTest.scala
+++ b/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterTest.scala
@@ -57,6 +57,10 @@ class ImporterTest extends AnyFunSuite with ImporterHarness with ParallelTestExe
     assertImportsOk("material-ui", pedantic = true, update = update, flavour = Slinky),
   )
 
+  test("inheritance-with-intersection")(
+    assertImportsOk("inheritance-with-intersection-slinky", pedantic = true, update = update, flavour = Slinky),
+  )
+
   test("material-ui-japgolly")(
     assertImportsOk("material-ui", pedantic = true, update = update, flavour = Japgolly),
   )

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/Name.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/Name.scala
@@ -53,6 +53,7 @@ object Name {
   val CONSTRUCTOR:     Name = Name("<init>")
   val UNION:           Name = Name("<union>")
   val INTERSECTION:    Name = Name("<intersection>")
+  val TYPE_LOOKUP:     Name = Name("<type_lookup>")
   val SINGLETON:       Name = Name("<typeof>")
   val STRING_LITERAL:  Name = Name("<string_literal>")
   val NUMBER_LITERAL:  Name = Name("<number_literal>")

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/ParentsResolver.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/ParentsResolver.scala
@@ -90,35 +90,43 @@ object ParentsResolver {
       typeRefs:   List[TypeRef],
       ld:         LoopDetector,
       newTParams: IArray[TypeParamTree],
-  ): Res =
-    ld.including(typeRefs.head.typeName.parts, scope) match {
+  ): Res = {
+    val typeRef = typeRefs.head
+    ld.including(typeRef.typeName.parts, scope) match {
       case Left(()) =>
         Circular
       case Right(newLd) =>
-        (scope lookup typeRefs.head.typeName).collectFirst {
-          case (cls: ClassTree, foundInScope) =>
-            val rewritten = FillInTParams(cls, scope, typeRefs.head.targs, newTParams)
-            val (parents, unresolved, circular) =
-              findParentRefs(rewritten)
-                .map(tr => recurse(foundInScope, tr :: Nil, newLd, newTParams))
-                .partitionCollect2({ case x: Resolved => x }, { case u: Unresolved => u })
+        if(typeRef.name == Name.INTERSECTION) {
+          recurse(scope, typeRef.targs.toList, newLd, newTParams)
+        } else {
+          scope.lookup(typeRef.typeName)
+            .collectFirst {
+              case (cls: ClassTree, foundInScope) =>
+                val rewritten = FillInTParams(cls, scope, typeRef.targs, newTParams)
+                val (parents, unresolved, circular) =
+                  findParentRefs(rewritten)
+                    .map(tr => recurse(foundInScope, tr :: Nil, newLd, newTParams))
+                    .partitionCollect2({ case x: Resolved => x }, { case u: Unresolved => u })
 
-            if (circular.nonEmpty) Circular
-            else
-              Resolved(
-                Parent(IArray.fromTraversable(typeRefs))(
-                  rewritten,
-                  foundInScope,
-                  parents.map(_.nr),
-                  unresolved.flatMap(_.tr),
-                ),
-              )
+                if (circular.nonEmpty) Circular
+                else
+                  Resolved(
+                    Parent(IArray.fromTraversable(typeRefs))(
+                      rewritten,
+                      foundInScope,
+                      parents.map(_.nr),
+                      unresolved.flatMap(_.tr),
+                    ),
+                  )
 
-          case (ta: TypeAliasTree, foundInScope) =>
-            val rewritten = FillInTParams(ta, scope, typeRefs.head.targs, newTParams)
-            recurse(foundInScope, rewritten.alias :: typeRefs, newLd, newTParams)
-        } getOrElse Unresolved(IArray.fromTraversable(typeRefs))
-    }
+              case (ta: TypeAliasTree, foundInScope) =>
+                val rewritten = FillInTParams(ta, scope, typeRef.targs, newTParams)
+                recurse(foundInScope, rewritten.alias :: typeRefs, newLd, newTParams)
+            }.getOrElse(Unresolved(IArray.fromTraversable(typeRefs)))
+        }
+        }
+
+  }
 }
 
 class ParentsResolver {

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/Printer.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/Printer.scala
@@ -121,12 +121,12 @@ object Printer {
         case (ScalaOutput.File(name), members: IArray[Tree]) =>
           reg.write(targetFolder / os.RelPath(s"${name.unescaped}.scala")) { writer =>
             val (imports, shortenedMembers) = ShortenNames(tree, scope, parentsResolver)(members)
-            writer println s"package ${formatQN(QualifiedName(packages))}"
+            writer.println(s"package ${formatQN(QualifiedName(packages))}")
             writer.println("")
             imports.foreach(i => writer.println(s"import ${formatQN(i.imported)}"))
             writer.println(Imports)
             writer.println("")
-            shortenedMembers foreach printTree(
+            shortenedMembers.foreach(printTree(
               scope,
               parentsResolver,
               reg,
@@ -135,7 +135,7 @@ object Printer {
               targetFolder,
               0,
               isNative = true,
-            )
+            ))
           }
 
         case (ScalaOutput.Package(name), pkgs) =>
@@ -431,6 +431,9 @@ object Printer {
 
           case TypeRef.Repeated(underlying: TypeRef, _) =>
             maybeSpace(paramsIfNeeded(formatTypeRef(indent)(underlying))) + "*"
+
+          case TypeRef.TypeLookup(_, _) =>
+            formatQN(QualifiedName.Any)
 
           case TypeRef(typeName, targs, _) =>
             val targsStr = targs match {

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/QualifiedName.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/QualifiedName.scala
@@ -71,6 +71,7 @@ object QualifiedName {
   val TopLevel:                   QualifiedName = Runtime + Name("TopLevel")
   val UNION:                      QualifiedName = QualifiedName(IArray(Name.UNION))
   val INTERSECTION:               QualifiedName = QualifiedName(IArray(Name.INTERSECTION))
+  val TYPE_LOOKUP:                QualifiedName = QualifiedName(IArray(Name.TYPE_LOOKUP))
   val STRING_LITERAL:             QualifiedName = QualifiedName(IArray(Name.STRING_LITERAL))
   val NUMBER_LITERAL:             QualifiedName = QualifiedName(IArray(Name.NUMBER_LITERAL))
   val BOOLEAN_LITERAL:            QualifiedName = QualifiedName(IArray(Name.BOOLEAN_LITERAL))

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/transforms/CleanupTypeLookups.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/transforms/CleanupTypeLookups.scala
@@ -1,0 +1,15 @@
+package org.scalablytyped.converter.internal
+package scalajs
+package transforms
+
+object CleanupTypeLookups extends TreeTransformation {
+  override def leaveTypeRef(scope: TreeScope)(s: TypeRef): TypeRef = s match {
+    case TypeRef.TypeLookup(_, _) =>
+      TypeRef(QualifiedName.Any, Empty, Comments(Comment.warning("Type Lookup not supported")))
+    case other => other
+  }
+
+
+
+
+}

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/tree.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/tree.scala
@@ -341,6 +341,17 @@ object TypeRef {
       case _                              => TypeRef(QualifiedName.Tuple(typeParams.length), typeParams, NoComments)
     }
 
+  object TypeLookup {
+    def apply(from: Name, key: Name) =
+      TypeRef(QualifiedName.TYPE_LOOKUP, IArray(TypeRef(from), TypeRef(key)), NoComments)
+
+    def unapply(typeRef: TypeRef): Option[(TypeRef, Name)] = typeRef match {
+      case TypeRef(QualifiedName.TYPE_LOOKUP, IArray.exactlyTwo(from, TypeRef(QualifiedName(IArray.exactlyOne(key)), Empty, _)), _) =>
+        Some((from, key))
+      case _ => None
+    }
+  }
+
   object Intersection {
     private def flattened(types: IArray[TypeRef]): IArray[TypeRef] =
       types flatMap {

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/build.sbt
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/build.sbt
@@ -1,0 +1,14 @@
+organization := "org.scalablytyped"
+name := "inheritance-with-intersection"
+version := "0.0-unknown-/pshemass/Converter.git-19700101Z-508952"
+scalaVersion := "2.13.3"
+enablePlugins(ScalaJSPlugin)
+libraryDependencies ++= Seq(
+  "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
+  "me.shadaj" %%% "slinky-web" % "0.6.5",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-/pshemass/Converter.git-19700101Z-4554bc")
+publishArtifact in packageDoc := false
+scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")
+licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
+bintrayRepository := "ScalablyTyped"
+resolvers += Resolver.bintrayRepo("oyvindberg", "ScalablyTyped")

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/project/build.properties
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.10

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/project/plugins.sbt
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.1.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/readme.md
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/readme.md
@@ -1,0 +1,15 @@
+
+# Scala.js typings for inheritance-with-intersection
+
+
+
+
+## Note
+This library has been generated from typescript code from first party type definitions.
+
+Provided with :purple_heart: from [ScalablyTyped](https://github.com/oyvindberg/ScalablyTyped)
+
+## Usage
+See [the main readme](../../readme.md) for instructions.
+
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/anon/CenterRipple.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/anon/CenterRipple.scala
@@ -1,0 +1,36 @@
+package typingsSlinky.inheritanceWithIntersection.anon
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait CenterRipple extends js.Object {
+  var centerRipple: js.UndefOr[Boolean] = js.native
+}
+
+object CenterRipple {
+  @scala.inline
+  def apply(): CenterRipple = {
+    val __obj = js.Dynamic.literal()
+    __obj.asInstanceOf[CenterRipple]
+  }
+  @scala.inline
+  implicit class CenterRippleOps[Self <: CenterRipple] (val x: Self) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setCenterRipple(value: Boolean): Self = this.set("centerRipple", value.asInstanceOf[js.Any])
+    @scala.inline
+    def deleteCenterRipple: Self = this.set("centerRipple", js.undefined)
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/anon/Component.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/anon/Component.scala
@@ -1,0 +1,39 @@
+package typingsSlinky.inheritanceWithIntersection.anon
+
+import slinky.core.facade.ReactElement
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait Component[C /* <: ReactElement */] extends js.Object {
+  /**
+    * The component used for the root node.
+    * Either a string to use a HTML element or a component.
+    */
+  var component: C = js.native
+}
+
+object Component {
+  @scala.inline
+  def apply[/* <: typingsSlinky.react.mod.ElementType */ C](component: C): Component[C] = {
+    val __obj = js.Dynamic.literal(component = component.asInstanceOf[js.Any])
+    __obj.asInstanceOf[Component[C]]
+  }
+  @scala.inline
+  implicit class ComponentOps[Self <: Component[_], /* <: typingsSlinky.react.mod.ElementType */ C] (val x: Self with Component[C]) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setComponent(value: C): Self = this.set("component", value.asInstanceOf[js.Any])
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/anon/Disabled.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/anon/Disabled.scala
@@ -1,0 +1,39 @@
+package typingsSlinky.inheritanceWithIntersection.anon
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait Disabled extends js.Object {
+  /**
+    * If `true`, the button will be disabled.
+    */
+  var disabled: js.UndefOr[Boolean] = js.native
+}
+
+object Disabled {
+  @scala.inline
+  def apply(): Disabled = {
+    val __obj = js.Dynamic.literal()
+    __obj.asInstanceOf[Disabled]
+  }
+  @scala.inline
+  implicit class DisabledOps[Self <: Disabled] (val x: Self) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setDisabled(value: Boolean): Self = this.set("disabled", value.asInstanceOf[js.Any])
+    @scala.inline
+    def deleteDisabled: Self = this.set("disabled", js.undefined)
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/anon/Href.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/anon/Href.scala
@@ -1,0 +1,34 @@
+package typingsSlinky.inheritanceWithIntersection.anon
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait Href extends js.Object {
+  var href: String = js.native
+}
+
+object Href {
+  @scala.inline
+  def apply(href: String): Href = {
+    val __obj = js.Dynamic.literal(href = href.asInstanceOf[js.Any])
+    __obj.asInstanceOf[Href]
+  }
+  @scala.inline
+  implicit class HrefOps[Self <: Href] (val x: Self) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setHref(value: String): Self = this.set("href", value.asInstanceOf[js.Any])
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/anon/Props.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/anon/Props.scala
@@ -1,0 +1,34 @@
+package typingsSlinky.inheritanceWithIntersection.anon
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait Props[P] extends js.Object {
+  var props: P with Disabled = js.native
+}
+
+object Props {
+  @scala.inline
+  def apply[P](props: P with Disabled): Props[P] = {
+    val __obj = js.Dynamic.literal(props = props.asInstanceOf[js.Any])
+    __obj.asInstanceOf[Props[P]]
+  }
+  @scala.inline
+  implicit class PropsOps[Self <: Props[_], P] (val x: Self with Props[P]) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setProps(value: P with Disabled): Self = this.set("props", value.asInstanceOf[js.Any])
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/components/Button.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/components/Button.scala
@@ -1,0 +1,41 @@
+package typingsSlinky.inheritanceWithIntersection.components
+
+import slinky.web.html.`*`.tag
+import typingsSlinky.StBuildingComponent
+import typingsSlinky.inheritanceWithIntersection.anon.Href
+import typingsSlinky.inheritanceWithIntersection.inheritanceWithIntersectionStrings.a
+import typingsSlinky.inheritanceWithIntersection.inheritanceWithIntersectionStrings.button
+import typingsSlinky.inheritanceWithIntersection.mod.ButtonTypeMap
+import typingsSlinky.inheritanceWithIntersection.mod.ExtendButtonBaseTypeMap
+import typingsSlinky.inheritanceWithIntersection.mod.OverrideProps
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+object Button {
+  @JSImport("inheritance-with-intersection", "Button")
+  @js.native
+  object component extends js.Object
+  
+  @scala.inline
+  class Builder (val args: js.Array[js.Any])
+    extends AnyVal
+       with StBuildingComponent[tag.type, js.Object] {
+    @scala.inline
+    def a(value: String): this.type = set("a", value.asInstanceOf[js.Any])
+    @scala.inline
+    def b(value: String): this.type = set("b", value.asInstanceOf[js.Any])
+    @scala.inline
+    def disabled(value: Boolean): this.type = set("disabled", value.asInstanceOf[js.Any])
+  }
+  
+  def withProps(
+    p: /* props */ Href with (OverrideProps[ExtendButtonBaseTypeMap[ButtonTypeMap[js.Object, button]], a])
+  ): Builder = new Builder(js.Array(this.component, p.asInstanceOf[js.Any]))
+  @scala.inline
+  def apply(href: String): Builder = {
+    val __props = js.Dynamic.literal(href = href.asInstanceOf[js.Any])
+    new Builder(js.Array(this.component, __props.asInstanceOf[/* props */ Href with (OverrideProps[ExtendButtonBaseTypeMap[ButtonTypeMap[js.Object, button]], a])]))
+  }
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/inheritanceWithIntersectionRequire.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/inheritanceWithIntersectionRequire.scala
@@ -1,0 +1,12 @@
+package typingsSlinky.inheritanceWithIntersection
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+/* This can be used to `require` the library as a side effect.
+  If it is a global library this will make scalajs-bundler include it */
+@JSImport("inheritance-with-intersection", JSImport.Namespace)
+@js.native
+object inheritanceWithIntersectionRequire extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/inheritanceWithIntersectionStrings.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/inheritanceWithIntersectionStrings.scala
@@ -1,0 +1,19 @@
+package typingsSlinky.inheritanceWithIntersection
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+object inheritanceWithIntersectionStrings {
+  @js.native
+  sealed trait a extends js.Object
+  
+  @js.native
+  sealed trait button extends js.Object
+  
+  @scala.inline
+  def a: a = "a".asInstanceOf[a]
+  @scala.inline
+  def button: button = "button".asInstanceOf[button]
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/AProps.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/AProps.scala
@@ -1,0 +1,36 @@
+package typingsSlinky.inheritanceWithIntersection.mod
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait AProps extends js.Object {
+  var a: js.UndefOr[String] = js.native
+}
+
+object AProps {
+  @scala.inline
+  def apply(): AProps = {
+    val __obj = js.Dynamic.literal()
+    __obj.asInstanceOf[AProps]
+  }
+  @scala.inline
+  implicit class APropsOps[Self <: AProps] (val x: Self) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setA(value: String): Self = this.set("a", value.asInstanceOf[js.Any])
+    @scala.inline
+    def deleteA: Self = this.set("a", js.undefined)
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/BProps.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/BProps.scala
@@ -1,0 +1,36 @@
+package typingsSlinky.inheritanceWithIntersection.mod
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait BProps extends js.Object {
+  var b: js.UndefOr[String] = js.native
+}
+
+object BProps {
+  @scala.inline
+  def apply(): BProps = {
+    val __obj = js.Dynamic.literal()
+    __obj.asInstanceOf[BProps]
+  }
+  @scala.inline
+  implicit class BPropsOps[Self <: BProps] (val x: Self) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setB(value: String): Self = this.set("b", value.asInstanceOf[js.Any])
+    @scala.inline
+    def deleteB: Self = this.set("b", js.undefined)
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/Button.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/Button.scala
@@ -1,0 +1,13 @@
+package typingsSlinky.inheritanceWithIntersection.mod
+
+import org.scalablytyped.runtime.TopLevel
+import typingsSlinky.inheritanceWithIntersection.inheritanceWithIntersectionStrings.button
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@JSImport("inheritance-with-intersection", "Button")
+@js.native
+object Button
+  extends TopLevel[ExtendBase[ButtonTypeMap[js.Object, button]]]
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/ButtonBaseTypeMap.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/ButtonBaseTypeMap.scala
@@ -1,0 +1,39 @@
+package typingsSlinky.inheritanceWithIntersection.mod
+
+import slinky.core.facade.ReactElement
+import typingsSlinky.inheritanceWithIntersection.anon.CenterRipple
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait ButtonBaseTypeMap[P, D /* <: ReactElement */] extends js.Object {
+  var defaultComponent: D = js.native
+  var props: P with CenterRipple = js.native
+}
+
+object ButtonBaseTypeMap {
+  @scala.inline
+  def apply[P, /* <: typingsSlinky.react.mod.ElementType */ D](defaultComponent: D, props: P with CenterRipple): ButtonBaseTypeMap[P, D] = {
+    val __obj = js.Dynamic.literal(defaultComponent = defaultComponent.asInstanceOf[js.Any], props = props.asInstanceOf[js.Any])
+    __obj.asInstanceOf[ButtonBaseTypeMap[P, D]]
+  }
+  @scala.inline
+  implicit class ButtonBaseTypeMapOps[Self <: ButtonBaseTypeMap[_, _], P, /* <: typingsSlinky.react.mod.ElementType */ D] (val x: Self with (ButtonBaseTypeMap[P, D])) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setDefaultComponent(value: D): Self = this.set("defaultComponent", value.asInstanceOf[js.Any])
+    @scala.inline
+    def setProps(value: P with CenterRipple): Self = this.set("props", value.asInstanceOf[js.Any])
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/ExtendButtonBaseTypeMap.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/ExtendButtonBaseTypeMap.scala
@@ -1,0 +1,37 @@
+package typingsSlinky.inheritanceWithIntersection.mod
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait ExtendButtonBaseTypeMap[M /* <: OverridableTypeMap */] extends js.Object {
+  var defaultComponent: js.Any = js.native
+  var props: js.Any = js.native
+}
+
+object ExtendButtonBaseTypeMap {
+  @scala.inline
+  def apply[/* <: typingsSlinky.inheritanceWithIntersection.mod.OverridableTypeMap */ M](defaultComponent: js.Any, props: js.Any): ExtendButtonBaseTypeMap[M] = {
+    val __obj = js.Dynamic.literal(defaultComponent = defaultComponent.asInstanceOf[js.Any], props = props.asInstanceOf[js.Any])
+    __obj.asInstanceOf[ExtendButtonBaseTypeMap[M]]
+  }
+  @scala.inline
+  implicit class ExtendButtonBaseTypeMapOps[Self <: ExtendButtonBaseTypeMap[_], /* <: typingsSlinky.inheritanceWithIntersection.mod.OverridableTypeMap */ M] (val x: Self with ExtendButtonBaseTypeMap[M]) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setDefaultComponent(value: js.Any): Self = this.set("defaultComponent", value.asInstanceOf[js.Any])
+    @scala.inline
+    def setProps(value: js.Any): Self = this.set("props", value.asInstanceOf[js.Any])
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/OverridableComponent.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/OverridableComponent.scala
@@ -1,0 +1,14 @@
+package typingsSlinky.inheritanceWithIntersection.mod
+
+import slinky.core.facade.ReactElement
+import typingsSlinky.inheritanceWithIntersection.anon.Component
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait OverridableComponent extends js.Object {
+  def apply(props: AProps): ReactElement = js.native
+  def apply[C /* <: ReactElement */](props: Component[C]): ReactElement = js.native
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/OverridableTypeMap.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/OverridableTypeMap.scala
@@ -1,0 +1,35 @@
+package typingsSlinky.inheritanceWithIntersection.mod
+
+import slinky.core.facade.ReactElement
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait OverridableTypeMap extends js.Object {
+  var defaultComponent: ReactElement = js.native
+}
+
+object OverridableTypeMap {
+  @scala.inline
+  def apply(defaultComponent: ReactElement): OverridableTypeMap = {
+    val __obj = js.Dynamic.literal(defaultComponent = defaultComponent.asInstanceOf[js.Any])
+    __obj.asInstanceOf[OverridableTypeMap]
+  }
+  @scala.inline
+  implicit class OverridableTypeMapOps[Self <: OverridableTypeMap] (val x: Self) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setDefaultComponent(value: ReactElement): Self = this.set("defaultComponent", value.asInstanceOf[js.Any])
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/package.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/i/inheritance-with-intersection/src/main/scala/typingsSlinky/inheritanceWithIntersection/mod/package.scala
@@ -1,0 +1,18 @@
+package typingsSlinky.inheritanceWithIntersection
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+package object mod {
+  type BaseProps[M /* <: typingsSlinky.inheritanceWithIntersection.mod.OverridableTypeMap */] = js.Any with typingsSlinky.inheritanceWithIntersection.mod.BProps
+  type ButtonTypeMap[P, D /* <: slinky.core.facade.ReactElement */] = typingsSlinky.inheritanceWithIntersection.mod.ExtendButtonBaseTypeMap[typingsSlinky.inheritanceWithIntersection.anon.Props[P]]
+  type ExtendBase[M /* <: typingsSlinky.inheritanceWithIntersection.mod.OverridableTypeMap */] = (js.Function1[
+    /* props */ typingsSlinky.inheritanceWithIntersection.anon.Href with (typingsSlinky.inheritanceWithIntersection.mod.OverrideProps[
+      typingsSlinky.inheritanceWithIntersection.mod.ExtendButtonBaseTypeMap[M], 
+      typingsSlinky.inheritanceWithIntersection.inheritanceWithIntersectionStrings.a
+    ]), 
+    slinky.core.facade.ReactElement
+  ]) with typingsSlinky.inheritanceWithIntersection.mod.OverridableComponent
+  type OverrideProps[M /* <: typingsSlinky.inheritanceWithIntersection.mod.OverridableTypeMap */, C /* <: slinky.core.facade.ReactElement */] = typingsSlinky.inheritanceWithIntersection.mod.BaseProps[M] with typingsSlinky.inheritanceWithIntersection.mod.AProps
+}

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/build.sbt
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/build.sbt
@@ -1,0 +1,13 @@
+organization := "org.scalablytyped"
+name := "react"
+version := "0.0-unknown-/pshemass/Converter.git-19700101Z-4554bc"
+scalaVersion := "2.13.3"
+enablePlugins(ScalaJSPlugin)
+libraryDependencies ++= Seq(
+  "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
+  "me.shadaj" %%% "slinky-web" % "0.6.5")
+publishArtifact in packageDoc := false
+scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")
+licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
+bintrayRepository := "ScalablyTyped"
+resolvers += Resolver.bintrayRepo("oyvindberg", "ScalablyTyped")

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/project/build.properties
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.10

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/project/plugins.sbt
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.1.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/readme.md
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/readme.md
@@ -1,0 +1,15 @@
+
+# Scala.js typings for react
+
+
+
+
+## Note
+This library has been generated from typescript code from first party type definitions.
+
+Provided with :purple_heart: from [ScalablyTyped](https://github.com/oyvindberg/ScalablyTyped)
+
+## Usage
+See [the main readme](../../readme.md) for instructions.
+
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/StBuildingComponent.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/StBuildingComponent.scala
@@ -1,0 +1,77 @@
+package typingsSlinky
+
+import slinky.core.AttrPair
+import slinky.core.OptionalAttrPair
+import slinky.core.TagMod
+import slinky.core.facade.ReactElement
+import slinky.core.facade.ReactRef
+import typingsSlinky.StBuildingComponent.make
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+trait StBuildingComponent[E, R <: js.Object] extends Any {
+  @scala.inline
+  def args: js.Array[js.Any]
+  @scala.inline
+  def set(key: String, value: js.Any): this.type = {
+    args(1).asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+    this
+  }
+  @scala.inline
+  def withComponent(f: js.Any => js.Any): this.type = {
+    args.update(0, f(args(0)))
+    this
+  }
+  /* You typically shouldnt call this yourself, but it can be useful if you're for instance mapping a sequence and you need types to infer properly */
+  @scala.inline
+  def build: ReactElement = make(this)
+  @scala.inline
+  def unsafeSpread(obj: js.Any): this.type = {
+    js.Object.assign(args(1).asInstanceOf[js.Object], obj.asInstanceOf[js.Object])
+    this
+  }
+  @scala.inline
+  def apply(mods: TagMod[E]*): this.type = {
+    mods.foreach((mod: TagMod[E]) => if (mod.isInstanceOf[AttrPair[_]]) {
+      val a = mod.asInstanceOf[AttrPair[_]]
+      set(a.name, a.value)
+  } else if (mod.isInstanceOf[OptionalAttrPair[_]]) {
+      val o = mod.asInstanceOf[OptionalAttrPair[_]]
+      if (o.value.isDefined) set(o.name, o.value.get)
+  } else args.push(mod))
+    this
+  }
+  @scala.inline
+  def withKey(key: String): this.type = set("key", key)
+  @scala.inline
+  def withRef(ref: R => Unit): this.type = set("ref", ref)
+  @scala.inline
+  def withRef(ref: ReactRef[R]): this.type = set("ref", ref)
+}
+
+object StBuildingComponent {
+  @JSImport("react", JSImport.Namespace, "React")
+  @js.native
+  object ReactRaw
+    extends js.Object {
+    val createElement: js.Dynamic = js.native
+  }
+  
+  @scala.inline
+  implicit def make[E, R <: js.Object](comp: StBuildingComponent[_, _]): ReactElement = {
+    if (!scala.scalajs.runtime.linkingInfo.productionMode) {
+      if (comp.args(0) == null) throw new IllegalStateException("This component has already been built into a ReactElement, and cannot be reused")
+  }
+    val ret = (ReactRaw.createElement.applyDynamic("apply")(ReactRaw, comp.args)).asInstanceOf[ReactElement]
+    if (!scala.scalajs.runtime.linkingInfo.productionMode) {
+      comp.args.update(0, null)
+  }
+    ret
+  }
+  class Default[E, R <: js.Object] (val args: js.Array[js.Any])
+    extends AnyVal
+       with StBuildingComponent[E, R]
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/anon/Html.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/anon/Html.scala
@@ -1,0 +1,34 @@
+package typingsSlinky.react.anon
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait Html extends js.Object {
+  var __html: String = js.native
+}
+
+object Html {
+  @scala.inline
+  def apply(__html: String): Html = {
+    val __obj = js.Dynamic.literal(__html = __html.asInstanceOf[js.Any])
+    __obj.asInstanceOf[Html]
+  }
+  @scala.inline
+  implicit class HtmlOps[Self <: Html] (val x: Self) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def set__html(value: String): Self = this.set("__html", value.asInstanceOf[js.Any])
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/AllHTMLAttributes.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/AllHTMLAttributes.scala
@@ -1,0 +1,41 @@
+package typingsSlinky.react.mod
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait AllHTMLAttributes[T] extends HTMLAttributes[T] {
+  var accept: js.UndefOr[String] = js.native
+  var acceptCharset: js.UndefOr[String] = js.native
+}
+
+object AllHTMLAttributes {
+  @scala.inline
+  def apply[T](): AllHTMLAttributes[T] = {
+    val __obj = js.Dynamic.literal()
+    __obj.asInstanceOf[AllHTMLAttributes[T]]
+  }
+  @scala.inline
+  implicit class AllHTMLAttributesOps[Self <: AllHTMLAttributes[_], T] (val x: Self with AllHTMLAttributes[T]) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setAccept(value: String): Self = this.set("accept", value.asInstanceOf[js.Any])
+    @scala.inline
+    def deleteAccept: Self = this.set("accept", js.undefined)
+    @scala.inline
+    def setAcceptCharset(value: String): Self = this.set("acceptCharset", value.asInstanceOf[js.Any])
+    @scala.inline
+    def deleteAcceptCharset: Self = this.set("acceptCharset", js.undefined)
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DOMAttributes.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DOMAttributes.scala
@@ -1,0 +1,49 @@
+package typingsSlinky.react.mod
+
+import typingsSlinky.react.anon.Html
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait DOMAttributes[T] extends js.Object {
+  var children: js.UndefOr[slinky.core.facade.ReactElement] = js.native
+  var dangerouslySetInnerHTML: js.UndefOr[Html] = js.native
+  var onClick: js.UndefOr[Double | (js.Function1[/* x */ String, Unit])] = js.native
+}
+
+object DOMAttributes {
+  @scala.inline
+  def apply[T](): DOMAttributes[T] = {
+    val __obj = js.Dynamic.literal()
+    __obj.asInstanceOf[DOMAttributes[T]]
+  }
+  @scala.inline
+  implicit class DOMAttributesOps[Self <: DOMAttributes[_], T] (val x: Self with DOMAttributes[T]) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setChildren(value: slinky.core.facade.ReactElement): Self = this.set("children", value.asInstanceOf[js.Any])
+    @scala.inline
+    def deleteChildren: Self = this.set("children", js.undefined)
+    @scala.inline
+    def setDangerouslySetInnerHTML(value: Html): Self = this.set("dangerouslySetInnerHTML", value.asInstanceOf[js.Any])
+    @scala.inline
+    def deleteDangerouslySetInnerHTML: Self = this.set("dangerouslySetInnerHTML", js.undefined)
+    @scala.inline
+    def setOnClickFunction1(value: /* x */ String => Unit): Self = this.set("onClick", js.Any.fromFunction1(value))
+    @scala.inline
+    def setOnClick(value: Double | (js.Function1[/* x */ String, Unit])): Self = this.set("onClick", value.asInstanceOf[js.Any])
+    @scala.inline
+    def deleteOnClick: Self = this.set("onClick", js.undefined)
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ElementType.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ElementType.scala
@@ -1,0 +1,9 @@
+package typingsSlinky.react.mod
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait ElementType extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/HTMLAttributes.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/HTMLAttributes.scala
@@ -1,0 +1,36 @@
+package typingsSlinky.react.mod
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait HTMLAttributes[T] extends DOMAttributes[T] {
+  var defaultChecked: js.UndefOr[Boolean] = js.native
+}
+
+object HTMLAttributes {
+  @scala.inline
+  def apply[T](): HTMLAttributes[T] = {
+    val __obj = js.Dynamic.literal()
+    __obj.asInstanceOf[HTMLAttributes[T]]
+  }
+  @scala.inline
+  implicit class HTMLAttributesOps[Self <: HTMLAttributes[_], T] (val x: Self with HTMLAttributes[T]) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setDefaultChecked(value: Boolean): Self = this.set("defaultChecked", value.asInstanceOf[js.Any])
+    @scala.inline
+    def deleteDefaultChecked: Self = this.set("defaultChecked", js.undefined)
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/HTMLProps.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/HTMLProps.scala
@@ -1,0 +1,45 @@
+package typingsSlinky.react.mod
+
+import typingsSlinky.react.reactStrings.foo
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait HTMLProps[T] extends AllHTMLAttributes[T] {
+  var defaultValue: foo = js.native
+  var onChange: foo = js.native
+  var `type`: foo = js.native
+  var value: foo = js.native
+}
+
+object HTMLProps {
+  @scala.inline
+  def apply[T](defaultValue: foo, onChange: foo, `type`: foo, value: foo): HTMLProps[T] = {
+    val __obj = js.Dynamic.literal(defaultValue = defaultValue.asInstanceOf[js.Any], onChange = onChange.asInstanceOf[js.Any], value = value.asInstanceOf[js.Any])
+    __obj.updateDynamic("type")(`type`.asInstanceOf[js.Any])
+    __obj.asInstanceOf[HTMLProps[T]]
+  }
+  @scala.inline
+  implicit class HTMLPropsOps[Self <: HTMLProps[_], T] (val x: Self with HTMLProps[T]) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setDefaultValue(value: foo): Self = this.set("defaultValue", value.asInstanceOf[js.Any])
+    @scala.inline
+    def setOnChange(value: foo): Self = this.set("onChange", value.asInstanceOf[js.Any])
+    @scala.inline
+    def setType(value: foo): Self = this.set("type", value.asInstanceOf[js.Any])
+    @scala.inline
+    def setValue(value: foo): Self = this.set("value", value.asInstanceOf[js.Any])
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactElement.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactElement.scala
@@ -1,0 +1,9 @@
+package typingsSlinky.react.mod
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait ReactElement extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/global.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/global.scala
@@ -1,0 +1,16 @@
+package typingsSlinky.react.mod
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@JSGlobalScope
+@js.native
+object global extends js.Object {
+  @js.native
+  object JSX extends js.Object {
+    type Element = slinky.core.facade.ReactElement
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/package.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/package.scala
@@ -1,0 +1,10 @@
+package typingsSlinky.react
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+package object mod {
+  type ReactNode = js.UndefOr[java.lang.String | scala.Double | scala.Boolean]
+  type SVGAttributes[T] = typingsSlinky.react.mod.DOMAttributes[T]
+}

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/reactRequire.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/reactRequire.scala
@@ -1,0 +1,12 @@
+package typingsSlinky.react
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+/* This can be used to `require` the library as a side effect.
+  If it is a global library this will make scalajs-bundler include it */
+@JSImport("react", JSImport.Namespace)
+@js.native
+object reactRequire extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/reactStrings.scala
+++ b/tests/inheritance-with-intersection-slinky/check-slinky/r/react/src/main/scala/typingsSlinky/react/reactStrings.scala
@@ -1,0 +1,14 @@
+package typingsSlinky.react
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+object reactStrings {
+  @js.native
+  sealed trait foo extends js.Object
+  
+  @scala.inline
+  def foo: foo = "foo".asInstanceOf[foo]
+}
+

--- a/tests/inheritance-with-intersection-slinky/check/s/std/build.sbt
+++ b/tests/inheritance-with-intersection-slinky/check/s/std/build.sbt
@@ -1,0 +1,12 @@
+organization := "org.scalablytyped"
+name := "std"
+version := "0.0-unknown-d0eaba"
+scalaVersion := "2.13.3"
+enablePlugins(ScalaJSPlugin)
+libraryDependencies ++= Seq(
+  "com.olvind" %%% "scalablytyped-runtime" % "2.1.0")
+publishArtifact in packageDoc := false
+scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")
+licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
+bintrayRepository := "ScalablyTyped"
+resolvers += Resolver.bintrayRepo("oyvindberg", "ScalablyTyped")

--- a/tests/inheritance-with-intersection-slinky/check/s/std/project/build.properties
+++ b/tests/inheritance-with-intersection-slinky/check/s/std/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.10

--- a/tests/inheritance-with-intersection-slinky/check/s/std/project/plugins.sbt
+++ b/tests/inheritance-with-intersection-slinky/check/s/std/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.1.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")

--- a/tests/inheritance-with-intersection-slinky/check/s/std/readme.md
+++ b/tests/inheritance-with-intersection-slinky/check/s/std/readme.md
@@ -1,0 +1,15 @@
+
+# Scala.js typings for std
+
+
+
+
+## Note
+This library has been generated from typescript code from first party type definitions.
+
+Provided with :purple_heart: from [ScalablyTyped](https://github.com/oyvindberg/ScalablyTyped)
+
+## Usage
+See [the main readme](../../readme.md) for instructions.
+
+

--- a/tests/inheritance-with-intersection-slinky/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/inheritance-with-intersection-slinky/check/s/std/src/main/scala/typings/std/Array.scala
@@ -1,0 +1,9 @@
+package typings.std
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait Array[T] extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check/s/std/src/main/scala/typings/std/HTMLInputElement.scala
+++ b/tests/inheritance-with-intersection-slinky/check/s/std/src/main/scala/typings/std/HTMLInputElement.scala
@@ -1,0 +1,9 @@
+package typings.std
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait HTMLInputElement extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check/s/std/src/main/scala/typings/std/TwoFoo.scala
+++ b/tests/inheritance-with-intersection-slinky/check/s/std/src/main/scala/typings/std/TwoFoo.scala
@@ -1,0 +1,35 @@
+package typings.std
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+/* let's pretend */
+@js.native
+trait TwoFoo[Foo1, Foo2] extends js.Object {
+  var value: Foo1 = js.native
+}
+
+object TwoFoo {
+  @scala.inline
+  def apply[Foo1, Foo2](value: Foo1): TwoFoo[Foo1, Foo2] = {
+    val __obj = js.Dynamic.literal(value = value.asInstanceOf[js.Any])
+    __obj.asInstanceOf[TwoFoo[Foo1, Foo2]]
+  }
+  @scala.inline
+  implicit class TwoFooOps[Self <: TwoFoo[_, _], Foo1, Foo2] (val x: Self with (TwoFoo[Foo1, Foo2])) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setValue(value: Foo1): Self = this.set("value", value.asInstanceOf[js.Any])
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check/s/std/src/main/scala/typings/std/stdRequire.scala
+++ b/tests/inheritance-with-intersection-slinky/check/s/std/src/main/scala/typings/std/stdRequire.scala
@@ -1,0 +1,12 @@
+package typings.std
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+/* This can be used to `require` the library as a side effect.
+  If it is a global library this will make scalajs-bundler include it */
+@JSImport("std", JSImport.Namespace)
+@js.native
+object stdRequire extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/build.sbt
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/build.sbt
@@ -1,0 +1,13 @@
+organization := "org.scalablytyped"
+name := "union-to-inheritance"
+version := "0.0-unknown-ac769e"
+scalaVersion := "2.13.3"
+enablePlugins(ScalaJSPlugin)
+libraryDependencies ++= Seq(
+  "com.olvind" %%% "scalablytyped-runtime" % "2.1.0",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d0eaba")
+publishArtifact in packageDoc := false
+scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")
+licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
+bintrayRepository := "ScalablyTyped"
+resolvers += Resolver.bintrayRepo("oyvindberg", "ScalablyTyped")

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/project/build.properties
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.10

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/project/plugins.sbt
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.1.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/readme.md
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/readme.md
@@ -1,0 +1,15 @@
+
+# Scala.js typings for union-to-inheritance
+
+
+
+
+## Note
+This library has been generated from typescript code from first party type definitions.
+
+Provided with :purple_heart: from [ScalablyTyped](https://github.com/oyvindberg/ScalablyTyped)
+
+## Usage
+See [the main readme](../../readme.md) for instructions.
+
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Either.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Either.scala
@@ -1,0 +1,37 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait Either[L, R]
+  extends Legal3[js.Any, L, R]
+     with _Test[js.Any, L, R]
+     with _Test2[R, L] {
+  var value: R = js.native
+}
+
+object Either {
+  @scala.inline
+  def apply[L, R](value: R): Either[L, R] = {
+    val __obj = js.Dynamic.literal(value = value.asInstanceOf[js.Any])
+    __obj.asInstanceOf[Either[L, R]]
+  }
+  @scala.inline
+  implicit class EitherOps[Self <: Either[_, _], L, R] (val x: Self with (Either[L, R])) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setValue(value: R): Self = this.set("value", value.asInstanceOf[js.Any])
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Foo.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Foo.scala
@@ -1,0 +1,37 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait Foo[U]
+  extends Legal1[U]
+     with Legal2[U, js.Any]
+     with Legal3[js.Any, js.Any, U] {
+  var value: U = js.native
+}
+
+object Foo {
+  @scala.inline
+  def apply[U](value: U): Foo[U] = {
+    val __obj = js.Dynamic.literal(value = value.asInstanceOf[js.Any])
+    __obj.asInstanceOf[Foo[U]]
+  }
+  @scala.inline
+  implicit class FooOps[Self <: Foo[_], U] (val x: Self with Foo[U]) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setValue(value: U): Self = this.set("value", value.asInstanceOf[js.Any])
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Foo2.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Foo2.scala
@@ -1,0 +1,40 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+@js.native
+trait Foo2[U, V]
+  extends Legal2[V, U]
+     with Legal3[U, js.Any, V]
+     with _Test[U, js.Any, V] {
+  var u: U = js.native
+  var v: V = js.native
+}
+
+object Foo2 {
+  @scala.inline
+  def apply[U, V](u: U, v: V): Foo2[U, V] = {
+    val __obj = js.Dynamic.literal(u = u.asInstanceOf[js.Any], v = v.asInstanceOf[js.Any])
+    __obj.asInstanceOf[Foo2[U, V]]
+  }
+  @scala.inline
+  implicit class Foo2Ops[Self <: Foo2[_, _], U, V] (val x: Self with (Foo2[U, V])) extends AnyVal {
+    @scala.inline
+    def duplicate: Self = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x)).asInstanceOf[Self]
+    @scala.inline
+    def combineWith[Other <: js.Any](other: Other): Self with Other = (js.Dynamic.global.Object.assign(js.Dynamic.literal(), x, other.asInstanceOf[js.Any])).asInstanceOf[Self with Other]
+    @scala.inline
+    def set(key: String, value: js.Any): Self = {
+        x.asInstanceOf[js.Dynamic].updateDynamic(key)(value)
+        x
+    }
+    @scala.inline
+    def setU(value: U): Self = this.set("u", value.asInstanceOf[js.Any])
+    @scala.inline
+    def setV(value: V): Self = this.set("v", value.asInstanceOf[js.Any])
+  }
+  
+}
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Legal1.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Legal1.scala
@@ -1,0 +1,14 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+/* Rewritten from type alias, can be one of: 
+  - typings.unionToInheritance.unionToInheritanceStrings.foo
+  - typings.unionToInheritance.unionToInheritanceStrings.bar
+  - typings.unionToInheritance.Foo[T]
+*/
+trait Legal1[T]
+  extends _Test2[js.Any, T]
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Legal2.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Legal2.scala
@@ -1,0 +1,14 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+/* Rewritten from type alias, can be one of: 
+  - typings.unionToInheritance.unionToInheritanceStrings.foo
+  - typings.unionToInheritance.unionToInheritanceStrings.bar
+  - typings.unionToInheritance.Foo[P]
+  - typings.unionToInheritance.Foo2[T, P]
+*/
+trait Legal2[P, T] extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Legal3.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Legal3.scala
@@ -1,0 +1,15 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+/* Rewritten from type alias, can be one of: 
+  - typings.unionToInheritance.unionToInheritanceStrings.foo
+  - typings.unionToInheritance.unionToInheritanceStrings.bar
+  - typings.unionToInheritance.Foo[T3]
+  - typings.unionToInheritance.Either[T2, T3]
+  - typings.unionToInheritance.Foo2[T1, T3]
+*/
+trait Legal3[T1, T2, T3] extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_A.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_A.scala
@@ -1,0 +1,8 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+trait _A extends _B
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_B.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_B.scala
@@ -1,0 +1,8 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+trait _B extends _C
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_C.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_C.scala
@@ -1,0 +1,8 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+trait _C extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_Illegal1.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_Illegal1.scala
@@ -1,0 +1,8 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+trait _Illegal1 extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_Illegal2.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_Illegal2.scala
@@ -1,0 +1,8 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+trait _Illegal2 extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_Illegal3.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_Illegal3.scala
@@ -1,0 +1,8 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+trait _Illegal3[T] extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_Test.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_Test.scala
@@ -1,0 +1,8 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+trait _Test[T1, T2, T3] extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_Test2.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/_Test2.scala
@@ -1,0 +1,8 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+trait _Test2[O1, O2] extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/package.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/package.scala
@@ -1,0 +1,61 @@
+package typings
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+package object unionToInheritance {
+  /* Rewritten from type alias, can be one of: 
+    - typings.unionToInheritance.unionToInheritanceStrings.a1
+    - typings.unionToInheritance.unionToInheritanceStrings.a2
+    - java.lang.String
+  */
+  type A = typings.unionToInheritance._A | java.lang.String
+  /* Rewritten from type alias, can be one of: 
+    - typings.unionToInheritance.unionToInheritanceStrings.b1
+    - typings.unionToInheritance.unionToInheritanceStrings.b2
+    - scala.Double
+    - typings.unionToInheritance.A
+  */
+  type B = typings.unionToInheritance._B | scala.Double | java.lang.String
+  /* Rewritten from type alias, can be one of: 
+    - typings.unionToInheritance.unionToInheritanceNumbers.`1`
+    - typings.unionToInheritance.unionToInheritanceNumbers.`2`
+    - typings.std.HTMLInputElement
+    - js.Array[typings.unionToInheritance.B]
+    - typings.unionToInheritance.B
+  */
+  type C = typings.unionToInheritance._C | js.Array[typings.unionToInheritance.B] | typings.std.HTMLInputElement | scala.Double | java.lang.String
+  /* Rewritten from type alias, can be one of: 
+    - typings.unionToInheritance.unionToInheritanceStrings.foo
+    - typings.unionToInheritance.unionToInheritanceStrings.bar
+    - typings.unionToInheritance.Foo[java.lang.String]
+  */
+  type Illegal1 = typings.unionToInheritance._Illegal1 | typings.unionToInheritance.Foo[java.lang.String]
+  /* Rewritten from type alias, can be one of: 
+    - typings.unionToInheritance.unionToInheritanceStrings.foo
+    - typings.unionToInheritance.unionToInheritanceStrings.bar
+    - typings.unionToInheritance.Foo[typings.unionToInheritance.A]
+  */
+  type Illegal2 = typings.unionToInheritance._Illegal2 | typings.unionToInheritance.Foo[typings.unionToInheritance.A]
+  /* Rewritten from type alias, can be one of: 
+    - typings.unionToInheritance.unionToInheritanceStrings.foo
+    - typings.unionToInheritance.unionToInheritanceStrings.bar
+    - typings.unionToInheritance.Foo2[T, T]
+  */
+  type Illegal3[T] = typings.unionToInheritance._Illegal3[T] | (typings.unionToInheritance.Foo2[T, T])
+  /* Rewritten from type alias, can be one of: 
+    - typings.unionToInheritance.unionToInheritanceStrings.foo
+    - typings.unionToInheritance.unionToInheritanceStrings.bar
+    - typings.std.TwoFoo[T3, T1]
+    - typings.unionToInheritance.Either[T2, T3]
+    - typings.unionToInheritance.Foo2[T1, T3]
+  */
+  type Test[T1, T2, T3] = (typings.unionToInheritance._Test[T1, T2, T3]) | (typings.std.TwoFoo[T3, T1])
+  /* Rewritten from type alias, can be one of: 
+    - typings.unionToInheritance.Test[O1, O1, O2]
+    - typings.unionToInheritance.Either[O2, O1]
+    - typings.unionToInheritance.Legal1[O2]
+  */
+  type Test2[O1, O2] = (typings.unionToInheritance._Test2[O1, O2]) | (typings.unionToInheritance.Test[O1, O1, O2])
+}

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/unionToInheritanceNumbers.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/unionToInheritanceNumbers.scala
@@ -1,0 +1,19 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+object unionToInheritanceNumbers {
+  @js.native
+  sealed trait `1` extends _C
+  
+  @js.native
+  sealed trait `2` extends _C
+  
+  @scala.inline
+  def `1`: `1` = 1.asInstanceOf[`1`]
+  @scala.inline
+  def `2`: `2` = 2.asInstanceOf[`2`]
+}
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/unionToInheritanceRequire.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/unionToInheritanceRequire.scala
@@ -1,0 +1,12 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+/* This can be used to `require` the library as a side effect.
+  If it is a global library this will make scalajs-bundler include it */
+@JSImport("union-to-inheritance", JSImport.Namespace)
+@js.native
+object unionToInheritanceRequire extends js.Object
+

--- a/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/unionToInheritanceStrings.scala
+++ b/tests/inheritance-with-intersection-slinky/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/unionToInheritanceStrings.scala
@@ -1,0 +1,53 @@
+package typings.unionToInheritance
+
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation._
+
+object unionToInheritanceStrings {
+  @js.native
+  sealed trait a1 extends _A
+  
+  @js.native
+  sealed trait a2 extends _A
+  
+  @js.native
+  sealed trait b1 extends _B
+  
+  @js.native
+  sealed trait b2 extends _B
+  
+  @js.native
+  sealed trait bar
+    extends Legal1[js.Any]
+       with Legal2[js.Any, js.Any]
+       with Legal3[js.Any, js.Any, js.Any]
+       with _Illegal1
+       with _Illegal2
+       with _Illegal3[js.Any]
+       with _Test[js.Any, js.Any, js.Any]
+  
+  @js.native
+  sealed trait foo
+    extends Legal1[js.Any]
+       with Legal2[js.Any, js.Any]
+       with Legal3[js.Any, js.Any, js.Any]
+       with _Illegal1
+       with _Illegal2
+       with _Illegal3[js.Any]
+       with _Test[js.Any, js.Any, js.Any]
+  
+  @scala.inline
+  def a1: a1 = "a1".asInstanceOf[a1]
+  @scala.inline
+  def a2: a2 = "a2".asInstanceOf[a2]
+  @scala.inline
+  def b1: b1 = "b1".asInstanceOf[b1]
+  @scala.inline
+  def b2: b2 = "b2".asInstanceOf[b2]
+  @scala.inline
+  def bar: bar = "bar".asInstanceOf[bar]
+  @scala.inline
+  def foo: foo = "foo".asInstanceOf[foo]
+}
+

--- a/tests/inheritance-with-intersection-slinky/in/inheritance-with-intersection/index.d.ts
+++ b/tests/inheritance-with-intersection-slinky/in/inheritance-with-intersection/index.d.ts
@@ -1,0 +1,73 @@
+import * as React from "react";
+
+export interface AProps {
+  a?: string
+}
+
+export interface BProps {
+  b?: string
+}
+
+export interface OverridableComponent {
+  <C extends React.ElementType>(
+    props: {
+      /**
+       * The component used for the root node.
+       * Either a string to use a HTML element or a component.
+       */
+      component: C;
+    }
+  ): JSX.Element;
+  (props: AProps): JSX.Element;
+}
+
+export type BaseProps<M extends OverridableTypeMap> =
+  & M['props']
+  & BProps
+
+
+export interface OverridableTypeMap {
+  props: {};
+  defaultComponent: React.ElementType;
+}
+
+export type OverrideProps<
+  M extends OverridableTypeMap,
+  C extends React.ElementType
+> = (
+  & BaseProps<M>
+  & AProps
+);
+
+export interface ExtendButtonBaseTypeMap<M extends OverridableTypeMap> {
+  props: M['props'] ;
+  defaultComponent: M['defaultComponent'];
+}
+
+export interface ButtonBaseTypeMap<P = {}, D extends React.ElementType = 'button'> {
+  props: P & {
+    centerRipple?: boolean;
+  };
+  defaultComponent: D;
+}
+
+
+
+export type ExtendBase<M extends OverridableTypeMap> = ((
+  props: { href: string } & OverrideProps<ExtendButtonBaseTypeMap<M>, 'a'>
+) => JSX.Element) &
+  OverridableComponent;
+
+export type ButtonTypeMap<
+  P = {},
+  D extends React.ElementType = 'button'
+> = ExtendButtonBaseTypeMap<{
+  props: P & {
+    /**
+     * If `true`, the button will be disabled.
+     */
+    disabled?: boolean;
+}}>;
+
+
+declare const Button: ExtendBase<ButtonTypeMap>;

--- a/tests/inheritance-with-intersection-slinky/in/react/index.d.ts
+++ b/tests/inheritance-with-intersection-slinky/in/react/index.d.ts
@@ -1,0 +1,42 @@
+export = React;
+export as namespace React;
+
+declare namespace React {
+    interface ReactElement {}
+    interface ElementType {}
+
+    type ReactNode = string | number | boolean | null | undefined;
+
+    interface DOMAttributes<T> {
+            children?: ReactNode;
+            onClick?: number | ((x: string) => void);
+            dangerouslySetInnerHTML?: {
+                __html: string;
+            };
+        }
+
+        interface HTMLAttributes<T> extends DOMAttributes<T> {
+            defaultChecked?: boolean;
+        }
+
+        interface AllHTMLAttributes<T> extends HTMLAttributes<T> {
+            accept?: string;
+            acceptCharset?: string;
+        }
+
+        interface HTMLProps<T> extends AllHTMLAttributes<T>{
+            onChange: "foo"
+            defaultValue: "foo"
+            type: "foo"
+            value: "foo"
+        }
+
+        interface SVGAttributes<T> extends DOMAttributes<T> {
+        }
+}
+
+declare global {
+    namespace JSX {
+        interface Element extends React.ReactElement<any, any> { }
+    }
+}

--- a/tests/inheritance-with-intersection-slinky/in/stdlib.d.ts
+++ b/tests/inheritance-with-intersection-slinky/in/stdlib.d.ts
@@ -1,0 +1,13 @@
+interface HTMLInputElement {
+
+}
+interface Array<T> {
+
+}
+
+/* let's pretend */
+interface TwoFoo<Foo1, Foo2> {
+    value: Foo1
+}
+
+


### PR DESCRIPTION
First of all I want to say that the model that was build here to represent Typescript and operations on it like Rewrites, FollowAliases are really powerful. 

This PR is result of of my investigation why `Button` and `IconButton` are not parsed correctly in 4.x of `material-ui`. 
It seems that the problem is with inheritance with intersection type. 

```
export type ExtendBase<M extends OverridableTypeMap> = ((
  props: { href: string } & OverrideProps<ExtendButtonBaseTypeMap<M>, 'a'> // <-- here we have type alias to intersection
) => JSX.Element) &
  OverridableComponent;

declare const Button: ExtendBase<ButtonTypeMap>;
```

another problem that I found was support for field type lookup that is pretty difficult to express in scala. I added some trick to resolve issue with missing props in Slinky components but I don't know if that is good enough.

```
export interface ExtendButtonBaseTypeMap<M extends OverridableTypeMap> {
  props: M['props'] ; // type of field with name "props" in type M
  defaultComponent: M['defaultComponent'];
}
```