### PR TITLE
More usage of js.Dynamic instead of `@js.native` def/vars

### DIFF
--- a/tests/aws-sdk/check/a/aws-sdk/build.sbt
+++ b/tests/aws-sdk/check/a/aws-sdk/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "aws-sdk"
-version := "2.247.1-6008f9"
+version := "2.247.1-6e15c2"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsSdk/allMod.scala
+++ b/tests/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsSdk/allMod.scala
@@ -26,12 +26,14 @@ object allMod {
     /* static members */
     object Converter {
       
-      @JSImport("aws-sdk/clients/all", "DynamoDB.Converter.input")
+      @JSImport("aws-sdk/clients/all", "DynamoDB.Converter")
       @js.native
-      def input(data: js.Any): AttributeValue = js.native
-      @JSImport("aws-sdk/clients/all", "DynamoDB.Converter.input")
-      @js.native
-      def input(data: js.Any, options: ConverterOptions): AttributeValue = js.native
+      val ^ : js.Any = js.native
+      
+      @scala.inline
+      def input(data: js.Any): AttributeValue = ^.asInstanceOf[js.Dynamic].applyDynamic("input")(data.asInstanceOf[js.Any]).asInstanceOf[AttributeValue]
+      @scala.inline
+      def input(data: js.Any, options: ConverterOptions): AttributeValue = (^.asInstanceOf[js.Dynamic].applyDynamic("input")(data.asInstanceOf[js.Any], options.asInstanceOf[js.Any])).asInstanceOf[AttributeValue]
     }
     
     @JSImport("aws-sdk/clients/all", "DynamoDB.DocumentClient")

--- a/tests/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsSdk/converterMod.scala
+++ b/tests/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsSdk/converterMod.scala
@@ -14,12 +14,14 @@ object converterMod {
   /* static members */
   object Converter {
     
-    @JSImport("aws-sdk/lib/dynamodb/converter", "Converter.input")
+    @JSImport("aws-sdk/lib/dynamodb/converter", "Converter")
     @js.native
-    def input(data: js.Any): AttributeValue = js.native
-    @JSImport("aws-sdk/lib/dynamodb/converter", "Converter.input")
-    @js.native
-    def input(data: js.Any, options: ConverterOptions): AttributeValue = js.native
+    val ^ : js.Any = js.native
+    
+    @scala.inline
+    def input(data: js.Any): AttributeValue = ^.asInstanceOf[js.Dynamic].applyDynamic("input")(data.asInstanceOf[js.Any]).asInstanceOf[AttributeValue]
+    @scala.inline
+    def input(data: js.Any, options: ConverterOptions): AttributeValue = (^.asInstanceOf[js.Dynamic].applyDynamic("input")(data.asInstanceOf[js.Any], options.asInstanceOf[js.Any])).asInstanceOf[AttributeValue]
     
     type ConverterOptions = typings.awsSdk.documentClientMod.DocumentClient.ConverterOptions
   }

--- a/tests/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsSdk/dynamodbMod.scala
+++ b/tests/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsSdk/dynamodbMod.scala
@@ -24,12 +24,14 @@ object dynamodbMod {
   /* static members */
   object Converter {
     
-    @JSImport("aws-sdk/clients/dynamodb", "Converter.input")
+    @JSImport("aws-sdk/clients/dynamodb", "Converter")
     @js.native
-    def input(data: js.Any): AttributeValue = js.native
-    @JSImport("aws-sdk/clients/dynamodb", "Converter.input")
-    @js.native
-    def input(data: js.Any, options: ConverterOptions): AttributeValue = js.native
+    val ^ : js.Any = js.native
+    
+    @scala.inline
+    def input(data: js.Any): AttributeValue = ^.asInstanceOf[js.Dynamic].applyDynamic("input")(data.asInstanceOf[js.Any]).asInstanceOf[AttributeValue]
+    @scala.inline
+    def input(data: js.Any, options: ConverterOptions): AttributeValue = (^.asInstanceOf[js.Dynamic].applyDynamic("input")(data.asInstanceOf[js.Any], options.asInstanceOf[js.Any])).asInstanceOf[AttributeValue]
   }
   
   @JSImport("aws-sdk/clients/dynamodb", "DocumentClient")

--- a/tests/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsSdk/mod.scala
+++ b/tests/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsSdk/mod.scala
@@ -27,12 +27,14 @@ object mod {
     /* static members */
     object Converter {
       
-      @JSImport("aws-sdk", "DynamoDB.Converter.input")
+      @JSImport("aws-sdk", "DynamoDB.Converter")
       @js.native
-      def input(data: js.Any): AttributeValue = js.native
-      @JSImport("aws-sdk", "DynamoDB.Converter.input")
-      @js.native
-      def input(data: js.Any, options: ConverterOptions): AttributeValue = js.native
+      val ^ : js.Any = js.native
+      
+      @scala.inline
+      def input(data: js.Any): AttributeValue = ^.asInstanceOf[js.Dynamic].applyDynamic("input")(data.asInstanceOf[js.Any]).asInstanceOf[AttributeValue]
+      @scala.inline
+      def input(data: js.Any, options: ConverterOptions): AttributeValue = (^.asInstanceOf[js.Dynamic].applyDynamic("input")(data.asInstanceOf[js.Any], options.asInstanceOf[js.Any])).asInstanceOf[AttributeValue]
     }
     
     @JSImport("aws-sdk", "DynamoDB.DocumentClient")

--- a/tests/bigint/check/b/bigint/build.sbt
+++ b/tests/bigint/check/b/bigint/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "bigint"
-version := "v5.5.3-98f6ae"
+version := "v5.5.3-831f00"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/bigint/check/b/bigint/src/main/scala/typings/bigint/global.scala
+++ b/tests/bigint/check/b/bigint/src/main/scala/typings/bigint/global.scala
@@ -10,12 +10,14 @@ object global {
   
   object BigInt {
     
-    @JSGlobal("BigInt.add")
+    @JSGlobal("BigInt")
     @js.native
-    def add(x: typings.bigint.BigInt.BigInt, y: typings.bigint.BigInt.BigInt): typings.bigint.BigInt.BigInt = js.native
+    val ^ : js.Any = js.native
     
-    @JSGlobal("BigInt.setRandom")
-    @js.native
-    def setRandom(random: IRandom): Unit = js.native
+    @scala.inline
+    def add(x: typings.bigint.BigInt.BigInt, y: typings.bigint.BigInt.BigInt): typings.bigint.BigInt.BigInt = (^.asInstanceOf[js.Dynamic].applyDynamic("add")(x.asInstanceOf[js.Any], y.asInstanceOf[js.Any])).asInstanceOf[typings.bigint.BigInt.BigInt]
+    
+    @scala.inline
+    def setRandom(random: IRandom): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("setRandom")(random.asInstanceOf[js.Any]).asInstanceOf[Unit]
   }
 }

--- a/tests/const-enum/check/c/const-enum/build.sbt
+++ b/tests/const-enum/check/c/const-enum/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "const-enum"
-version := "0.0-unknown-aa01e5"
+version := "0.0-unknown-adfe26"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/const-enum/check/c/const-enum/src/main/scala/typings/constEnum/mod.scala
+++ b/tests/const-enum/check/c/const-enum/src/main/scala/typings/constEnum/mod.scala
@@ -15,20 +15,21 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
-  @JSImport("const-enum", "bar")
+  @JSImport("const-enum", JSImport.Namespace)
   @js.native
-  def bar(x: Foo_): `22` = js.native
+  val ^ : js.Any = js.native
   
-  @JSImport("const-enum", "foo2")
-  @js.native
-  def foo2(x: Foo2_): Double = js.native
+  @scala.inline
+  def bar(x: Foo_): `22` = ^.asInstanceOf[js.Dynamic].applyDynamic("bar")(x.asInstanceOf[js.Any]).asInstanceOf[`22`]
   
-  @JSImport("const-enum", "foo")
-  @js.native
-  def foo_1(x: `1`): Double = js.native
-  @JSImport("const-enum", "foo")
-  @js.native
-  def foo_C(x: C): Double = js.native
+  @scala.inline
+  def foo2(x: Foo2_): Double = ^.asInstanceOf[js.Dynamic].applyDynamic("foo2")(x.asInstanceOf[js.Any]).asInstanceOf[Double]
+  
+  @scala.inline
+  def foo_1(x: `1`): Double = ^.asInstanceOf[js.Dynamic].applyDynamic("foo")(x.asInstanceOf[js.Any]).asInstanceOf[Double]
+  
+  @scala.inline
+  def foo_C(x: C): Double = ^.asInstanceOf[js.Dynamic].applyDynamic("foo")(x.asInstanceOf[js.Any]).asInstanceOf[Double]
   
   /* Rewritten from type alias, can be one of: 
     - typings.constEnum.constEnumNumbers.`0`

--- a/tests/create-error/check/c/create-error/build.sbt
+++ b/tests/create-error/check/c/create-error/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "create-error"
-version := "0.3.1-a31f67"
+version := "0.3.1-adc505"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/create-error/check/c/create-error/src/main/scala/typings/createError/mod.scala
+++ b/tests/create-error/check/c/create-error/src/main/scala/typings/createError/mod.scala
@@ -10,27 +10,24 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
+  @scala.inline
+  def apply(): Error[Error[Err]] = ^.asInstanceOf[js.Dynamic].apply().asInstanceOf[Error[Error[Err]]]
+  @scala.inline
+  def apply[T /* <: Error[Error[Err]] */](Target: Error[Error[Err]]): T = ^.asInstanceOf[js.Dynamic].apply(Target.asInstanceOf[js.Any]).asInstanceOf[T]
+  @scala.inline
+  def apply[T /* <: Error[Error[Err]] */](Target: Error[Error[Err]], name: js.UndefOr[scala.Nothing], properties: js.Any): T = (^.asInstanceOf[js.Dynamic].apply(Target.asInstanceOf[js.Any], name.asInstanceOf[js.Any], properties.asInstanceOf[js.Any])).asInstanceOf[T]
+  @scala.inline
+  def apply[T /* <: Error[Error[Err]] */](Target: Error[Error[Err]], name: String): T = (^.asInstanceOf[js.Dynamic].apply(Target.asInstanceOf[js.Any], name.asInstanceOf[js.Any])).asInstanceOf[T]
+  @scala.inline
+  def apply[T /* <: Error[Error[Err]] */](Target: Error[Error[Err]], name: String, properties: js.Any): T = (^.asInstanceOf[js.Dynamic].apply(Target.asInstanceOf[js.Any], name.asInstanceOf[js.Any], properties.asInstanceOf[js.Any])).asInstanceOf[T]
+  @scala.inline
+  def apply[T /* <: Error[Error[Err]] */](name: String): T = ^.asInstanceOf[js.Dynamic].apply(name.asInstanceOf[js.Any]).asInstanceOf[T]
+  @scala.inline
+  def apply[T /* <: Error[Error[Err]] */](name: String, properties: js.Any): T = (^.asInstanceOf[js.Dynamic].apply(name.asInstanceOf[js.Any], properties.asInstanceOf[js.Any])).asInstanceOf[T]
+  
   @JSImport("create-error", JSImport.Namespace)
   @js.native
-  def apply(): Error[Error[Err]] = js.native
-  @JSImport("create-error", JSImport.Namespace)
-  @js.native
-  def apply[T /* <: Error[Error[Err]] */](Target: Error[Error[Err]]): T = js.native
-  @JSImport("create-error", JSImport.Namespace)
-  @js.native
-  def apply[T /* <: Error[Error[Err]] */](Target: Error[Error[Err]], name: js.UndefOr[scala.Nothing], properties: js.Any): T = js.native
-  @JSImport("create-error", JSImport.Namespace)
-  @js.native
-  def apply[T /* <: Error[Error[Err]] */](Target: Error[Error[Err]], name: String): T = js.native
-  @JSImport("create-error", JSImport.Namespace)
-  @js.native
-  def apply[T /* <: Error[Error[Err]] */](Target: Error[Error[Err]], name: String, properties: js.Any): T = js.native
-  @JSImport("create-error", JSImport.Namespace)
-  @js.native
-  def apply[T /* <: Error[Error[Err]] */](name: String): T = js.native
-  @JSImport("create-error", JSImport.Namespace)
-  @js.native
-  def apply[T /* <: Error[Error[Err]] */](name: String, properties: js.Any): T = js.native
+  val ^ : js.Any = js.native
   
   type Err = typings.std.Error
   

--- a/tests/defaulted-tparams/check/d/defaulted-tparams/build.sbt
+++ b/tests/defaulted-tparams/check/d/defaulted-tparams/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "defaulted-tparams"
-version := "0.0-unknown-2b3cd7"
+version := "0.0-unknown-227cf9"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/defaulted-tparams/check/d/defaulted-tparams/src/main/scala/typings/defaultedTparams/global.scala
+++ b/tests/defaulted-tparams/check/d/defaulted-tparams/src/main/scala/typings/defaultedTparams/global.scala
@@ -14,12 +14,14 @@ object global {
     extends typings.defaultedTparams.Queue[S, T]
   object Queue {
     
+    @JSGlobal("Queue")
+    @js.native
+    val ^ : js.Any = js.native
+    
     /* static member */
-    @JSGlobal("Queue.from")
-    @js.native
-    def from[T](iterable: Iterable[T]): typings.defaultedTparams.Queue[T, T] = js.native
-    @JSGlobal("Queue.from")
-    @js.native
-    def from[T](iterable: Iterable[T], length: Double): typings.defaultedTparams.Queue[T, T] = js.native
+    @scala.inline
+    def from[T](iterable: Iterable[T]): typings.defaultedTparams.Queue[T, T] = ^.asInstanceOf[js.Dynamic].applyDynamic("from")(iterable.asInstanceOf[js.Any]).asInstanceOf[typings.defaultedTparams.Queue[T, T]]
+    @scala.inline
+    def from[T](iterable: Iterable[T], length: Double): typings.defaultedTparams.Queue[T, T] = (^.asInstanceOf[js.Dynamic].applyDynamic("from")(iterable.asInstanceOf[js.Any], length.asInstanceOf[js.Any])).asInstanceOf[typings.defaultedTparams.Queue[T, T]]
   }
 }

--- a/tests/firebase-admin/check/f/firebase-admin/build.sbt
+++ b/tests/firebase-admin/check/f/firebase-admin/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "firebase-admin"
-version := "8.2.0-00d5b1"
+version := "8.2.0-dbc343"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/firebase-admin/check/f/firebase-admin/src/main/scala/typings/firebaseAdmin/mod.scala
+++ b/tests/firebase-admin/check/f/firebase-admin/src/main/scala/typings/firebaseAdmin/mod.scala
@@ -10,12 +10,14 @@ object mod {
   
   object firestore {
     
+    @scala.inline
+    def apply(): Firestore = ^.asInstanceOf[js.Dynamic].applyDynamic("firestore")().asInstanceOf[Firestore]
+    @scala.inline
+    def apply(str: String): Firestore = ^.asInstanceOf[js.Dynamic].applyDynamic("firestore")(str.asInstanceOf[js.Any]).asInstanceOf[Firestore]
+    
     @JSImport("firebase-admin", "firestore")
     @js.native
-    def apply(): Firestore = js.native
-    @JSImport("firebase-admin", "firestore")
-    @js.native
-    def apply(str: String): Firestore = js.native
+    val ^ : js.Any = js.native
     
     @JSImport("firebase-admin", "firestore.Firestore")
     @js.native

--- a/tests/fp-ts/check/f/fp-ts/build.sbt
+++ b/tests/fp-ts/check/f/fp-ts/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "fp-ts"
-version := "1.2.0-666455"
+version := "1.2.0-678dc1"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/fp-ts/check/f/fp-ts/src/main/scala/typings/fpTs/mod.scala
+++ b/tests/fp-ts/check/f/fp-ts/src/main/scala/typings/fpTs/mod.scala
@@ -17,8 +17,11 @@ object mod {
   
   object task {
     
-    @JSImport("fp-ts", "task.tryCatch")
+    @JSImport("fp-ts", "task")
     @js.native
-    def tryCatch[L, A](f: js.Any, onrejected: js.Function1[/* reason */ js.Object, L]): Either[L, A] = js.native
+    val ^ : js.Any = js.native
+    
+    @scala.inline
+    def tryCatch[L, A](f: js.Any, onrejected: js.Function1[/* reason */ js.Object, L]): Either[L, A] = (^.asInstanceOf[js.Dynamic].applyDynamic("tryCatch")(f.asInstanceOf[js.Any], onrejected.asInstanceOf[js.Any])).asInstanceOf[Either[L, A]]
   }
 }

--- a/tests/fp-ts/check/f/fp-ts/src/main/scala/typings/fpTs/taskMod.scala
+++ b/tests/fp-ts/check/f/fp-ts/src/main/scala/typings/fpTs/taskMod.scala
@@ -8,7 +8,10 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object taskMod {
   
-  @JSImport("fp-ts/lib/Task", "tryCatch")
+  @JSImport("fp-ts/lib/Task", JSImport.Namespace)
   @js.native
-  def tryCatch[L, A](f: js.Any, onrejected: js.Function1[/* reason */ js.Object, L]): Either[L, A] = js.native
+  val ^ : js.Any = js.native
+  
+  @scala.inline
+  def tryCatch[L, A](f: js.Any, onrejected: js.Function1[/* reason */ js.Object, L]): Either[L, A] = (^.asInstanceOf[js.Dynamic].applyDynamic("tryCatch")(f.asInstanceOf[js.Any], onrejected.asInstanceOf[js.Any])).asInstanceOf[Either[L, A]]
 }

--- a/tests/fullcalendar/check/f/fullcalendar/build.sbt
+++ b/tests/fullcalendar/check/f/fullcalendar/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "fullcalendar"
-version := "0.0-unknown-dbc4db"
+version := "0.0-unknown-0c462d"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/fullcalendar/check/f/fullcalendar/src/main/scala/typings/fullcalendar/mixinMod.scala
+++ b/tests/fullcalendar/check/f/fullcalendar/src/main/scala/typings/fullcalendar/mixinMod.scala
@@ -13,13 +13,15 @@ object mixinMod {
   /* static members */
   object default {
     
-    @JSImport("fullcalendar/Mixin", "default.mixInto")
+    @JSImport("fullcalendar/Mixin", JSImport.Default)
     @js.native
-    def mixInto(destClass: js.Any): Unit = js.native
+    val ^ : js.Any = js.native
     
-    @JSImport("fullcalendar/Mixin", "default.mixOver")
-    @js.native
-    def mixOver(destClass: js.Any): Unit = js.native
+    @scala.inline
+    def mixInto(destClass: js.Any): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("mixInto")(destClass.asInstanceOf[js.Any]).asInstanceOf[Unit]
+    
+    @scala.inline
+    def mixOver(destClass: js.Any): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("mixOver")(destClass.asInstanceOf[js.Any]).asInstanceOf[Unit]
   }
   
   @JSImport("fullcalendar/Mixin", "Default")
@@ -28,12 +30,14 @@ object mixinMod {
   /* static members */
   object Default_ {
     
-    @JSImport("fullcalendar/Mixin", "Default.mixInto")
+    @JSImport("fullcalendar/Mixin", "Default")
     @js.native
-    def mixInto(destClass: js.Any): Unit = js.native
+    val ^ : js.Any = js.native
     
-    @JSImport("fullcalendar/Mixin", "Default.mixOver")
-    @js.native
-    def mixOver(destClass: js.Any): Unit = js.native
+    @scala.inline
+    def mixInto(destClass: js.Any): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("mixInto")(destClass.asInstanceOf[js.Any]).asInstanceOf[Unit]
+    
+    @scala.inline
+    def mixOver(destClass: js.Any): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("mixOver")(destClass.asInstanceOf[js.Any]).asInstanceOf[Unit]
   }
 }

--- a/tests/keyof/check/k/keyof/build.sbt
+++ b/tests/keyof/check/k/keyof/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "keyof"
-version := "0.0-unknown-1d4d71"
+version := "0.0-unknown-e6bd2a"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/keyof/check/k/keyof/src/main/scala/typings/keyof/global.scala
+++ b/tests/keyof/check/k/keyof/src/main/scala/typings/keyof/global.scala
@@ -16,8 +16,11 @@ object global {
   
   object C {
     
-    @JSGlobal("C.bar")
+    @JSGlobal("C")
     @js.native
-    def bar(p: /* keyof keyof.anon.PickAcb */ c | b): String = js.native
+    val ^ : js.Any = js.native
+    
+    @scala.inline
+    def bar(p: /* keyof keyof.anon.PickAcb */ c | b): String = ^.asInstanceOf[js.Dynamic].applyDynamic("bar")(p.asInstanceOf[js.Any]).asInstanceOf[String]
   }
 }

--- a/tests/material-ui/check-japgolly/m/material-ui/build.sbt
+++ b/tests/material-ui/check-japgolly/m/material-ui/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "material-ui"
-version := "0.0-unknown-0b2d6d"
+version := "0.0-unknown-28d847"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/material-ui/check-japgolly/m/material-ui/src/main/scala/typingsJapgolly/materialUi/global.scala
+++ b/tests/material-ui/check-japgolly/m/material-ui/src/main/scala/typingsJapgolly/materialUi/global.scala
@@ -44,9 +44,8 @@ object global {
       @scala.inline
       def a_=(x: js.Any): Unit = ^.asInstanceOf[js.Dynamic].updateDynamic("a")(x.asInstanceOf[js.Any])
       
-      @JSGlobal("__MaterialUI.Styles.getMuiTheme")
-      @js.native
-      def getMuiTheme(muiTheme: MuiTheme*): MuiTheme = js.native
+      @scala.inline
+      def getMuiTheme(muiTheme: MuiTheme*): MuiTheme = ^.asInstanceOf[js.Dynamic].applyDynamic("getMuiTheme")(muiTheme.asInstanceOf[js.Any]).asInstanceOf[MuiTheme]
       
       @JSGlobal("__MaterialUI.Styles.zIndex")
       @js.native

--- a/tests/material-ui/check-japgolly/m/material-ui/src/main/scala/typingsJapgolly/materialUi/mod.scala
+++ b/tests/material-ui/check-japgolly/m/material-ui/src/main/scala/typingsJapgolly/materialUi/mod.scala
@@ -12,9 +12,8 @@ object mod {
   @js.native
   val ^ : js.Any = js.native
   
-  @JSImport("material-ui/styles", "getMuiTheme")
-  @js.native
-  def getMuiTheme(muiTheme: MuiTheme*): MuiTheme = js.native
+  @scala.inline
+  def getMuiTheme(muiTheme: MuiTheme*): MuiTheme = ^.asInstanceOf[js.Dynamic].applyDynamic("getMuiTheme")(muiTheme.asInstanceOf[js.Any]).asInstanceOf[MuiTheme]
   
   @JSImport("material-ui/styles", "spacing")
   @js.native

--- a/tests/material-ui/check-slinky/m/material-ui/build.sbt
+++ b/tests/material-ui/check-slinky/m/material-ui/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "material-ui"
-version := "0.0-unknown-d9a0a8"
+version := "0.0-unknown-6d54e7"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/material-ui/check-slinky/m/material-ui/src/main/scala/typingsSlinky/materialUi/global.scala
+++ b/tests/material-ui/check-slinky/m/material-ui/src/main/scala/typingsSlinky/materialUi/global.scala
@@ -44,9 +44,8 @@ object global {
       @scala.inline
       def a_=(x: js.Any): Unit = ^.asInstanceOf[js.Dynamic].updateDynamic("a")(x.asInstanceOf[js.Any])
       
-      @JSGlobal("__MaterialUI.Styles.getMuiTheme")
-      @js.native
-      def getMuiTheme(muiTheme: MuiTheme*): MuiTheme = js.native
+      @scala.inline
+      def getMuiTheme(muiTheme: MuiTheme*): MuiTheme = ^.asInstanceOf[js.Dynamic].applyDynamic("getMuiTheme")(muiTheme.asInstanceOf[js.Any]).asInstanceOf[MuiTheme]
       
       @JSGlobal("__MaterialUI.Styles.zIndex")
       @js.native

--- a/tests/material-ui/check-slinky/m/material-ui/src/main/scala/typingsSlinky/materialUi/mod.scala
+++ b/tests/material-ui/check-slinky/m/material-ui/src/main/scala/typingsSlinky/materialUi/mod.scala
@@ -12,9 +12,8 @@ object mod {
   @js.native
   val ^ : js.Any = js.native
   
-  @JSImport("material-ui/styles", "getMuiTheme")
-  @js.native
-  def getMuiTheme(muiTheme: MuiTheme*): MuiTheme = js.native
+  @scala.inline
+  def getMuiTheme(muiTheme: MuiTheme*): MuiTheme = ^.asInstanceOf[js.Dynamic].applyDynamic("getMuiTheme")(muiTheme.asInstanceOf[js.Any]).asInstanceOf[MuiTheme]
   
   @JSImport("material-ui/styles", "spacing")
   @js.native

--- a/tests/monaco-editor/check/m/monaco-editor/build.sbt
+++ b/tests/monaco-editor/check/m/monaco-editor/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "monaco-editor"
-version := "0.0-unknown-7507d9"
+version := "0.0-unknown-3f755d"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/monaco-editor/check/m/monaco-editor/src/main/scala/typings/monacoEditor/global.scala
+++ b/tests/monaco-editor/check/m/monaco-editor/src/main/scala/typings/monacoEditor/global.scala
@@ -33,9 +33,12 @@ object global {
     /* static members */
     object Promise {
       
-      @JSGlobal("monaco.Promise.any")
+      @JSGlobal("monaco.Promise")
       @js.native
-      def any[T](promises: js.Array[T | js.Thenable[T]]): typings.monacoEditor.monaco.Promise[Key[T], _] = js.native
+      val ^ : js.Any = js.native
+      
+      @scala.inline
+      def any[T](promises: js.Array[T | js.Thenable[T]]): typings.monacoEditor.monaco.Promise[Key[T], _] = ^.asInstanceOf[js.Dynamic].applyDynamic("any")(promises.asInstanceOf[js.Any]).asInstanceOf[typings.monacoEditor.monaco.Promise[Key[T], _]]
     }
   }
 }

--- a/tests/mongoose-simple-random/check/m/mongoose-simple-random/build.sbt
+++ b/tests/mongoose-simple-random/check/m/mongoose-simple-random/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "mongoose-simple-random"
-version := "0.4-046b70"
+version := "0.4-24eafd"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/mongoose-simple-random/check/m/mongoose-simple-random/src/main/scala/typings/mongooseSimpleRandom/mod.scala
+++ b/tests/mongoose-simple-random/check/m/mongoose-simple-random/src/main/scala/typings/mongooseSimpleRandom/mod.scala
@@ -11,9 +11,12 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
+  @scala.inline
+  def apply(schema: Schema): Unit = ^.asInstanceOf[js.Dynamic].apply(schema.asInstanceOf[js.Any]).asInstanceOf[Unit]
+  
   @JSImport("mongoose-simple-random", JSImport.Namespace)
   @js.native
-  def apply(schema: Schema): Unit = js.native
+  val ^ : js.Any = js.native
   
   /* augmented module */
   object mongooseAugmentingMod {

--- a/tests/numjs/check/n/ndarray/build.sbt
+++ b/tests/numjs/check/n/ndarray/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "ndarray"
-version := "0.0-unknown-07cb28"
+version := "0.0-unknown-f02254"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/numjs/check/n/ndarray/src/main/scala/typings/ndarray/mod.scala
+++ b/tests/numjs/check/n/ndarray/src/main/scala/typings/ndarray/mod.scala
@@ -7,30 +7,26 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
+  @scala.inline
+  def apply[T](data: Data[T]): typings.ndarray.mod.ndarray[T] = ^.asInstanceOf[js.Dynamic].apply(data.asInstanceOf[js.Any]).asInstanceOf[typings.ndarray.mod.ndarray[T]]
+  @scala.inline
+  def apply[T](data: Data[T], shape: js.UndefOr[scala.Nothing], stride: js.UndefOr[scala.Nothing], offset: Double): typings.ndarray.mod.ndarray[T] = (^.asInstanceOf[js.Dynamic].apply(data.asInstanceOf[js.Any], shape.asInstanceOf[js.Any], stride.asInstanceOf[js.Any], offset.asInstanceOf[js.Any])).asInstanceOf[typings.ndarray.mod.ndarray[T]]
+  @scala.inline
+  def apply[T](data: Data[T], shape: js.UndefOr[scala.Nothing], stride: js.Array[Double]): typings.ndarray.mod.ndarray[T] = (^.asInstanceOf[js.Dynamic].apply(data.asInstanceOf[js.Any], shape.asInstanceOf[js.Any], stride.asInstanceOf[js.Any])).asInstanceOf[typings.ndarray.mod.ndarray[T]]
+  @scala.inline
+  def apply[T](data: Data[T], shape: js.UndefOr[scala.Nothing], stride: js.Array[Double], offset: Double): typings.ndarray.mod.ndarray[T] = (^.asInstanceOf[js.Dynamic].apply(data.asInstanceOf[js.Any], shape.asInstanceOf[js.Any], stride.asInstanceOf[js.Any], offset.asInstanceOf[js.Any])).asInstanceOf[typings.ndarray.mod.ndarray[T]]
+  @scala.inline
+  def apply[T](data: Data[T], shape: js.Array[Double]): typings.ndarray.mod.ndarray[T] = (^.asInstanceOf[js.Dynamic].apply(data.asInstanceOf[js.Any], shape.asInstanceOf[js.Any])).asInstanceOf[typings.ndarray.mod.ndarray[T]]
+  @scala.inline
+  def apply[T](data: Data[T], shape: js.Array[Double], stride: js.UndefOr[scala.Nothing], offset: Double): typings.ndarray.mod.ndarray[T] = (^.asInstanceOf[js.Dynamic].apply(data.asInstanceOf[js.Any], shape.asInstanceOf[js.Any], stride.asInstanceOf[js.Any], offset.asInstanceOf[js.Any])).asInstanceOf[typings.ndarray.mod.ndarray[T]]
+  @scala.inline
+  def apply[T](data: Data[T], shape: js.Array[Double], stride: js.Array[Double]): typings.ndarray.mod.ndarray[T] = (^.asInstanceOf[js.Dynamic].apply(data.asInstanceOf[js.Any], shape.asInstanceOf[js.Any], stride.asInstanceOf[js.Any])).asInstanceOf[typings.ndarray.mod.ndarray[T]]
+  @scala.inline
+  def apply[T](data: Data[T], shape: js.Array[Double], stride: js.Array[Double], offset: Double): typings.ndarray.mod.ndarray[T] = (^.asInstanceOf[js.Dynamic].apply(data.asInstanceOf[js.Any], shape.asInstanceOf[js.Any], stride.asInstanceOf[js.Any], offset.asInstanceOf[js.Any])).asInstanceOf[typings.ndarray.mod.ndarray[T]]
+  
   @JSImport("ndarray", JSImport.Namespace)
   @js.native
-  def apply[T](data: Data[T]): typings.ndarray.mod.ndarray[T] = js.native
-  @JSImport("ndarray", JSImport.Namespace)
-  @js.native
-  def apply[T](data: Data[T], shape: js.UndefOr[scala.Nothing], stride: js.UndefOr[scala.Nothing], offset: Double): typings.ndarray.mod.ndarray[T] = js.native
-  @JSImport("ndarray", JSImport.Namespace)
-  @js.native
-  def apply[T](data: Data[T], shape: js.UndefOr[scala.Nothing], stride: js.Array[Double]): typings.ndarray.mod.ndarray[T] = js.native
-  @JSImport("ndarray", JSImport.Namespace)
-  @js.native
-  def apply[T](data: Data[T], shape: js.UndefOr[scala.Nothing], stride: js.Array[Double], offset: Double): typings.ndarray.mod.ndarray[T] = js.native
-  @JSImport("ndarray", JSImport.Namespace)
-  @js.native
-  def apply[T](data: Data[T], shape: js.Array[Double]): typings.ndarray.mod.ndarray[T] = js.native
-  @JSImport("ndarray", JSImport.Namespace)
-  @js.native
-  def apply[T](data: Data[T], shape: js.Array[Double], stride: js.UndefOr[scala.Nothing], offset: Double): typings.ndarray.mod.ndarray[T] = js.native
-  @JSImport("ndarray", JSImport.Namespace)
-  @js.native
-  def apply[T](data: Data[T], shape: js.Array[Double], stride: js.Array[Double]): typings.ndarray.mod.ndarray[T] = js.native
-  @JSImport("ndarray", JSImport.Namespace)
-  @js.native
-  def apply[T](data: Data[T], shape: js.Array[Double], stride: js.Array[Double], offset: Double): typings.ndarray.mod.ndarray[T] = js.native
+  val ^ : js.Any = js.native
   
   type Data[T] = js.Array[T]
   

--- a/tests/numjs/check/n/numjs/build.sbt
+++ b/tests/numjs/check/n/numjs/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "numjs"
-version := "0.0-unknown-133306"
+version := "0.0-unknown-ad9540"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
-  "org.scalablytyped" %%% "ndarray" % "0.0-unknown-07cb28",
+  "org.scalablytyped" %%% "ndarray" % "0.0-unknown-f02254",
   "org.scalablytyped" %%% "std" % "0.0-unknown-e56105")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-japgolly/c/componentstest/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-829e1e"
+version := "0.0-unknown-b3aac1"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.5",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-c9d0c6",
+  "org.scalablytyped" %%% "react" % "16.9.2-5cfa3c",
   "org.scalablytyped" %%% "std" % "0.0-unknown-43ed0a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-bootstrap/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-170fe6"
+version := "0.32-a43133"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.5",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-c9d0c6",
+  "org.scalablytyped" %%% "react" % "16.9.2-5cfa3c",
   "org.scalablytyped" %%% "std" % "0.0-unknown-43ed0a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/bootstrapUtilsMod.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/bootstrapUtilsMod.scala
@@ -7,9 +7,12 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object bootstrapUtilsMod {
   
-  @JSImport("react-bootstrap/lib/utils/bootstrapUtils", "getBsProps")
+  @JSImport("react-bootstrap/lib/utils/bootstrapUtils", JSImport.Namespace)
   @js.native
-  def getBsProps(props: js.Any): BSProps = js.native
+  val ^ : js.Any = js.native
+  
+  @scala.inline
+  def getBsProps(props: js.Any): BSProps = ^.asInstanceOf[js.Dynamic].applyDynamic("getBsProps")(props.asInstanceOf[js.Any]).asInstanceOf[BSProps]
   
   @js.native
   trait BSProps extends StObject {

--- a/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/createChainedFunctionMod.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/createChainedFunctionMod.scala
@@ -7,7 +7,10 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object createChainedFunctionMod {
   
-  @JSImport("react-bootstrap/lib/utils/createChainedFunction", JSImport.Default)
+  @JSImport("react-bootstrap/lib/utils/createChainedFunction", JSImport.Namespace)
   @js.native
-  def default(funcs: js.Function*): js.Function = js.native
+  val ^ : js.Any = js.native
+  
+  @scala.inline
+  def default(funcs: js.Function*): js.Function = ^.asInstanceOf[js.Dynamic].applyDynamic("default")(funcs.asInstanceOf[js.Any]).asInstanceOf[js.Function]
 }

--- a/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/libMod.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/libMod.scala
@@ -20,15 +20,21 @@ object libMod {
   
   object utils {
     
+    @JSImport("react-bootstrap/lib", "utils")
+    @js.native
+    val ^ : js.Any = js.native
+    
     object bootstrapUtils {
       
-      @JSImport("react-bootstrap/lib", "utils.bootstrapUtils.getBsProps")
+      @JSImport("react-bootstrap/lib", "utils.bootstrapUtils")
       @js.native
-      def getBsProps(props: js.Any): BSProps = js.native
+      val ^ : js.Any = js.native
+      
+      @scala.inline
+      def getBsProps(props: js.Any): BSProps = ^.asInstanceOf[js.Dynamic].applyDynamic("getBsProps")(props.asInstanceOf[js.Any]).asInstanceOf[BSProps]
     }
     
-    @JSImport("react-bootstrap/lib", "utils.createChainedFunction")
-    @js.native
-    def createChainedFunction(funcs: js.Function*): js.Function = js.native
+    @scala.inline
+    def createChainedFunction(funcs: js.Function*): js.Function = ^.asInstanceOf[js.Dynamic].applyDynamic("createChainedFunction")(funcs.asInstanceOf[js.Any]).asInstanceOf[js.Function]
   }
 }

--- a/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/mod.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/mod.scala
@@ -21,16 +21,22 @@ object mod {
   
   object utils {
     
+    @JSImport("react-bootstrap", "utils")
+    @js.native
+    val ^ : js.Any = js.native
+    
     object bootstrapUtils {
       
-      @JSImport("react-bootstrap", "utils.bootstrapUtils.getBsProps")
+      @JSImport("react-bootstrap", "utils.bootstrapUtils")
       @js.native
-      def getBsProps(props: js.Any): BSProps = js.native
+      val ^ : js.Any = js.native
+      
+      @scala.inline
+      def getBsProps(props: js.Any): BSProps = ^.asInstanceOf[js.Dynamic].applyDynamic("getBsProps")(props.asInstanceOf[js.Any]).asInstanceOf[BSProps]
     }
     
-    @JSImport("react-bootstrap", "utils.createChainedFunction")
-    @js.native
-    def createChainedFunction(funcs: js.Function*): js.Function = js.native
+    @scala.inline
+    def createChainedFunction(funcs: js.Function*): js.Function = ^.asInstanceOf[js.Dynamic].applyDynamic("createChainedFunction")(funcs.asInstanceOf[js.Any]).asInstanceOf[js.Function]
   }
   
   type Omit[T, K /* <: /* keyof T */ String */] = Pick[

--- a/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/utilsMod.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/utilsMod.scala
@@ -8,14 +8,20 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object utilsMod {
   
+  @JSImport("react-bootstrap/lib/utils", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+  
   object bootstrapUtils {
     
-    @JSImport("react-bootstrap/lib/utils", "bootstrapUtils.getBsProps")
+    @JSImport("react-bootstrap/lib/utils", "bootstrapUtils")
     @js.native
-    def getBsProps(props: js.Any): BSProps = js.native
+    val ^ : js.Any = js.native
+    
+    @scala.inline
+    def getBsProps(props: js.Any): BSProps = ^.asInstanceOf[js.Dynamic].applyDynamic("getBsProps")(props.asInstanceOf[js.Any]).asInstanceOf[BSProps]
   }
   
-  @JSImport("react-bootstrap/lib/utils", "createChainedFunction")
-  @js.native
-  def createChainedFunction(funcs: js.Function*): js.Function = js.native
+  @scala.inline
+  def createChainedFunction(funcs: js.Function*): js.Function = ^.asInstanceOf[js.Dynamic].applyDynamic("createChainedFunction")(funcs.asInstanceOf[js.Any]).asInstanceOf[js.Function]
 }

--- a/tests/react-integration-test/check-japgolly/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-contextmenu/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-395d2b"
+version := "2.13.0-bcee21"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.5",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-c9d0c6",
+  "org.scalablytyped" %%% "react" % "16.9.2-5cfa3c",
   "org.scalablytyped" %%% "std" % "0.0-unknown-43ed0a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-contextmenu/src/main/scala/typingsJapgolly/reactContextmenu/actionsMod.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-contextmenu/src/main/scala/typingsJapgolly/reactContextmenu/actionsMod.scala
@@ -8,29 +8,25 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object actionsMod {
   
-  @JSImport("react-contextmenu/modules/actions", "hideMenu")
+  @JSImport("react-contextmenu/modules/actions", JSImport.Namespace)
   @js.native
-  def hideMenu(): Unit = js.native
-  @JSImport("react-contextmenu/modules/actions", "hideMenu")
-  @js.native
-  def hideMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = js.native
-  @JSImport("react-contextmenu/modules/actions", "hideMenu")
-  @js.native
-  def hideMenu(opts: js.Any): Unit = js.native
-  @JSImport("react-contextmenu/modules/actions", "hideMenu")
-  @js.native
-  def hideMenu(opts: js.Any, target: HTMLElement): Unit = js.native
+  val ^ : js.Any = js.native
   
-  @JSImport("react-contextmenu/modules/actions", "showMenu")
-  @js.native
-  def showMenu(): Unit = js.native
-  @JSImport("react-contextmenu/modules/actions", "showMenu")
-  @js.native
-  def showMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = js.native
-  @JSImport("react-contextmenu/modules/actions", "showMenu")
-  @js.native
-  def showMenu(opts: js.Any): Unit = js.native
-  @JSImport("react-contextmenu/modules/actions", "showMenu")
-  @js.native
-  def showMenu(opts: js.Any, target: HTMLElement): Unit = js.native
+  @scala.inline
+  def hideMenu(): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")().asInstanceOf[Unit]
+  @scala.inline
+  def hideMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
+  @scala.inline
+  def hideMenu(opts: js.Any): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")(opts.asInstanceOf[js.Any]).asInstanceOf[Unit]
+  @scala.inline
+  def hideMenu(opts: js.Any, target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
+  
+  @scala.inline
+  def showMenu(): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")().asInstanceOf[Unit]
+  @scala.inline
+  def showMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
+  @scala.inline
+  def showMenu(opts: js.Any): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")(opts.asInstanceOf[js.Any]).asInstanceOf[Unit]
+  @scala.inline
+  def showMenu(opts: js.Any, target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
 }

--- a/tests/react-integration-test/check-japgolly/r/react-contextmenu/src/main/scala/typingsJapgolly/reactContextmenu/mod.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-contextmenu/src/main/scala/typingsJapgolly/reactContextmenu/mod.scala
@@ -19,6 +19,10 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
+  @JSImport("react-contextmenu", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+  
   /* This class was inferred from a value with a constructor. In rare cases (like HTMLElement in the DOM) it might not work as you expect. */
   @JSImport("react-contextmenu", "ContextMenu")
   @js.native
@@ -67,35 +71,26 @@ object mod {
   @js.native
   val SubMenu: ComponentClassP[SubMenuProps with js.Object] = js.native
   
-  @JSImport("react-contextmenu", "connectMenu")
-  @js.native
-  def connectMenu(menuId: String): js.Function1[/* menu */ js.Any, _] = js.native
+  @scala.inline
+  def connectMenu(menuId: String): js.Function1[/* menu */ js.Any, _] = ^.asInstanceOf[js.Dynamic].applyDynamic("connectMenu")(menuId.asInstanceOf[js.Any]).asInstanceOf[js.Function1[/* menu */ js.Any, _]]
   
-  @JSImport("react-contextmenu", "hideMenu")
-  @js.native
-  def hideMenu(): Unit = js.native
-  @JSImport("react-contextmenu", "hideMenu")
-  @js.native
-  def hideMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = js.native
-  @JSImport("react-contextmenu", "hideMenu")
-  @js.native
-  def hideMenu(opts: js.Any): Unit = js.native
-  @JSImport("react-contextmenu", "hideMenu")
-  @js.native
-  def hideMenu(opts: js.Any, target: HTMLElement): Unit = js.native
+  @scala.inline
+  def hideMenu(): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")().asInstanceOf[Unit]
+  @scala.inline
+  def hideMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
+  @scala.inline
+  def hideMenu(opts: js.Any): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")(opts.asInstanceOf[js.Any]).asInstanceOf[Unit]
+  @scala.inline
+  def hideMenu(opts: js.Any, target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
   
-  @JSImport("react-contextmenu", "showMenu")
-  @js.native
-  def showMenu(): Unit = js.native
-  @JSImport("react-contextmenu", "showMenu")
-  @js.native
-  def showMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = js.native
-  @JSImport("react-contextmenu", "showMenu")
-  @js.native
-  def showMenu(opts: js.Any): Unit = js.native
-  @JSImport("react-contextmenu", "showMenu")
-  @js.native
-  def showMenu(opts: js.Any, target: HTMLElement): Unit = js.native
+  @scala.inline
+  def showMenu(): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")().asInstanceOf[Unit]
+  @scala.inline
+  def showMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
+  @scala.inline
+  def showMenu(opts: js.Any): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")(opts.asInstanceOf[js.Any]).asInstanceOf[Unit]
+  @scala.inline
+  def showMenu(opts: js.Any, target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
   
   @js.native
   trait ContextMenuProps extends StObject {

--- a/tests/react-integration-test/check-japgolly/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-dropzone/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-a99c87"
+version := "10.1.10-9528b8"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.5",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-c9d0c6",
+  "org.scalablytyped" %%% "react" % "16.9.2-5cfa3c",
   "org.scalablytyped" %%% "std" % "0.0-unknown-43ed0a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react-dropzone/src/main/scala/typingsJapgolly/reactDropzone/mod.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-dropzone/src/main/scala/typingsJapgolly/reactDropzone/mod.scala
@@ -21,16 +21,17 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
-  @JSImport("react-dropzone", JSImport.Default)
+  @JSImport("react-dropzone", JSImport.Namespace)
   @js.native
-  def default(props: DropzoneProps with RefAttributes[DropzoneRef]): Element = js.native
+  val ^ : js.Any = js.native
   
-  @JSImport("react-dropzone", "useDropzone")
-  @js.native
-  def useDropzone(): DropzoneState = js.native
-  @JSImport("react-dropzone", "useDropzone")
-  @js.native
-  def useDropzone(options: DropzoneOptions): DropzoneState = js.native
+  @scala.inline
+  def default(props: DropzoneProps with RefAttributes[DropzoneRef]): Element = ^.asInstanceOf[js.Dynamic].applyDynamic("default")(props.asInstanceOf[js.Any]).asInstanceOf[Element]
+  
+  @scala.inline
+  def useDropzone(): DropzoneState = ^.asInstanceOf[js.Dynamic].applyDynamic("useDropzone")().asInstanceOf[DropzoneState]
+  @scala.inline
+  def useDropzone(options: DropzoneOptions): DropzoneState = ^.asInstanceOf[js.Dynamic].applyDynamic("useDropzone")(options.asInstanceOf[js.Any]).asInstanceOf[DropzoneState]
   
   type DropEvent = ReactDragEventFrom[HTMLElement] | ReactEventFrom[HTMLInputElement] | DragEvent | Event
   

--- a/tests/react-integration-test/check-japgolly/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-select/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-c58701"
+version := "0.0-unknown-3ad0b0"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.5",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-c9d0c6",
+  "org.scalablytyped" %%% "react" % "16.9.2-5cfa3c",
   "org.scalablytyped" %%% "std" % "0.0-unknown-43ed0a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/r/react/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-c9d0c6"
+version := "16.9.2-5cfa3c"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/package.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/package.scala
@@ -7,352 +7,14 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 package object mod {
   
-  type AnimationEventHandler[T] = typingsJapgolly.react.mod.EventHandler[
-    japgolly.scalajs.react.ReactAnimationEventFrom[T with org.scalajs.dom.raw.Element]
-  ]
-  
-  // tslint:disable-next-line:no-empty-interface
-  type AudioHTMLAttributes[T] = typingsJapgolly.react.mod.MediaHTMLAttributes[T]
-  
-  type CElement[P, T /* <: japgolly.scalajs.react.raw.React.Component[P with js.Object, js.Object] */] = typingsJapgolly.react.mod.ComponentElement[P, T]
-  
-  type CFactory[P, T /* <: japgolly.scalajs.react.raw.React.Component[P with js.Object, js.Object] */] = typingsJapgolly.react.mod.ComponentFactory[P, T]
-  
-  type ChangeEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactEventFrom[T with org.scalajs.dom.raw.Element]]
-  
   @scala.inline
   def Children: typingsJapgolly.react.mod.ReactChildren = typingsJapgolly.react.mod.^.asInstanceOf[js.Dynamic].selectDynamic("Children").asInstanceOf[typingsJapgolly.react.mod.ReactChildren]
-  
-  /**
-    * We use an intersection type to infer multiple type parameters from
-    * a single argument, which is useful for many top-level API defs.
-    * See https://github.com/Microsoft/TypeScript/issues/7234 for more info.
-    */
-  type ClassType[P, T /* <: japgolly.scalajs.react.raw.React.Component[P with js.Object, js.Object] */, C /* <: japgolly.scalajs.react.raw.React.ComponentClassP[P with js.Object] */] = C with (org.scalablytyped.runtime.Instantiable2[/* props */ P, /* context */ js.UndefOr[js.Any], T])
-  
-  type ClassicElement[P] = typingsJapgolly.react.mod.CElement[P, typingsJapgolly.react.mod.ClassicComponent[P, js.Object]]
-  
-  type ClassicFactory[P] = typingsJapgolly.react.mod.CFactory[P, typingsJapgolly.react.mod.ClassicComponent[P, js.Object]]
-  
-  type ClipboardEventHandler[T] = typingsJapgolly.react.mod.EventHandler[
-    japgolly.scalajs.react.ReactClipboardEventFrom[T with org.scalajs.dom.raw.Element]
-  ]
-  
-  type ComponentFactory[P, T /* <: japgolly.scalajs.react.raw.React.Component[P with js.Object, js.Object] */] = js.Function2[
-    /* props */ js.UndefOr[typingsJapgolly.react.mod.ClassAttributes[T] with P], 
-    /* repeated */ japgolly.scalajs.react.raw.React.Node, 
-    typingsJapgolly.react.mod.CElement[P, T]
-  ]
-  
-  /**
-    * NOTE: prefer ComponentPropsWithRef, if the ref is forwarded,
-    * or ComponentPropsWithoutRef when refs are not supported.
-    */
-  type ComponentProps[T /* <: typingsJapgolly.react.reactStrings.a_ | typingsJapgolly.react.reactStrings.abbr | typingsJapgolly.react.reactStrings.address | typingsJapgolly.react.reactStrings.area | typingsJapgolly.react.reactStrings.article | typingsJapgolly.react.reactStrings.aside | typingsJapgolly.react.reactStrings.audio | typingsJapgolly.react.reactStrings.b | typingsJapgolly.react.reactStrings.base | typingsJapgolly.react.reactStrings.bdi | typingsJapgolly.react.reactStrings.bdo | typingsJapgolly.react.reactStrings.big | typingsJapgolly.react.reactStrings.view | typingsJapgolly.react.mod.JSXElementConstructor[_] */] = js.Object | (/* import warning: importer.ImportType#apply Failed type conversion: react.react.<global>.JSX.IntrinsicElements[T] */ js.Any)
-  
-  type ComponentPropsWithRef[T /* <: japgolly.scalajs.react.raw.React.ElementType */] = typingsJapgolly.react.mod.PropsWithRef[typingsJapgolly.react.mod.ComponentProps[T]] | (typingsJapgolly.react.mod.PropsWithoutRef[_] with (typingsJapgolly.react.mod.RefAttributes[
-    /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify InstanceType<T> */ _
-  ]))
-  
-  type ComponentPropsWithoutRef[T /* <: japgolly.scalajs.react.raw.React.ElementType */] = typingsJapgolly.react.mod.PropsWithoutRef[typingsJapgolly.react.mod.ComponentProps[T]]
-  
-  type ComponentState = js.Any
-  
-  type ComponentType[P] = (japgolly.scalajs.react.raw.React.ComponentClassP[P with js.Object]) | typingsJapgolly.react.mod.FunctionComponent[P]
-  
-  type CompositionEventHandler[T] = typingsJapgolly.react.mod.EventHandler[
-    japgolly.scalajs.react.ReactCompositionEventFrom[T with org.scalajs.dom.raw.Element]
-  ]
-  
-  type Consumer[T] = typingsJapgolly.react.mod.ExoticComponent[typingsJapgolly.react.mod.ConsumerProps[T]]
-  
-  type ContextType[C /* <: typingsJapgolly.react.mod.Context[_] */] = js.Any
-  
-  type DOMFactory[P /* <: typingsJapgolly.react.mod.DOMAttributes[T] */, T /* <: org.scalajs.dom.raw.Element */] = js.Function2[
-    /* props */ js.UndefOr[(typingsJapgolly.react.mod.ClassAttributes[T] with P) | scala.Null], 
-    /* repeated */ japgolly.scalajs.react.raw.React.Node, 
-    japgolly.scalajs.react.raw.React.DomElement
-  ]
-  
-  // Any prop that has a default prop becomes optional, but its type is unchanged
-  // Undeclared default props are augmented into the resulting allowable attributes
-  // If declared props have indexed properties, ignore default props entirely as keyof gets widened
-  // Wrap in an outer-level conditional type to allow distribution over props that are unions
-  type Defaultize[P, D] = ((typingsJapgolly.std.Pick[
-    P, 
-    typingsJapgolly.std.Exclude[/* keyof P */ java.lang.String, /* keyof D */ java.lang.String]
-  ]) with (typingsJapgolly.std.Partial[
-    typingsJapgolly.std.Pick[
-      P, 
-      /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Extract<keyof P, keyof D> */ _
-    ]
-  ]) with (typingsJapgolly.std.Partial[
-    typingsJapgolly.std.Pick[
-      D, 
-      typingsJapgolly.std.Exclude[/* keyof D */ java.lang.String, /* keyof P */ java.lang.String]
-    ]
-  ])) | P
-  
-  // The identity check is done with the SameValue algorithm (Object.is), which is stricter than ===
-  // TODO (TypeScript 3.0): ReadonlyArray<unknown>
-  type DependencyList = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify ReadonlyArray<any> */ js.Any
-  
-  type DetailedHTMLProps[E /* <: typingsJapgolly.react.mod.HTMLAttributes[T] */, T] = typingsJapgolly.react.mod.ClassAttributes[T] with E
-  
-  // this technically does accept a second argument, but it's already under a deprecation warning
-  // and it's not even released so probably better to not define it.
-  type Dispatch[A] = js.Function1[/* value */ A, scala.Unit]
-  
-  type DragEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactDragEventFrom[T with org.scalajs.dom.raw.Element]]
-  
-  // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
-  // The destructor is itself only allowed to return void.
-  type EffectCallback = js.Function0[scala.Unit | js.Function0[js.UndefOr[scala.Unit]]]
-  
-  //
-  // React Elements
-  // ----------------------------------------------------------------------
-  type ElementType[P] = (/* import warning: importer.ImportType#apply Failed type conversion: {[ K in 'a' | 'abbr' | 'address' | 'area' | 'article' | 'aside' | 'audio' | 'b' | 'base' | 'bdi' | 'bdo' | 'big' | 'view' ]: P extends react.react.<global>.JSX.IntrinsicElements[K]? K : never}['a' | 'abbr' | 'address' | 'area' | 'article' | 'aside' | 'audio' | 'b' | 'base' | 'bdi' | 'bdo' | 'big' | 'view'] */ js.Any) | typingsJapgolly.react.mod.ComponentType[P]
-  
-  //
-  // Event Handler Types
-  // ----------------------------------------------------------------------
-  type EventHandler[E /* <: japgolly.scalajs.react.ReactEventFrom[org.scalajs.dom.raw.Element] */] = js.Function1[/* event */ E, scala.Unit]
-  
-  type ExactlyAnyPropertyKeys[T] = /* import warning: importer.ImportType#apply Failed type conversion: {[ K in keyof T ]: react.react.IsExactlyAny<T[K]> extends true? K : never}[keyof T] */ js.Any
-  
-  type FC[P] = typingsJapgolly.react.mod.FunctionComponent[P]
-  
-  //
-  // Factories
-  // ----------------------------------------------------------------------
-  type Factory[P] = js.Function2[
-    /* props */ js.UndefOr[typingsJapgolly.react.mod.Attributes with P], 
-    /* repeated */ japgolly.scalajs.react.raw.React.Node, 
-    japgolly.scalajs.react.raw.React.Element
-  ]
-  
-  type FocusEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactFocusEventFrom[T with org.scalajs.dom.raw.Element]]
-  
-  // tslint:disable-next-line:no-empty-interface
-  type FormEvent[T] = japgolly.scalajs.react.ReactEventFrom[T with org.scalajs.dom.raw.Element]
-  
-  type FormEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactEventFrom[T with org.scalajs.dom.raw.Element]]
   
   @scala.inline
   def Fragment: typingsJapgolly.react.mod.ExoticComponent[typingsJapgolly.react.anon.Children] = typingsJapgolly.react.mod.^.asInstanceOf[js.Dynamic].selectDynamic("Fragment").asInstanceOf[typingsJapgolly.react.mod.ExoticComponent[typingsJapgolly.react.anon.Children]]
   
-  type FunctionComponentFactory[P] = js.Function2[
-    /* props */ js.UndefOr[typingsJapgolly.react.mod.Attributes with P], 
-    /* repeated */ japgolly.scalajs.react.raw.React.Node, 
-    typingsJapgolly.react.mod.FunctionComponentElement[P]
-  ]
-  
-  type GetDerivedStateFromError[P, S] = /**
-    * This lifecycle is invoked after an error has been thrown by a descendant component.
-    * It receives the error that was thrown as a parameter and should return a value to update state.
-    *
-    * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
-    */
-  js.Function1[/* error */ js.Any, typingsJapgolly.std.Partial[S] | scala.Null]
-  
-  type GetDerivedStateFromProps[P, S] = /**
-    * Returns an update to a component's state based on its new props and old state.
-    *
-    * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
-    */
-  js.Function2[/* nextProps */ P, /* prevState */ S, typingsJapgolly.std.Partial[S] | scala.Null]
-  
-  // tslint:disable-next-line:no-empty-interface
-  type HTMLFactory[T /* <: org.scalajs.dom.raw.HTMLElement */] = typingsJapgolly.react.mod.DetailedHTMLFactory[typingsJapgolly.react.mod.AllHTMLAttributes[T], T]
-  
-  type JSXElementConstructor[P] = (js.Function1[/* props */ P, japgolly.scalajs.react.raw.React.Element | scala.Null]) | (org.scalablytyped.runtime.Instantiable1[
-    /* props */ P, 
-    japgolly.scalajs.react.raw.React.Component[P with js.Object, js.Object]
-  ])
-  
-  type Key = java.lang.String | scala.Double
-  
-  type KeyboardEventHandler[T] = typingsJapgolly.react.mod.EventHandler[
-    japgolly.scalajs.react.ReactKeyboardEventFrom[T with org.scalajs.dom.raw.Element]
-  ]
-  
-  type LazyExoticComponent[T /* <: typingsJapgolly.react.mod.ComponentType[_] */] = typingsJapgolly.react.mod.ExoticComponent[typingsJapgolly.react.mod.ComponentPropsWithRef[T]] with typingsJapgolly.react.anon.Result[T]
-  
-  type LegacyRef[T] = java.lang.String | japgolly.scalajs.react.raw.React.Ref
-  
-  // will show `Memo(${Component.displayName || Component.name})` in devtools by default,
-  // but can be given its own specific name
-  type MemoExoticComponent[T /* <: typingsJapgolly.react.mod.ComponentType[_] */] = typingsJapgolly.react.mod.NamedExoticComponent[typingsJapgolly.react.mod.ComponentPropsWithRef[T]] with typingsJapgolly.react.anon.Type[T]
-  
-  // Try to resolve ill-defined props like for JS users: props can be any, or sometimes objects with properties of type any
-  type MergePropTypes[P, T] = ((typingsJapgolly.std.Pick[P, typingsJapgolly.react.mod.NotExactlyAnyPropertyKeys[P]]) with (typingsJapgolly.std.Pick[
-    T, 
-    typingsJapgolly.std.Exclude[
-      /* keyof T */ java.lang.String, 
-      typingsJapgolly.react.mod.NotExactlyAnyPropertyKeys[P]
-    ]
-  ]) with (typingsJapgolly.std.Pick[
-    P, 
-    typingsJapgolly.std.Exclude[/* keyof P */ java.lang.String, /* keyof T */ java.lang.String]
-  ])) | P | T
-  
-  type MouseEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactMouseEventFrom[T with org.scalajs.dom.raw.Element]]
-  
-  type NativeAnimationEvent = org.scalajs.dom.raw.AnimationEvent
-  
-  type NativeClipboardEvent = org.scalajs.dom.raw.ClipboardEvent
-  
-  type NativeCompositionEvent = org.scalajs.dom.raw.CompositionEvent
-  
-  type NativeDragEvent = org.scalajs.dom.raw.DragEvent
-  
-  type NativeFocusEvent = org.scalajs.dom.raw.FocusEvent
-  
-  type NativeKeyboardEvent = org.scalajs.dom.raw.KeyboardEvent
-  
-  type NativeMouseEvent = org.scalajs.dom.raw.MouseEvent
-  
-  type NativePointerEvent = org.scalajs.dom.raw.PointerEvent
-  
-  type NativeTouchEvent = org.scalajs.dom.raw.TouchEvent
-  
-  type NativeTransitionEvent = org.scalajs.dom.raw.TransitionEvent
-  
-  type NativeUIEvent = org.scalajs.dom.raw.UIEvent
-  
-  type NativeWheelEvent = org.scalajs.dom.raw.WheelEvent
-  
-  type NotExactlyAnyPropertyKeys[T] = typingsJapgolly.std.Exclude[
-    /* keyof T */ java.lang.String, 
-    typingsJapgolly.react.mod.ExactlyAnyPropertyKeys[T]
-  ]
-  
-  type PointerEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactPointerEventFrom[T with org.scalajs.dom.raw.Element]]
-  
   @scala.inline
   def Profiler: typingsJapgolly.react.mod.ExoticComponent[typingsJapgolly.react.mod.ProfilerProps] = typingsJapgolly.react.mod.^.asInstanceOf[js.Dynamic].selectDynamic("Profiler").asInstanceOf[typingsJapgolly.react.mod.ExoticComponent[typingsJapgolly.react.mod.ProfilerProps]]
-  
-  /**
-    * {@link https://github.com/bvaughn/rfcs/blob/profiler/text/0000-profiler.md#detailed-design | API}
-    */
-  type ProfilerOnRenderCallback = js.Function7[
-    /* id */ java.lang.String, 
-    /* phase */ typingsJapgolly.react.reactStrings.mount | typingsJapgolly.react.reactStrings.update, 
-    /* actualDuration */ scala.Double, 
-    /* baseDuration */ scala.Double, 
-    /* startTime */ scala.Double, 
-    /* commitTime */ scala.Double, 
-    /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Set<SchedulerInteraction> */ /* interactions */ js.Any, 
-    scala.Unit
-  ]
-  
-  type PropsWithChildren[P] = P with typingsJapgolly.react.anon.Children
-  
-  /** Ensures that the props do not include string ref, which cannot be forwarded */
-  type PropsWithRef[P] = P | (typingsJapgolly.react.mod.PropsWithoutRef[P] with typingsJapgolly.react.anon.`1`)
-  
-  /** Ensures that the props do not include ref at all */
-  type PropsWithoutRef[P] = P | (typingsJapgolly.std.Pick[
-    P, 
-    typingsJapgolly.std.Exclude[/* keyof P */ java.lang.String, typingsJapgolly.react.reactStrings.ref]
-  ])
-  
-  // NOTE: only the Context object itself can get a displayName
-  // https://github.com/facebook/react-devtools/blob/e0b854e4c/backend/attachRendererFiber.js#L310-L325
-  type Provider[T] = typingsJapgolly.react.mod.ProviderExoticComponent[typingsJapgolly.react.mod.ProviderProps[T]]
-  
-  type ReactChild = japgolly.scalajs.react.raw.React.Element | typingsJapgolly.react.mod.ReactText
-  
-  type ReactComponentElement[T /* <: typingsJapgolly.react.reactStrings.a_ | typingsJapgolly.react.reactStrings.abbr | typingsJapgolly.react.reactStrings.address | typingsJapgolly.react.reactStrings.area | typingsJapgolly.react.reactStrings.article | typingsJapgolly.react.reactStrings.aside | typingsJapgolly.react.reactStrings.audio | typingsJapgolly.react.reactStrings.b | typingsJapgolly.react.reactStrings.base | typingsJapgolly.react.reactStrings.bdi | typingsJapgolly.react.reactStrings.bdo | typingsJapgolly.react.reactStrings.big | typingsJapgolly.react.reactStrings.view | typingsJapgolly.react.mod.JSXElementConstructor[_] */, P] = japgolly.scalajs.react.raw.React.Element
-  
-  type ReactEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactEventFrom[T with org.scalajs.dom.raw.Element]]
-  
-  type ReactFragment = js.Object | typingsJapgolly.react.mod.ReactNodeArray
-  
-  // ReactHTML for ReactHTMLElement
-  // tslint:disable-next-line:no-empty-interface
-  type ReactHTMLElement[T /* <: org.scalajs.dom.raw.HTMLElement */] = typingsJapgolly.react.mod.DetailedReactHTMLElement[typingsJapgolly.react.mod.AllHTMLAttributes[T], T]
-  
-  //
-  // Component API
-  // ----------------------------------------------------------------------
-  type ReactInstance = (japgolly.scalajs.react.raw.React.Component[js.Any with js.Object, js.Object]) | org.scalajs.dom.raw.Element
-  
-  type ReactManagedAttributes[C, P] = P | (typingsJapgolly.react.mod.Defaultize[
-    (typingsJapgolly.react.mod.MergePropTypes[
-      P, 
-      /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.InferProps<T> */ js.Any
-    ]) | P, 
-    js.Any
-  ]) | (typingsJapgolly.react.mod.MergePropTypes[
-    P, 
-    /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.InferProps<T> */ js.Any
-  ])
-  
-  type ReactNode = js.UndefOr[
-    typingsJapgolly.react.mod.ReactChild | typingsJapgolly.react.mod.ReactFragment | typingsJapgolly.react.mod.ReactPortal | scala.Boolean
-  ]
-  
-  //
-  // React Nodes
-  // http://facebook.github.io/react/docs/glossary.html
-  // ----------------------------------------------------------------------
-  type ReactText = java.lang.String | scala.Double
-  
-  /**
-    * @deprecated Please use `ElementType`
-    */
-  type ReactType[P] = japgolly.scalajs.react.raw.React.ElementType
-  
-  // Unlike redux, the actions _can_ be anything
-  type Reducer[S, A] = js.Function2[/* prevState */ S, /* action */ A, S]
-  
-  type ReducerAction[R /* <: typingsJapgolly.react.mod.Reducer[_, _] */] = js.Any
-  
-  // types used to try and prevent the compiler from reducing S
-  // to a supertype common with the second argument to useReducer()
-  type ReducerState[R /* <: typingsJapgolly.react.mod.Reducer[_, _] */] = js.Any
-  
-  type Ref[T] = (js.Function1[/* instance */ T | scala.Null, scala.Unit]) | japgolly.scalajs.react.raw.React.RefHandle[T] | scala.Null
-  
-  type Requireable[T] = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Requireable<T> */ js.Any
-  
-  //
-  // Class Interfaces
-  // ----------------------------------------------------------------------
-  /**
-    * @deprecated as of recent React versions, function components can no
-    * longer be considered 'stateless'. Please use `FunctionComponent` instead.
-    *
-    * @see [React Hooks](https://reactjs.org/docs/hooks-intro.html)
-    */
-  type SFC[P] = typingsJapgolly.react.mod.FunctionComponent[P]
-  
-  /**
-    * @deprecated Please use `FunctionComponentElement`
-    */
-  type SFCElement[P] = typingsJapgolly.react.mod.FunctionComponentElement[P]
-  
-  /**
-    * @deprecated Please use `FunctionComponentFactory`
-    */
-  type SFCFactory[P] = typingsJapgolly.react.mod.FunctionComponentFactory[P]
-  
-  //
-  // React Hooks
-  // ----------------------------------------------------------------------
-  // based on the code in https://github.com/facebook/react/pull/13968
-  // Unlike the class component setState, the updates are not allowed to be partial
-  type SetStateAction[S] = S | (js.Function1[/* prevState */ S, S])
-  
-  /**
-    * @deprecated as of recent React versions, function components can no
-    * longer be considered 'stateless'. Please use `FunctionComponent` instead.
-    *
-    * @see [React Hooks](https://reactjs.org/docs/hooks-intro.html)
-    */
-  type StatelessComponent[P] = typingsJapgolly.react.mod.FunctionComponent[P]
   
   @scala.inline
   def StrictMode: typingsJapgolly.react.mod.ExoticComponent[typingsJapgolly.react.anon.Children] = typingsJapgolly.react.mod.^.asInstanceOf[js.Dynamic].selectDynamic("StrictMode").asInstanceOf[typingsJapgolly.react.mod.ExoticComponent[typingsJapgolly.react.anon.Children]]
@@ -363,36 +25,6 @@ package object mod {
     */
   @scala.inline
   def Suspense: typingsJapgolly.react.mod.ExoticComponent[typingsJapgolly.react.mod.SuspenseProps] = typingsJapgolly.react.mod.^.asInstanceOf[js.Dynamic].selectDynamic("Suspense").asInstanceOf[typingsJapgolly.react.mod.ExoticComponent[typingsJapgolly.react.mod.SuspenseProps]]
-  
-  /**
-    * currentTarget - a reference to the element on which the event listener is registered.
-    *
-    * target - a reference to the element from which the event was originally dispatched.
-    * This might be a child element to the element on which the event listener is registered.
-    * If you thought this should be `EventTarget & T`, see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12239
-    */
-  type SyntheticEvent[T, E] = japgolly.scalajs.react.ReactEventFrom[org.scalajs.dom.raw.EventTarget with T with org.scalajs.dom.raw.Element]
-  
-  type TouchEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactTouchEventFrom[T with org.scalajs.dom.raw.Element]]
-  
-  type TransitionEventHandler[T] = typingsJapgolly.react.mod.EventHandler[
-    japgolly.scalajs.react.ReactTransitionEventFrom[T with org.scalajs.dom.raw.Element]
-  ]
-  
-  type UIEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactUIEventFrom[T with org.scalajs.dom.raw.Element]]
-  
-  type ValidationMap[T] = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.ValidationMap<T> */ js.Any
-  
-  //
-  // React.PropTypes
-  // ----------------------------------------------------------------------
-  type Validator[T] = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<T> */ js.Any
-  
-  type WeakValidationMap[T] = /* import warning: importer.ImportType#apply c Unsupported type mapping: 
-  {[ K in keyof T ]:? null extends T[K]? react.react.Validator<T[K] | null | undefined> : undefined extends T[K]? react.react.Validator<T[K] | null | undefined> : react.react.Validator<T[K]>}
-    */ typingsJapgolly.react.reactStrings.WeakValidationMap with org.scalablytyped.runtime.TopLevel[js.Any]
-  
-  type WheelEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactWheelEventFrom[T with org.scalajs.dom.raw.Element]]
   
   @scala.inline
   def cloneElement[P](
@@ -1024,4 +656,372 @@ package object mod {
   
   @scala.inline
   def version: java.lang.String = typingsJapgolly.react.mod.^.asInstanceOf[js.Dynamic].selectDynamic("version").asInstanceOf[java.lang.String]
+  
+  type AnimationEventHandler[T] = typingsJapgolly.react.mod.EventHandler[
+    japgolly.scalajs.react.ReactAnimationEventFrom[T with org.scalajs.dom.raw.Element]
+  ]
+  
+  // tslint:disable-next-line:no-empty-interface
+  type AudioHTMLAttributes[T] = typingsJapgolly.react.mod.MediaHTMLAttributes[T]
+  
+  type CElement[P, T /* <: japgolly.scalajs.react.raw.React.Component[P with js.Object, js.Object] */] = typingsJapgolly.react.mod.ComponentElement[P, T]
+  
+  type CFactory[P, T /* <: japgolly.scalajs.react.raw.React.Component[P with js.Object, js.Object] */] = typingsJapgolly.react.mod.ComponentFactory[P, T]
+  
+  type ChangeEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactEventFrom[T with org.scalajs.dom.raw.Element]]
+  
+  /**
+    * We use an intersection type to infer multiple type parameters from
+    * a single argument, which is useful for many top-level API defs.
+    * See https://github.com/Microsoft/TypeScript/issues/7234 for more info.
+    */
+  type ClassType[P, T /* <: japgolly.scalajs.react.raw.React.Component[P with js.Object, js.Object] */, C /* <: japgolly.scalajs.react.raw.React.ComponentClassP[P with js.Object] */] = C with (org.scalablytyped.runtime.Instantiable2[/* props */ P, /* context */ js.UndefOr[js.Any], T])
+  
+  type ClassicElement[P] = typingsJapgolly.react.mod.CElement[P, typingsJapgolly.react.mod.ClassicComponent[P, js.Object]]
+  
+  type ClassicFactory[P] = typingsJapgolly.react.mod.CFactory[P, typingsJapgolly.react.mod.ClassicComponent[P, js.Object]]
+  
+  type ClipboardEventHandler[T] = typingsJapgolly.react.mod.EventHandler[
+    japgolly.scalajs.react.ReactClipboardEventFrom[T with org.scalajs.dom.raw.Element]
+  ]
+  
+  type ComponentFactory[P, T /* <: japgolly.scalajs.react.raw.React.Component[P with js.Object, js.Object] */] = js.Function2[
+    /* props */ js.UndefOr[typingsJapgolly.react.mod.ClassAttributes[T] with P], 
+    /* repeated */ japgolly.scalajs.react.raw.React.Node, 
+    typingsJapgolly.react.mod.CElement[P, T]
+  ]
+  
+  /**
+    * NOTE: prefer ComponentPropsWithRef, if the ref is forwarded,
+    * or ComponentPropsWithoutRef when refs are not supported.
+    */
+  type ComponentProps[T /* <: typingsJapgolly.react.reactStrings.a_ | typingsJapgolly.react.reactStrings.abbr | typingsJapgolly.react.reactStrings.address | typingsJapgolly.react.reactStrings.area | typingsJapgolly.react.reactStrings.article | typingsJapgolly.react.reactStrings.aside | typingsJapgolly.react.reactStrings.audio | typingsJapgolly.react.reactStrings.b | typingsJapgolly.react.reactStrings.base | typingsJapgolly.react.reactStrings.bdi | typingsJapgolly.react.reactStrings.bdo | typingsJapgolly.react.reactStrings.big | typingsJapgolly.react.reactStrings.view | typingsJapgolly.react.mod.JSXElementConstructor[_] */] = js.Object | (/* import warning: importer.ImportType#apply Failed type conversion: react.react.<global>.JSX.IntrinsicElements[T] */ js.Any)
+  
+  type ComponentPropsWithRef[T /* <: japgolly.scalajs.react.raw.React.ElementType */] = typingsJapgolly.react.mod.PropsWithRef[typingsJapgolly.react.mod.ComponentProps[T]] | (typingsJapgolly.react.mod.PropsWithoutRef[_] with (typingsJapgolly.react.mod.RefAttributes[
+    /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify InstanceType<T> */ _
+  ]))
+  
+  type ComponentPropsWithoutRef[T /* <: japgolly.scalajs.react.raw.React.ElementType */] = typingsJapgolly.react.mod.PropsWithoutRef[typingsJapgolly.react.mod.ComponentProps[T]]
+  
+  type ComponentState = js.Any
+  
+  type ComponentType[P] = (japgolly.scalajs.react.raw.React.ComponentClassP[P with js.Object]) | typingsJapgolly.react.mod.FunctionComponent[P]
+  
+  type CompositionEventHandler[T] = typingsJapgolly.react.mod.EventHandler[
+    japgolly.scalajs.react.ReactCompositionEventFrom[T with org.scalajs.dom.raw.Element]
+  ]
+  
+  type Consumer[T] = typingsJapgolly.react.mod.ExoticComponent[typingsJapgolly.react.mod.ConsumerProps[T]]
+  
+  type ContextType[C /* <: typingsJapgolly.react.mod.Context[_] */] = js.Any
+  
+  type DOMFactory[P /* <: typingsJapgolly.react.mod.DOMAttributes[T] */, T /* <: org.scalajs.dom.raw.Element */] = js.Function2[
+    /* props */ js.UndefOr[(typingsJapgolly.react.mod.ClassAttributes[T] with P) | scala.Null], 
+    /* repeated */ japgolly.scalajs.react.raw.React.Node, 
+    japgolly.scalajs.react.raw.React.DomElement
+  ]
+  
+  // Any prop that has a default prop becomes optional, but its type is unchanged
+  // Undeclared default props are augmented into the resulting allowable attributes
+  // If declared props have indexed properties, ignore default props entirely as keyof gets widened
+  // Wrap in an outer-level conditional type to allow distribution over props that are unions
+  type Defaultize[P, D] = ((typingsJapgolly.std.Pick[
+    P, 
+    typingsJapgolly.std.Exclude[/* keyof P */ java.lang.String, /* keyof D */ java.lang.String]
+  ]) with (typingsJapgolly.std.Partial[
+    typingsJapgolly.std.Pick[
+      P, 
+      /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Extract<keyof P, keyof D> */ _
+    ]
+  ]) with (typingsJapgolly.std.Partial[
+    typingsJapgolly.std.Pick[
+      D, 
+      typingsJapgolly.std.Exclude[/* keyof D */ java.lang.String, /* keyof P */ java.lang.String]
+    ]
+  ])) | P
+  
+  // The identity check is done with the SameValue algorithm (Object.is), which is stricter than ===
+  // TODO (TypeScript 3.0): ReadonlyArray<unknown>
+  type DependencyList = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify ReadonlyArray<any> */ js.Any
+  
+  type DetailedHTMLProps[E /* <: typingsJapgolly.react.mod.HTMLAttributes[T] */, T] = typingsJapgolly.react.mod.ClassAttributes[T] with E
+  
+  // this technically does accept a second argument, but it's already under a deprecation warning
+  // and it's not even released so probably better to not define it.
+  type Dispatch[A] = js.Function1[/* value */ A, scala.Unit]
+  
+  type DragEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactDragEventFrom[T with org.scalajs.dom.raw.Element]]
+  
+  // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
+  // The destructor is itself only allowed to return void.
+  type EffectCallback = js.Function0[scala.Unit | js.Function0[js.UndefOr[scala.Unit]]]
+  
+  //
+  // React Elements
+  // ----------------------------------------------------------------------
+  type ElementType[P] = (/* import warning: importer.ImportType#apply Failed type conversion: {[ K in 'a' | 'abbr' | 'address' | 'area' | 'article' | 'aside' | 'audio' | 'b' | 'base' | 'bdi' | 'bdo' | 'big' | 'view' ]: P extends react.react.<global>.JSX.IntrinsicElements[K]? K : never}['a' | 'abbr' | 'address' | 'area' | 'article' | 'aside' | 'audio' | 'b' | 'base' | 'bdi' | 'bdo' | 'big' | 'view'] */ js.Any) | typingsJapgolly.react.mod.ComponentType[P]
+  
+  //
+  // Event Handler Types
+  // ----------------------------------------------------------------------
+  type EventHandler[E /* <: japgolly.scalajs.react.ReactEventFrom[org.scalajs.dom.raw.Element] */] = js.Function1[/* event */ E, scala.Unit]
+  
+  type ExactlyAnyPropertyKeys[T] = /* import warning: importer.ImportType#apply Failed type conversion: {[ K in keyof T ]: react.react.IsExactlyAny<T[K]> extends true? K : never}[keyof T] */ js.Any
+  
+  type FC[P] = typingsJapgolly.react.mod.FunctionComponent[P]
+  
+  //
+  // Factories
+  // ----------------------------------------------------------------------
+  type Factory[P] = js.Function2[
+    /* props */ js.UndefOr[typingsJapgolly.react.mod.Attributes with P], 
+    /* repeated */ japgolly.scalajs.react.raw.React.Node, 
+    japgolly.scalajs.react.raw.React.Element
+  ]
+  
+  type FocusEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactFocusEventFrom[T with org.scalajs.dom.raw.Element]]
+  
+  // tslint:disable-next-line:no-empty-interface
+  type FormEvent[T] = japgolly.scalajs.react.ReactEventFrom[T with org.scalajs.dom.raw.Element]
+  
+  type FormEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactEventFrom[T with org.scalajs.dom.raw.Element]]
+  
+  type FunctionComponentFactory[P] = js.Function2[
+    /* props */ js.UndefOr[typingsJapgolly.react.mod.Attributes with P], 
+    /* repeated */ japgolly.scalajs.react.raw.React.Node, 
+    typingsJapgolly.react.mod.FunctionComponentElement[P]
+  ]
+  
+  type GetDerivedStateFromError[P, S] = /**
+    * This lifecycle is invoked after an error has been thrown by a descendant component.
+    * It receives the error that was thrown as a parameter and should return a value to update state.
+    *
+    * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
+    */
+  js.Function1[/* error */ js.Any, typingsJapgolly.std.Partial[S] | scala.Null]
+  
+  type GetDerivedStateFromProps[P, S] = /**
+    * Returns an update to a component's state based on its new props and old state.
+    *
+    * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
+    */
+  js.Function2[/* nextProps */ P, /* prevState */ S, typingsJapgolly.std.Partial[S] | scala.Null]
+  
+  // tslint:disable-next-line:no-empty-interface
+  type HTMLFactory[T /* <: org.scalajs.dom.raw.HTMLElement */] = typingsJapgolly.react.mod.DetailedHTMLFactory[typingsJapgolly.react.mod.AllHTMLAttributes[T], T]
+  
+  type JSXElementConstructor[P] = (js.Function1[/* props */ P, japgolly.scalajs.react.raw.React.Element | scala.Null]) | (org.scalablytyped.runtime.Instantiable1[
+    /* props */ P, 
+    japgolly.scalajs.react.raw.React.Component[P with js.Object, js.Object]
+  ])
+  
+  type Key = java.lang.String | scala.Double
+  
+  type KeyboardEventHandler[T] = typingsJapgolly.react.mod.EventHandler[
+    japgolly.scalajs.react.ReactKeyboardEventFrom[T with org.scalajs.dom.raw.Element]
+  ]
+  
+  type LazyExoticComponent[T /* <: typingsJapgolly.react.mod.ComponentType[_] */] = typingsJapgolly.react.mod.ExoticComponent[typingsJapgolly.react.mod.ComponentPropsWithRef[T]] with typingsJapgolly.react.anon.Result[T]
+  
+  type LegacyRef[T] = java.lang.String | japgolly.scalajs.react.raw.React.Ref
+  
+  // will show `Memo(${Component.displayName || Component.name})` in devtools by default,
+  // but can be given its own specific name
+  type MemoExoticComponent[T /* <: typingsJapgolly.react.mod.ComponentType[_] */] = typingsJapgolly.react.mod.NamedExoticComponent[typingsJapgolly.react.mod.ComponentPropsWithRef[T]] with typingsJapgolly.react.anon.Type[T]
+  
+  // Try to resolve ill-defined props like for JS users: props can be any, or sometimes objects with properties of type any
+  type MergePropTypes[P, T] = ((typingsJapgolly.std.Pick[P, typingsJapgolly.react.mod.NotExactlyAnyPropertyKeys[P]]) with (typingsJapgolly.std.Pick[
+    T, 
+    typingsJapgolly.std.Exclude[
+      /* keyof T */ java.lang.String, 
+      typingsJapgolly.react.mod.NotExactlyAnyPropertyKeys[P]
+    ]
+  ]) with (typingsJapgolly.std.Pick[
+    P, 
+    typingsJapgolly.std.Exclude[/* keyof P */ java.lang.String, /* keyof T */ java.lang.String]
+  ])) | P | T
+  
+  type MouseEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactMouseEventFrom[T with org.scalajs.dom.raw.Element]]
+  
+  type NativeAnimationEvent = org.scalajs.dom.raw.AnimationEvent
+  
+  type NativeClipboardEvent = org.scalajs.dom.raw.ClipboardEvent
+  
+  type NativeCompositionEvent = org.scalajs.dom.raw.CompositionEvent
+  
+  type NativeDragEvent = org.scalajs.dom.raw.DragEvent
+  
+  type NativeFocusEvent = org.scalajs.dom.raw.FocusEvent
+  
+  type NativeKeyboardEvent = org.scalajs.dom.raw.KeyboardEvent
+  
+  type NativeMouseEvent = org.scalajs.dom.raw.MouseEvent
+  
+  type NativePointerEvent = org.scalajs.dom.raw.PointerEvent
+  
+  type NativeTouchEvent = org.scalajs.dom.raw.TouchEvent
+  
+  type NativeTransitionEvent = org.scalajs.dom.raw.TransitionEvent
+  
+  type NativeUIEvent = org.scalajs.dom.raw.UIEvent
+  
+  type NativeWheelEvent = org.scalajs.dom.raw.WheelEvent
+  
+  type NotExactlyAnyPropertyKeys[T] = typingsJapgolly.std.Exclude[
+    /* keyof T */ java.lang.String, 
+    typingsJapgolly.react.mod.ExactlyAnyPropertyKeys[T]
+  ]
+  
+  type PointerEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactPointerEventFrom[T with org.scalajs.dom.raw.Element]]
+  
+  /**
+    * {@link https://github.com/bvaughn/rfcs/blob/profiler/text/0000-profiler.md#detailed-design | API}
+    */
+  type ProfilerOnRenderCallback = js.Function7[
+    /* id */ java.lang.String, 
+    /* phase */ typingsJapgolly.react.reactStrings.mount | typingsJapgolly.react.reactStrings.update, 
+    /* actualDuration */ scala.Double, 
+    /* baseDuration */ scala.Double, 
+    /* startTime */ scala.Double, 
+    /* commitTime */ scala.Double, 
+    /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Set<SchedulerInteraction> */ /* interactions */ js.Any, 
+    scala.Unit
+  ]
+  
+  type PropsWithChildren[P] = P with typingsJapgolly.react.anon.Children
+  
+  /** Ensures that the props do not include string ref, which cannot be forwarded */
+  type PropsWithRef[P] = P | (typingsJapgolly.react.mod.PropsWithoutRef[P] with typingsJapgolly.react.anon.`1`)
+  
+  /** Ensures that the props do not include ref at all */
+  type PropsWithoutRef[P] = P | (typingsJapgolly.std.Pick[
+    P, 
+    typingsJapgolly.std.Exclude[/* keyof P */ java.lang.String, typingsJapgolly.react.reactStrings.ref]
+  ])
+  
+  // NOTE: only the Context object itself can get a displayName
+  // https://github.com/facebook/react-devtools/blob/e0b854e4c/backend/attachRendererFiber.js#L310-L325
+  type Provider[T] = typingsJapgolly.react.mod.ProviderExoticComponent[typingsJapgolly.react.mod.ProviderProps[T]]
+  
+  type ReactChild = japgolly.scalajs.react.raw.React.Element | typingsJapgolly.react.mod.ReactText
+  
+  type ReactComponentElement[T /* <: typingsJapgolly.react.reactStrings.a_ | typingsJapgolly.react.reactStrings.abbr | typingsJapgolly.react.reactStrings.address | typingsJapgolly.react.reactStrings.area | typingsJapgolly.react.reactStrings.article | typingsJapgolly.react.reactStrings.aside | typingsJapgolly.react.reactStrings.audio | typingsJapgolly.react.reactStrings.b | typingsJapgolly.react.reactStrings.base | typingsJapgolly.react.reactStrings.bdi | typingsJapgolly.react.reactStrings.bdo | typingsJapgolly.react.reactStrings.big | typingsJapgolly.react.reactStrings.view | typingsJapgolly.react.mod.JSXElementConstructor[_] */, P] = japgolly.scalajs.react.raw.React.Element
+  
+  type ReactEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactEventFrom[T with org.scalajs.dom.raw.Element]]
+  
+  type ReactFragment = js.Object | typingsJapgolly.react.mod.ReactNodeArray
+  
+  // ReactHTML for ReactHTMLElement
+  // tslint:disable-next-line:no-empty-interface
+  type ReactHTMLElement[T /* <: org.scalajs.dom.raw.HTMLElement */] = typingsJapgolly.react.mod.DetailedReactHTMLElement[typingsJapgolly.react.mod.AllHTMLAttributes[T], T]
+  
+  //
+  // Component API
+  // ----------------------------------------------------------------------
+  type ReactInstance = (japgolly.scalajs.react.raw.React.Component[js.Any with js.Object, js.Object]) | org.scalajs.dom.raw.Element
+  
+  type ReactManagedAttributes[C, P] = P | (typingsJapgolly.react.mod.Defaultize[
+    (typingsJapgolly.react.mod.MergePropTypes[
+      P, 
+      /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.InferProps<T> */ js.Any
+    ]) | P, 
+    js.Any
+  ]) | (typingsJapgolly.react.mod.MergePropTypes[
+    P, 
+    /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.InferProps<T> */ js.Any
+  ])
+  
+  type ReactNode = js.UndefOr[
+    typingsJapgolly.react.mod.ReactChild | typingsJapgolly.react.mod.ReactFragment | typingsJapgolly.react.mod.ReactPortal | scala.Boolean
+  ]
+  
+  //
+  // React Nodes
+  // http://facebook.github.io/react/docs/glossary.html
+  // ----------------------------------------------------------------------
+  type ReactText = java.lang.String | scala.Double
+  
+  /**
+    * @deprecated Please use `ElementType`
+    */
+  type ReactType[P] = japgolly.scalajs.react.raw.React.ElementType
+  
+  // Unlike redux, the actions _can_ be anything
+  type Reducer[S, A] = js.Function2[/* prevState */ S, /* action */ A, S]
+  
+  type ReducerAction[R /* <: typingsJapgolly.react.mod.Reducer[_, _] */] = js.Any
+  
+  // types used to try and prevent the compiler from reducing S
+  // to a supertype common with the second argument to useReducer()
+  type ReducerState[R /* <: typingsJapgolly.react.mod.Reducer[_, _] */] = js.Any
+  
+  type Ref[T] = (js.Function1[/* instance */ T | scala.Null, scala.Unit]) | japgolly.scalajs.react.raw.React.RefHandle[T] | scala.Null
+  
+  type Requireable[T] = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Requireable<T> */ js.Any
+  
+  //
+  // Class Interfaces
+  // ----------------------------------------------------------------------
+  /**
+    * @deprecated as of recent React versions, function components can no
+    * longer be considered 'stateless'. Please use `FunctionComponent` instead.
+    *
+    * @see [React Hooks](https://reactjs.org/docs/hooks-intro.html)
+    */
+  type SFC[P] = typingsJapgolly.react.mod.FunctionComponent[P]
+  
+  /**
+    * @deprecated Please use `FunctionComponentElement`
+    */
+  type SFCElement[P] = typingsJapgolly.react.mod.FunctionComponentElement[P]
+  
+  /**
+    * @deprecated Please use `FunctionComponentFactory`
+    */
+  type SFCFactory[P] = typingsJapgolly.react.mod.FunctionComponentFactory[P]
+  
+  //
+  // React Hooks
+  // ----------------------------------------------------------------------
+  // based on the code in https://github.com/facebook/react/pull/13968
+  // Unlike the class component setState, the updates are not allowed to be partial
+  type SetStateAction[S] = S | (js.Function1[/* prevState */ S, S])
+  
+  /**
+    * @deprecated as of recent React versions, function components can no
+    * longer be considered 'stateless'. Please use `FunctionComponent` instead.
+    *
+    * @see [React Hooks](https://reactjs.org/docs/hooks-intro.html)
+    */
+  type StatelessComponent[P] = typingsJapgolly.react.mod.FunctionComponent[P]
+  
+  /**
+    * currentTarget - a reference to the element on which the event listener is registered.
+    *
+    * target - a reference to the element from which the event was originally dispatched.
+    * This might be a child element to the element on which the event listener is registered.
+    * If you thought this should be `EventTarget & T`, see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12239
+    */
+  type SyntheticEvent[T, E] = japgolly.scalajs.react.ReactEventFrom[org.scalajs.dom.raw.EventTarget with T with org.scalajs.dom.raw.Element]
+  
+  type TouchEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactTouchEventFrom[T with org.scalajs.dom.raw.Element]]
+  
+  type TransitionEventHandler[T] = typingsJapgolly.react.mod.EventHandler[
+    japgolly.scalajs.react.ReactTransitionEventFrom[T with org.scalajs.dom.raw.Element]
+  ]
+  
+  type UIEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactUIEventFrom[T with org.scalajs.dom.raw.Element]]
+  
+  type ValidationMap[T] = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.ValidationMap<T> */ js.Any
+  
+  //
+  // React.PropTypes
+  // ----------------------------------------------------------------------
+  type Validator[T] = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<T> */ js.Any
+  
+  type WeakValidationMap[T] = /* import warning: importer.ImportType#apply c Unsupported type mapping: 
+  {[ K in keyof T ]:? null extends T[K]? react.react.Validator<T[K] | null | undefined> : undefined extends T[K]? react.react.Validator<T[K] | null | undefined> : react.react.Validator<T[K]>}
+    */ typingsJapgolly.react.reactStrings.WeakValidationMap with org.scalablytyped.runtime.TopLevel[js.Any]
+  
+  type WheelEventHandler[T] = typingsJapgolly.react.mod.EventHandler[japgolly.scalajs.react.ReactWheelEventFrom[T with org.scalajs.dom.raw.Element]]
 }

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-77e733"
+version := "0.0-unknown-c70301"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.5",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-c9d0c6",
+  "org.scalablytyped" %%% "react" % "16.9.2-5cfa3c",
   "org.scalablytyped" %%% "std" % "0.0-unknown-43ed0a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-5b976b"
+version := "0.38.0-00bf8c"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.5",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-c9d0c6",
+  "org.scalablytyped" %%% "react" % "16.9.2-5cfa3c",
   "org.scalablytyped" %%% "std" % "0.0-unknown-43ed0a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/src/main/scala/typingsJapgolly/stardustUiReactComponentEventListener/eventListenerMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/src/main/scala/typingsJapgolly/stardustUiReactComponentEventListener/eventListenerMod.scala
@@ -13,9 +13,9 @@ object eventListenerMod {
   
   object default {
     
-    @JSImport("@stardust-ui/react-component-event-listener/dist/es/EventListener", JSImport.Default)
-    @js.native
-    def apply[T /* <: EventTypes */](props: EventListenerOptions[T]): js.Any = js.native
+    @scala.inline
+    def apply[T /* <: EventTypes */](props: EventListenerOptions[T]): js.Any = ^.asInstanceOf[js.Dynamic].applyDynamic("default")(props.asInstanceOf[js.Any]).asInstanceOf[js.Any]
+    
     @JSImport("@stardust-ui/react-component-event-listener/dist/es/EventListener", JSImport.Default)
     @js.native
     val ^ : js.Any = js.native

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/src/main/scala/typingsJapgolly/stardustUiReactComponentEventListener/mod.scala
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/src/main/scala/typingsJapgolly/stardustUiReactComponentEventListener/mod.scala
@@ -12,11 +12,15 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
+  @JSImport("@stardust-ui/react-component-event-listener", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+  
   object EventListener {
     
-    @JSImport("@stardust-ui/react-component-event-listener", "EventListener")
-    @js.native
-    def apply[T /* <: EventTypes */](props: EventListenerOptions[T]): js.Any = js.native
+    @scala.inline
+    def apply[T /* <: EventTypes */](props: EventListenerOptions[T]): js.Any = ^.asInstanceOf[js.Dynamic].applyDynamic("EventListener")(props.asInstanceOf[js.Any]).asInstanceOf[js.Any]
+    
     @JSImport("@stardust-ui/react-component-event-listener", "EventListener")
     @js.native
     val ^ : js.Any = js.native
@@ -53,9 +57,8 @@ object mod {
     /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Node */ js.Any
   ] = js.native
   
-  @JSImport("@stardust-ui/react-component-event-listener", "useEventListener")
-  @js.native
-  def useEventListener[T /* <: /* import warning: LimitUnionLength.leaveTypeRef Was union type with length 91 */ js.Any */](options: EventListenerOptions[T]): Unit = js.native
+  @scala.inline
+  def useEventListener[T /* <: /* import warning: LimitUnionLength.leaveTypeRef Was union type with length 91 */ js.Any */](options: EventListenerOptions[T]): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("useEventListener")(options.asInstanceOf[js.Any]).asInstanceOf[Unit]
   
   @JSImport("@stardust-ui/react-component-event-listener", "windowRef")
   @js.native

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/src/main/scala/typingsJapgolly/stardustUiReactComponentEventListener/useEventListenerMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/src/main/scala/typingsJapgolly/stardustUiReactComponentEventListener/useEventListenerMod.scala
@@ -8,7 +8,10 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object useEventListenerMod {
   
-  @JSImport("@stardust-ui/react-component-event-listener/dist/es/useEventListener", JSImport.Default)
+  @JSImport("@stardust-ui/react-component-event-listener/dist/es/useEventListener", JSImport.Namespace)
   @js.native
-  def default[T /* <: /* import warning: LimitUnionLength.leaveTypeRef Was union type with length 91 */ js.Any */](options: EventListenerOptions[T]): Unit = js.native
+  val ^ : js.Any = js.native
+  
+  @scala.inline
+  def default[T /* <: /* import warning: LimitUnionLength.leaveTypeRef Was union type with length 91 */ js.Any */](options: EventListenerOptions[T]): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("default")(options.asInstanceOf[js.Any]).asInstanceOf[Unit]
 }

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-8dcc9c"
+version := "0.38.0-b681ab"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "1.7.5",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
-  "org.scalablytyped" %%% "react" % "16.9.2-c9d0c6",
+  "org.scalablytyped" %%% "react" % "16.9.2-5cfa3c",
   "org.scalablytyped" %%% "std" % "0.0-unknown-43ed0a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/src/main/scala/typingsJapgolly/stardustUiReactComponentRef/handleRefMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/src/main/scala/typingsJapgolly/stardustUiReactComponentRef/handleRefMod.scala
@@ -8,13 +8,16 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object handleRefMod {
   
+  @JSImport("@stardust-ui/react-component-ref/dist/es/handleRef", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+  
   /**
     * The function that correctly handles passing refs.
     *
     * @param ref An ref object or function
     * @param node A node that should be passed by ref
     */
-  @JSImport("@stardust-ui/react-component-ref/dist/es/handleRef", JSImport.Default)
-  @js.native
-  def default[N](ref: Ref, node: N): Unit = js.native
+  @scala.inline
+  def default[N](ref: Ref, node: N): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("default")(ref.asInstanceOf[js.Any], node.asInstanceOf[js.Any])).asInstanceOf[Unit]
 }

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/src/main/scala/typingsJapgolly/stardustUiReactComponentRef/isRefObjectMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/src/main/scala/typingsJapgolly/stardustUiReactComponentRef/isRefObjectMod.scala
@@ -7,8 +7,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object isRefObjectMod {
   
-  /** Checks that the passed object is a valid React ref object. */
-  @JSImport("@stardust-ui/react-component-ref/dist/es/isRefObject", JSImport.Default)
+  @JSImport("@stardust-ui/react-component-ref/dist/es/isRefObject", JSImport.Namespace)
   @js.native
-  def default(ref: js.Any): /* is react.react.RefObject<any> */ Boolean = js.native
+  val ^ : js.Any = js.native
+  
+  /** Checks that the passed object is a valid React ref object. */
+  @scala.inline
+  def default(ref: js.Any): /* is react.react.RefObject<any> */ Boolean = ^.asInstanceOf[js.Dynamic].applyDynamic("default")(ref.asInstanceOf[js.Any]).asInstanceOf[/* is react.react.RefObject<any> */ Boolean]
 }

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/src/main/scala/typingsJapgolly/stardustUiReactComponentRef/mod.scala
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/src/main/scala/typingsJapgolly/stardustUiReactComponentRef/mod.scala
@@ -13,6 +13,10 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
+  @JSImport("@stardust-ui/react-component-ref", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+  
   @JSImport("@stardust-ui/react-component-ref", "Ref")
   @js.native
   val Ref: FunctionComponent[RefProps] = js.native
@@ -70,21 +74,18 @@ object mod {
     * @param ref An ref object or function
     * @param node A node that should be passed by ref
     */
-  @JSImport("@stardust-ui/react-component-ref", "handleRef")
-  @js.native
-  def handleRef[N](ref: japgolly.scalajs.react.raw.React.Ref, node: N): Unit = js.native
+  @scala.inline
+  def handleRef[N](ref: japgolly.scalajs.react.raw.React.Ref, node: N): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("handleRef")(ref.asInstanceOf[js.Any], node.asInstanceOf[js.Any])).asInstanceOf[Unit]
   
   /** Checks that the passed object is a valid React ref object. */
-  @JSImport("@stardust-ui/react-component-ref", "isRefObject")
-  @js.native
-  def isRefObject(ref: js.Any): /* is react.react.RefObject<any> */ Boolean = js.native
+  @scala.inline
+  def isRefObject(ref: js.Any): /* is react.react.RefObject<any> */ Boolean = ^.asInstanceOf[js.Dynamic].applyDynamic("isRefObject")(ref.asInstanceOf[js.Any]).asInstanceOf[/* is react.react.RefObject<any> */ Boolean]
   
   @JSImport("@stardust-ui/react-component-ref", "refPropType")
   @js.native
   val refPropType: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Requireable<React.Ref<any>> */ js.Any = js.native
   
   /** Creates a React ref object from existing DOM node. */
-  @JSImport("@stardust-ui/react-component-ref", "toRefObject")
-  @js.native
-  def toRefObject[T /* <: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Node */ js.Any */](node: T): RefHandle[T] = js.native
+  @scala.inline
+  def toRefObject[T /* <: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Node */ js.Any */](node: T): RefHandle[T] = ^.asInstanceOf[js.Dynamic].applyDynamic("toRefObject")(node.asInstanceOf[js.Any]).asInstanceOf[RefHandle[T]]
 }

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/src/main/scala/typingsJapgolly/stardustUiReactComponentRef/toRefObjectMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/src/main/scala/typingsJapgolly/stardustUiReactComponentRef/toRefObjectMod.scala
@@ -8,8 +8,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object toRefObjectMod {
   
-  /** Creates a React ref object from existing DOM node. */
-  @JSImport("@stardust-ui/react-component-ref/dist/es/toRefObject", JSImport.Default)
+  @JSImport("@stardust-ui/react-component-ref/dist/es/toRefObject", JSImport.Namespace)
   @js.native
-  def default[T /* <: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Node */ js.Any */](node: T): RefHandle[T] = js.native
+  val ^ : js.Any = js.native
+  
+  /** Creates a React ref object from existing DOM node. */
+  @scala.inline
+  def default[T /* <: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Node */ js.Any */](node: T): RefHandle[T] = ^.asInstanceOf[js.Dynamic].applyDynamic("default")(node.asInstanceOf[js.Any]).asInstanceOf[RefHandle[T]]
 }

--- a/tests/react-integration-test/check-slinky/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-slinky/c/componentstest/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-1faf43"
+version := "0.0-unknown-c6dcad"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
   "me.shadaj" %%% "slinky-web" % "0.6.6",
-  "org.scalablytyped" %%% "react" % "16.9.2-ae7e84",
+  "org.scalablytyped" %%% "react" % "16.9.2-f96243",
   "org.scalablytyped" %%% "std" % "0.0-unknown-615776")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-bootstrap/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-986004"
+version := "0.32-152e4e"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
   "me.shadaj" %%% "slinky-web" % "0.6.6",
-  "org.scalablytyped" %%% "react" % "16.9.2-ae7e84",
+  "org.scalablytyped" %%% "react" % "16.9.2-f96243",
   "org.scalablytyped" %%% "std" % "0.0-unknown-615776")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/bootstrapUtilsMod.scala
+++ b/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/bootstrapUtilsMod.scala
@@ -7,9 +7,12 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object bootstrapUtilsMod {
   
-  @JSImport("react-bootstrap/lib/utils/bootstrapUtils", "getBsProps")
+  @JSImport("react-bootstrap/lib/utils/bootstrapUtils", JSImport.Namespace)
   @js.native
-  def getBsProps(props: js.Any): BSProps = js.native
+  val ^ : js.Any = js.native
+  
+  @scala.inline
+  def getBsProps(props: js.Any): BSProps = ^.asInstanceOf[js.Dynamic].applyDynamic("getBsProps")(props.asInstanceOf[js.Any]).asInstanceOf[BSProps]
   
   @js.native
   trait BSProps extends StObject {

--- a/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/createChainedFunctionMod.scala
+++ b/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/createChainedFunctionMod.scala
@@ -7,7 +7,10 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object createChainedFunctionMod {
   
-  @JSImport("react-bootstrap/lib/utils/createChainedFunction", JSImport.Default)
+  @JSImport("react-bootstrap/lib/utils/createChainedFunction", JSImport.Namespace)
   @js.native
-  def default(funcs: js.Function*): js.Function = js.native
+  val ^ : js.Any = js.native
+  
+  @scala.inline
+  def default(funcs: js.Function*): js.Function = ^.asInstanceOf[js.Dynamic].applyDynamic("default")(funcs.asInstanceOf[js.Any]).asInstanceOf[js.Function]
 }

--- a/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/libMod.scala
+++ b/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/libMod.scala
@@ -20,15 +20,21 @@ object libMod {
   
   object utils {
     
+    @JSImport("react-bootstrap/lib", "utils")
+    @js.native
+    val ^ : js.Any = js.native
+    
     object bootstrapUtils {
       
-      @JSImport("react-bootstrap/lib", "utils.bootstrapUtils.getBsProps")
+      @JSImport("react-bootstrap/lib", "utils.bootstrapUtils")
       @js.native
-      def getBsProps(props: js.Any): BSProps = js.native
+      val ^ : js.Any = js.native
+      
+      @scala.inline
+      def getBsProps(props: js.Any): BSProps = ^.asInstanceOf[js.Dynamic].applyDynamic("getBsProps")(props.asInstanceOf[js.Any]).asInstanceOf[BSProps]
     }
     
-    @JSImport("react-bootstrap/lib", "utils.createChainedFunction")
-    @js.native
-    def createChainedFunction(funcs: js.Function*): js.Function = js.native
+    @scala.inline
+    def createChainedFunction(funcs: js.Function*): js.Function = ^.asInstanceOf[js.Dynamic].applyDynamic("createChainedFunction")(funcs.asInstanceOf[js.Any]).asInstanceOf[js.Function]
   }
 }

--- a/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/mod.scala
+++ b/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/mod.scala
@@ -21,16 +21,22 @@ object mod {
   
   object utils {
     
+    @JSImport("react-bootstrap", "utils")
+    @js.native
+    val ^ : js.Any = js.native
+    
     object bootstrapUtils {
       
-      @JSImport("react-bootstrap", "utils.bootstrapUtils.getBsProps")
+      @JSImport("react-bootstrap", "utils.bootstrapUtils")
       @js.native
-      def getBsProps(props: js.Any): BSProps = js.native
+      val ^ : js.Any = js.native
+      
+      @scala.inline
+      def getBsProps(props: js.Any): BSProps = ^.asInstanceOf[js.Dynamic].applyDynamic("getBsProps")(props.asInstanceOf[js.Any]).asInstanceOf[BSProps]
     }
     
-    @JSImport("react-bootstrap", "utils.createChainedFunction")
-    @js.native
-    def createChainedFunction(funcs: js.Function*): js.Function = js.native
+    @scala.inline
+    def createChainedFunction(funcs: js.Function*): js.Function = ^.asInstanceOf[js.Dynamic].applyDynamic("createChainedFunction")(funcs.asInstanceOf[js.Any]).asInstanceOf[js.Function]
   }
   
   type Omit[T, K /* <: /* keyof T */ String */] = Pick[

--- a/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/utilsMod.scala
+++ b/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/utilsMod.scala
@@ -8,14 +8,20 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object utilsMod {
   
+  @JSImport("react-bootstrap/lib/utils", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+  
   object bootstrapUtils {
     
-    @JSImport("react-bootstrap/lib/utils", "bootstrapUtils.getBsProps")
+    @JSImport("react-bootstrap/lib/utils", "bootstrapUtils")
     @js.native
-    def getBsProps(props: js.Any): BSProps = js.native
+    val ^ : js.Any = js.native
+    
+    @scala.inline
+    def getBsProps(props: js.Any): BSProps = ^.asInstanceOf[js.Dynamic].applyDynamic("getBsProps")(props.asInstanceOf[js.Any]).asInstanceOf[BSProps]
   }
   
-  @JSImport("react-bootstrap/lib/utils", "createChainedFunction")
-  @js.native
-  def createChainedFunction(funcs: js.Function*): js.Function = js.native
+  @scala.inline
+  def createChainedFunction(funcs: js.Function*): js.Function = ^.asInstanceOf[js.Dynamic].applyDynamic("createChainedFunction")(funcs.asInstanceOf[js.Any]).asInstanceOf[js.Function]
 }

--- a/tests/react-integration-test/check-slinky/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-contextmenu/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-350064"
+version := "2.13.0-439a3f"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
   "me.shadaj" %%% "slinky-web" % "0.6.6",
-  "org.scalablytyped" %%% "react" % "16.9.2-ae7e84",
+  "org.scalablytyped" %%% "react" % "16.9.2-f96243",
   "org.scalablytyped" %%% "std" % "0.0-unknown-615776")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/r/react-contextmenu/src/main/scala/typingsSlinky/reactContextmenu/actionsMod.scala
+++ b/tests/react-integration-test/check-slinky/r/react-contextmenu/src/main/scala/typingsSlinky/reactContextmenu/actionsMod.scala
@@ -8,29 +8,25 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object actionsMod {
   
-  @JSImport("react-contextmenu/modules/actions", "hideMenu")
+  @JSImport("react-contextmenu/modules/actions", JSImport.Namespace)
   @js.native
-  def hideMenu(): Unit = js.native
-  @JSImport("react-contextmenu/modules/actions", "hideMenu")
-  @js.native
-  def hideMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = js.native
-  @JSImport("react-contextmenu/modules/actions", "hideMenu")
-  @js.native
-  def hideMenu(opts: js.Any): Unit = js.native
-  @JSImport("react-contextmenu/modules/actions", "hideMenu")
-  @js.native
-  def hideMenu(opts: js.Any, target: HTMLElement): Unit = js.native
+  val ^ : js.Any = js.native
   
-  @JSImport("react-contextmenu/modules/actions", "showMenu")
-  @js.native
-  def showMenu(): Unit = js.native
-  @JSImport("react-contextmenu/modules/actions", "showMenu")
-  @js.native
-  def showMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = js.native
-  @JSImport("react-contextmenu/modules/actions", "showMenu")
-  @js.native
-  def showMenu(opts: js.Any): Unit = js.native
-  @JSImport("react-contextmenu/modules/actions", "showMenu")
-  @js.native
-  def showMenu(opts: js.Any, target: HTMLElement): Unit = js.native
+  @scala.inline
+  def hideMenu(): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")().asInstanceOf[Unit]
+  @scala.inline
+  def hideMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
+  @scala.inline
+  def hideMenu(opts: js.Any): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")(opts.asInstanceOf[js.Any]).asInstanceOf[Unit]
+  @scala.inline
+  def hideMenu(opts: js.Any, target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
+  
+  @scala.inline
+  def showMenu(): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")().asInstanceOf[Unit]
+  @scala.inline
+  def showMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
+  @scala.inline
+  def showMenu(opts: js.Any): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")(opts.asInstanceOf[js.Any]).asInstanceOf[Unit]
+  @scala.inline
+  def showMenu(opts: js.Any, target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
 }

--- a/tests/react-integration-test/check-slinky/r/react-contextmenu/src/main/scala/typingsSlinky/reactContextmenu/mod.scala
+++ b/tests/react-integration-test/check-slinky/r/react-contextmenu/src/main/scala/typingsSlinky/reactContextmenu/mod.scala
@@ -17,6 +17,10 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
+  @JSImport("react-contextmenu", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+  
   /* This class was inferred from a value with a constructor. In rare cases (like HTMLElement in the DOM) it might not work as you expect. */
   @JSImport("react-contextmenu", "ContextMenu")
   @js.native
@@ -65,35 +69,26 @@ object mod {
   @js.native
   val SubMenu: ReactComponentClass[SubMenuProps] = js.native
   
-  @JSImport("react-contextmenu", "connectMenu")
-  @js.native
-  def connectMenu(menuId: String): js.Function1[/* menu */ js.Any, _] = js.native
+  @scala.inline
+  def connectMenu(menuId: String): js.Function1[/* menu */ js.Any, _] = ^.asInstanceOf[js.Dynamic].applyDynamic("connectMenu")(menuId.asInstanceOf[js.Any]).asInstanceOf[js.Function1[/* menu */ js.Any, _]]
   
-  @JSImport("react-contextmenu", "hideMenu")
-  @js.native
-  def hideMenu(): Unit = js.native
-  @JSImport("react-contextmenu", "hideMenu")
-  @js.native
-  def hideMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = js.native
-  @JSImport("react-contextmenu", "hideMenu")
-  @js.native
-  def hideMenu(opts: js.Any): Unit = js.native
-  @JSImport("react-contextmenu", "hideMenu")
-  @js.native
-  def hideMenu(opts: js.Any, target: HTMLElement): Unit = js.native
+  @scala.inline
+  def hideMenu(): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")().asInstanceOf[Unit]
+  @scala.inline
+  def hideMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
+  @scala.inline
+  def hideMenu(opts: js.Any): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")(opts.asInstanceOf[js.Any]).asInstanceOf[Unit]
+  @scala.inline
+  def hideMenu(opts: js.Any, target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("hideMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
   
-  @JSImport("react-contextmenu", "showMenu")
-  @js.native
-  def showMenu(): Unit = js.native
-  @JSImport("react-contextmenu", "showMenu")
-  @js.native
-  def showMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = js.native
-  @JSImport("react-contextmenu", "showMenu")
-  @js.native
-  def showMenu(opts: js.Any): Unit = js.native
-  @JSImport("react-contextmenu", "showMenu")
-  @js.native
-  def showMenu(opts: js.Any, target: HTMLElement): Unit = js.native
+  @scala.inline
+  def showMenu(): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")().asInstanceOf[Unit]
+  @scala.inline
+  def showMenu(opts: js.UndefOr[scala.Nothing], target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
+  @scala.inline
+  def showMenu(opts: js.Any): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")(opts.asInstanceOf[js.Any]).asInstanceOf[Unit]
+  @scala.inline
+  def showMenu(opts: js.Any, target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
   
   @js.native
   trait ContextMenuProps extends StObject {

--- a/tests/react-integration-test/check-slinky/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-dropzone/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-7879ea"
+version := "10.1.10-f83e3f"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
   "me.shadaj" %%% "slinky-web" % "0.6.6",
-  "org.scalablytyped" %%% "react" % "16.9.2-ae7e84",
+  "org.scalablytyped" %%% "react" % "16.9.2-f96243",
   "org.scalablytyped" %%% "std" % "0.0-unknown-615776")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/r/react-dropzone/src/main/scala/typingsSlinky/reactDropzone/mod.scala
+++ b/tests/react-integration-test/check-slinky/r/react-dropzone/src/main/scala/typingsSlinky/reactDropzone/mod.scala
@@ -19,16 +19,17 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
-  @JSImport("react-dropzone", JSImport.Default)
+  @JSImport("react-dropzone", JSImport.Namespace)
   @js.native
-  def default(props: DropzoneProps with RefAttributes[DropzoneRef]): ReactElement = js.native
+  val ^ : js.Any = js.native
   
-  @JSImport("react-dropzone", "useDropzone")
-  @js.native
-  def useDropzone(): DropzoneState = js.native
-  @JSImport("react-dropzone", "useDropzone")
-  @js.native
-  def useDropzone(options: DropzoneOptions): DropzoneState = js.native
+  @scala.inline
+  def default(props: DropzoneProps with RefAttributes[DropzoneRef]): ReactElement = ^.asInstanceOf[js.Dynamic].applyDynamic("default")(props.asInstanceOf[js.Any]).asInstanceOf[ReactElement]
+  
+  @scala.inline
+  def useDropzone(): DropzoneState = ^.asInstanceOf[js.Dynamic].applyDynamic("useDropzone")().asInstanceOf[DropzoneState]
+  @scala.inline
+  def useDropzone(options: DropzoneOptions): DropzoneState = ^.asInstanceOf[js.Dynamic].applyDynamic("useDropzone")(options.asInstanceOf[js.Any]).asInstanceOf[DropzoneState]
   
   type DropEvent = DragEvent[HTMLElement] | ChangeEvent[HTMLInputElement] | org.scalajs.dom.raw.DragEvent | Event
   

--- a/tests/react-integration-test/check-slinky/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-select/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-52f660"
+version := "0.0-unknown-fdcfea"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
   "me.shadaj" %%% "slinky-web" % "0.6.6",
-  "org.scalablytyped" %%% "react" % "16.9.2-ae7e84",
+  "org.scalablytyped" %%% "react" % "16.9.2-f96243",
   "org.scalablytyped" %%% "std" % "0.0-unknown-615776")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/r/react/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-ae7e84"
+version := "16.9.2-f96243"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/package.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/package.scala
@@ -7,340 +7,14 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 package object mod {
   
-  type AnimationEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticAnimationEvent[T]]
-  
-  // tslint:disable-next-line:no-empty-interface
-  type AudioHTMLAttributes[T] = typingsSlinky.react.mod.MediaHTMLAttributes[T]
-  
-  type CElement[P, T /* <: slinky.core.ReactComponentClass[P] */] = typingsSlinky.react.mod.ComponentElement[P, T]
-  
-  type CFactory[P, T /* <: slinky.core.ReactComponentClass[P] */] = typingsSlinky.react.mod.ComponentFactory[P, T]
-  
-  type ChangeEventHandler[T] = typingsSlinky.react.mod.EventHandler[typingsSlinky.react.mod.ChangeEvent[T]]
-  
   @scala.inline
   def Children: typingsSlinky.react.mod.ReactChildren = typingsSlinky.react.mod.^.asInstanceOf[js.Dynamic].selectDynamic("Children").asInstanceOf[typingsSlinky.react.mod.ReactChildren]
-  
-  /**
-    * We use an intersection type to infer multiple type parameters from
-    * a single argument, which is useful for many top-level API defs.
-    * See https://github.com/Microsoft/TypeScript/issues/7234 for more info.
-    */
-  type ClassType[P, T /* <: slinky.core.ReactComponentClass[P] */, C /* <: slinky.core.ReactComponentClass[P] */] = C with (org.scalablytyped.runtime.Instantiable2[/* props */ P, /* context */ js.UndefOr[js.Any], T])
-  
-  type ClassicElement[P] = typingsSlinky.react.mod.CElement[P, slinky.core.ReactComponentClass[P]]
-  
-  type ClassicFactory[P] = typingsSlinky.react.mod.CFactory[P, slinky.core.ReactComponentClass[P]]
-  
-  type ClipboardEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticClipboardEvent[T]]
-  
-  type ComponentFactory[P, T /* <: slinky.core.ReactComponentClass[P] */] = js.Function2[
-    /* props */ js.UndefOr[typingsSlinky.react.mod.ClassAttributes[T] with P], 
-    /* repeated */ slinky.core.facade.ReactElement, 
-    typingsSlinky.react.mod.CElement[P, T]
-  ]
-  
-  /**
-    * NOTE: prefer ComponentPropsWithRef, if the ref is forwarded,
-    * or ComponentPropsWithoutRef when refs are not supported.
-    */
-  type ComponentProps[T /* <: typingsSlinky.react.reactStrings.a_ | typingsSlinky.react.reactStrings.abbr | typingsSlinky.react.reactStrings.address | typingsSlinky.react.reactStrings.area | typingsSlinky.react.reactStrings.article | typingsSlinky.react.reactStrings.aside | typingsSlinky.react.reactStrings.audio | typingsSlinky.react.reactStrings.b | typingsSlinky.react.reactStrings.base | typingsSlinky.react.reactStrings.bdi | typingsSlinky.react.reactStrings.bdo | typingsSlinky.react.reactStrings.big | typingsSlinky.react.reactStrings.view | typingsSlinky.react.mod.JSXElementConstructor[_] */] = js.Object | (/* import warning: importer.ImportType#apply Failed type conversion: react.react.<global>.JSX.IntrinsicElements[T] */ js.Any)
-  
-  type ComponentPropsWithRef[T /* <: slinky.core.facade.ReactElement */] = typingsSlinky.react.mod.PropsWithRef[typingsSlinky.react.mod.ComponentProps[T]] | (typingsSlinky.react.mod.PropsWithoutRef[_] with (typingsSlinky.react.mod.RefAttributes[
-    /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify InstanceType<T> */ _
-  ]))
-  
-  type ComponentPropsWithoutRef[T /* <: slinky.core.facade.ReactElement */] = typingsSlinky.react.mod.PropsWithoutRef[typingsSlinky.react.mod.ComponentProps[T]]
-  
-  type ComponentState = js.Any
-  
-  type ComponentType[P] = slinky.core.ReactComponentClass[P]
-  
-  type CompositionEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticCompositionEvent[T]]
-  
-  type Consumer[T] = slinky.core.ReactComponentClass[typingsSlinky.react.mod.ConsumerProps[T]]
-  
-  type ContextType[C /* <: typingsSlinky.react.mod.Context[_] */] = js.Any
-  
-  type DOMFactory[P /* <: typingsSlinky.react.mod.DOMAttributes[T] */, T /* <: org.scalajs.dom.raw.Element */] = js.Function2[
-    /* props */ js.UndefOr[(typingsSlinky.react.mod.ClassAttributes[T] with P) | scala.Null], 
-    /* repeated */ slinky.core.facade.ReactElement, 
-    slinky.core.facade.ReactElement
-  ]
-  
-  // Any prop that has a default prop becomes optional, but its type is unchanged
-  // Undeclared default props are augmented into the resulting allowable attributes
-  // If declared props have indexed properties, ignore default props entirely as keyof gets widened
-  // Wrap in an outer-level conditional type to allow distribution over props that are unions
-  type Defaultize[P, D] = ((typingsSlinky.std.Pick[
-    P, 
-    typingsSlinky.std.Exclude[/* keyof P */ java.lang.String, /* keyof D */ java.lang.String]
-  ]) with (typingsSlinky.std.Partial[
-    typingsSlinky.std.Pick[
-      P, 
-      /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Extract<keyof P, keyof D> */ _
-    ]
-  ]) with (typingsSlinky.std.Partial[
-    typingsSlinky.std.Pick[
-      D, 
-      typingsSlinky.std.Exclude[/* keyof D */ java.lang.String, /* keyof P */ java.lang.String]
-    ]
-  ])) | P
-  
-  // The identity check is done with the SameValue algorithm (Object.is), which is stricter than ===
-  // TODO (TypeScript 3.0): ReadonlyArray<unknown>
-  type DependencyList = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify ReadonlyArray<any> */ js.Any
-  
-  type DetailedHTMLProps[E /* <: typingsSlinky.react.mod.HTMLAttributes[T] */, T] = typingsSlinky.react.mod.ClassAttributes[T] with E
-  
-  // this technically does accept a second argument, but it's already under a deprecation warning
-  // and it's not even released so probably better to not define it.
-  type Dispatch[A] = js.Function1[/* value */ A, scala.Unit]
-  
-  type DragEventHandler[T] = typingsSlinky.react.mod.EventHandler[typingsSlinky.react.mod.DragEvent[T]]
-  
-  // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
-  // The destructor is itself only allowed to return void.
-  type EffectCallback = js.Function0[scala.Unit | js.Function0[js.UndefOr[scala.Unit]]]
-  
-  //
-  // React Elements
-  // ----------------------------------------------------------------------
-  type ElementType[P] = (/* import warning: importer.ImportType#apply Failed type conversion: {[ K in 'a' | 'abbr' | 'address' | 'area' | 'article' | 'aside' | 'audio' | 'b' | 'base' | 'bdi' | 'bdo' | 'big' | 'view' ]: P extends react.react.<global>.JSX.IntrinsicElements[K]? K : never}['a' | 'abbr' | 'address' | 'area' | 'article' | 'aside' | 'audio' | 'b' | 'base' | 'bdi' | 'bdo' | 'big' | 'view'] */ js.Any) | slinky.core.ReactComponentClass[P]
-  
-  //
-  // Event Handler Types
-  // ----------------------------------------------------------------------
-  type EventHandler[E /* <: slinky.core.SyntheticEvent[org.scalajs.dom.raw.Event, _] */] = js.Function1[/* event */ E, scala.Unit]
-  
-  type ExactlyAnyPropertyKeys[T] = /* import warning: importer.ImportType#apply Failed type conversion: {[ K in keyof T ]: react.react.IsExactlyAny<T[K]> extends true? K : never}[keyof T] */ js.Any
-  
-  type FC[P] = slinky.core.ReactComponentClass[P]
-  
-  //
-  // Factories
-  // ----------------------------------------------------------------------
-  type Factory[P] = js.Function2[
-    /* props */ js.UndefOr[typingsSlinky.react.mod.Attributes with P], 
-    /* repeated */ slinky.core.facade.ReactElement, 
-    slinky.core.facade.ReactElement
-  ]
-  
-  type FocusEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticFocusEvent[T]]
-  
-  // tslint:disable-next-line:no-empty-interface
-  type FormEvent[T] = slinky.core.SyntheticEvent[org.scalajs.dom.raw.Event, T]
-  
-  type FormEventHandler[T] = typingsSlinky.react.mod.EventHandler[
-    slinky.core.SyntheticEvent[org.scalajs.dom.raw.EventTarget with T, org.scalajs.dom.raw.Event]
-  ]
   
   @scala.inline
   def Fragment: slinky.core.ReactComponentClass[typingsSlinky.react.anon.Children] = typingsSlinky.react.mod.^.asInstanceOf[js.Dynamic].selectDynamic("Fragment").asInstanceOf[slinky.core.ReactComponentClass[typingsSlinky.react.anon.Children]]
   
-  type FunctionComponentFactory[P] = js.Function2[
-    /* props */ js.UndefOr[typingsSlinky.react.mod.Attributes with P], 
-    /* repeated */ slinky.core.facade.ReactElement, 
-    typingsSlinky.react.mod.FunctionComponentElement[P]
-  ]
-  
-  type GetDerivedStateFromError[P, S] = /**
-    * This lifecycle is invoked after an error has been thrown by a descendant component.
-    * It receives the error that was thrown as a parameter and should return a value to update state.
-    *
-    * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
-    */
-  js.Function1[/* error */ js.Any, typingsSlinky.std.Partial[S] | scala.Null]
-  
-  type GetDerivedStateFromProps[P, S] = /**
-    * Returns an update to a component's state based on its new props and old state.
-    *
-    * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
-    */
-  js.Function2[/* nextProps */ P, /* prevState */ S, typingsSlinky.std.Partial[S] | scala.Null]
-  
-  // tslint:disable-next-line:no-empty-interface
-  type HTMLFactory[T /* <: org.scalajs.dom.raw.HTMLElement */] = typingsSlinky.react.mod.DetailedHTMLFactory[typingsSlinky.react.mod.AllHTMLAttributes[T], T]
-  
-  type JSXElementConstructor[P] = (js.Function1[/* props */ P, slinky.core.facade.ReactElement | scala.Null]) | (org.scalablytyped.runtime.Instantiable1[/* props */ P, slinky.core.ReactComponentClass[P]])
-  
-  type Key = java.lang.String | scala.Double
-  
-  type KeyboardEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticKeyboardEvent[T]]
-  
-  type LazyExoticComponent[T /* <: slinky.core.ReactComponentClass[_] */] = slinky.core.ReactComponentClass[typingsSlinky.react.mod.ComponentPropsWithRef[T]] with typingsSlinky.react.anon.Result[T]
-  
-  type LegacyRef[T] = java.lang.String | typingsSlinky.react.mod.Ref[T]
-  
-  // will show `Memo(${Component.displayName || Component.name})` in devtools by default,
-  // but can be given its own specific name
-  type MemoExoticComponent[T /* <: slinky.core.ReactComponentClass[_] */] = slinky.core.ReactComponentClass[typingsSlinky.react.mod.ComponentPropsWithRef[T]] with typingsSlinky.react.anon.Type[T]
-  
-  // Try to resolve ill-defined props like for JS users: props can be any, or sometimes objects with properties of type any
-  type MergePropTypes[P, T] = ((typingsSlinky.std.Pick[P, typingsSlinky.react.mod.NotExactlyAnyPropertyKeys[P]]) with (typingsSlinky.std.Pick[
-    T, 
-    typingsSlinky.std.Exclude[
-      /* keyof T */ java.lang.String, 
-      typingsSlinky.react.mod.NotExactlyAnyPropertyKeys[P]
-    ]
-  ]) with (typingsSlinky.std.Pick[
-    P, 
-    typingsSlinky.std.Exclude[/* keyof P */ java.lang.String, /* keyof T */ java.lang.String]
-  ])) | P | T
-  
-  type MouseEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticMouseEvent[T]]
-  
-  type NativeAnimationEvent = org.scalajs.dom.raw.AnimationEvent
-  
-  type NativeClipboardEvent = org.scalajs.dom.raw.ClipboardEvent
-  
-  type NativeCompositionEvent = org.scalajs.dom.raw.CompositionEvent
-  
-  type NativeDragEvent = org.scalajs.dom.raw.DragEvent
-  
-  type NativeFocusEvent = org.scalajs.dom.raw.FocusEvent
-  
-  type NativeKeyboardEvent = org.scalajs.dom.raw.KeyboardEvent
-  
-  type NativeMouseEvent = org.scalajs.dom.raw.MouseEvent
-  
-  type NativePointerEvent = org.scalajs.dom.raw.PointerEvent
-  
-  type NativeTouchEvent = org.scalajs.dom.raw.TouchEvent
-  
-  type NativeTransitionEvent = org.scalajs.dom.raw.TransitionEvent
-  
-  type NativeUIEvent = org.scalajs.dom.raw.UIEvent
-  
-  type NativeWheelEvent = org.scalajs.dom.raw.WheelEvent
-  
-  type NotExactlyAnyPropertyKeys[T] = typingsSlinky.std.Exclude[/* keyof T */ java.lang.String, typingsSlinky.react.mod.ExactlyAnyPropertyKeys[T]]
-  
-  type PointerEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticPointerEvent[T]]
-  
   @scala.inline
   def Profiler: slinky.core.ReactComponentClass[typingsSlinky.react.mod.ProfilerProps] = typingsSlinky.react.mod.^.asInstanceOf[js.Dynamic].selectDynamic("Profiler").asInstanceOf[slinky.core.ReactComponentClass[typingsSlinky.react.mod.ProfilerProps]]
-  
-  /**
-    * {@link https://github.com/bvaughn/rfcs/blob/profiler/text/0000-profiler.md#detailed-design | API}
-    */
-  type ProfilerOnRenderCallback = js.Function7[
-    /* id */ java.lang.String, 
-    /* phase */ typingsSlinky.react.reactStrings.mount | typingsSlinky.react.reactStrings.update, 
-    /* actualDuration */ scala.Double, 
-    /* baseDuration */ scala.Double, 
-    /* startTime */ scala.Double, 
-    /* commitTime */ scala.Double, 
-    /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Set<SchedulerInteraction> */ /* interactions */ js.Any, 
-    scala.Unit
-  ]
-  
-  type PropsWithChildren[P] = P with typingsSlinky.react.anon.Children
-  
-  /** Ensures that the props do not include string ref, which cannot be forwarded */
-  type PropsWithRef[P] = P | (typingsSlinky.react.mod.PropsWithoutRef[P] with typingsSlinky.react.anon.`1`)
-  
-  /** Ensures that the props do not include ref at all */
-  type PropsWithoutRef[P] = P | (typingsSlinky.std.Pick[
-    P, 
-    typingsSlinky.std.Exclude[/* keyof P */ java.lang.String, typingsSlinky.react.reactStrings.ref]
-  ])
-  
-  // NOTE: only the Context object itself can get a displayName
-  // https://github.com/facebook/react-devtools/blob/e0b854e4c/backend/attachRendererFiber.js#L310-L325
-  type Provider[T] = slinky.core.ReactComponentClass[typingsSlinky.react.mod.ProviderProps[T]]
-  
-  type ReactChild = slinky.core.facade.ReactElement | typingsSlinky.react.mod.ReactText
-  
-  type ReactComponentElement[T /* <: typingsSlinky.react.reactStrings.a_ | typingsSlinky.react.reactStrings.abbr | typingsSlinky.react.reactStrings.address | typingsSlinky.react.reactStrings.area | typingsSlinky.react.reactStrings.article | typingsSlinky.react.reactStrings.aside | typingsSlinky.react.reactStrings.audio | typingsSlinky.react.reactStrings.b | typingsSlinky.react.reactStrings.base | typingsSlinky.react.reactStrings.bdi | typingsSlinky.react.reactStrings.bdo | typingsSlinky.react.reactStrings.big | typingsSlinky.react.reactStrings.view | typingsSlinky.react.mod.JSXElementConstructor[_] */, P] = slinky.core.facade.ReactElement
-  
-  type ReactEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.core.SyntheticEvent[org.scalajs.dom.raw.Event, T]]
-  
-  type ReactFragment = js.Object | typingsSlinky.react.mod.ReactNodeArray
-  
-  // ReactHTML for ReactHTMLElement
-  // tslint:disable-next-line:no-empty-interface
-  type ReactHTMLElement[T /* <: org.scalajs.dom.raw.HTMLElement */] = typingsSlinky.react.mod.DetailedReactHTMLElement[typingsSlinky.react.mod.AllHTMLAttributes[T], T]
-  
-  //
-  // Component API
-  // ----------------------------------------------------------------------
-  type ReactInstance = slinky.core.ReactComponentClass[js.Any] | org.scalajs.dom.raw.Element
-  
-  type ReactManagedAttributes[C, P] = P | (typingsSlinky.react.mod.Defaultize[
-    (typingsSlinky.react.mod.MergePropTypes[
-      P, 
-      /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.InferProps<T> */ js.Any
-    ]) | P, 
-    js.Any
-  ]) | (typingsSlinky.react.mod.MergePropTypes[
-    P, 
-    /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.InferProps<T> */ js.Any
-  ])
-  
-  type ReactNode = js.UndefOr[
-    typingsSlinky.react.mod.ReactChild | typingsSlinky.react.mod.ReactFragment | typingsSlinky.react.mod.ReactPortal | scala.Boolean
-  ]
-  
-  //
-  // React Nodes
-  // http://facebook.github.io/react/docs/glossary.html
-  // ----------------------------------------------------------------------
-  type ReactText = java.lang.String | scala.Double
-  
-  /**
-    * @deprecated Please use `ElementType`
-    */
-  type ReactType[P] = slinky.core.facade.ReactElement
-  
-  // Unlike redux, the actions _can_ be anything
-  type Reducer[S, A] = js.Function2[/* prevState */ S, /* action */ A, S]
-  
-  type ReducerAction[R /* <: typingsSlinky.react.mod.Reducer[_, _] */] = js.Any
-  
-  // types used to try and prevent the compiler from reducing S
-  // to a supertype common with the second argument to useReducer()
-  type ReducerState[R /* <: typingsSlinky.react.mod.Reducer[_, _] */] = js.Any
-  
-  type Ref[T] = (js.Function1[/* instance */ T | scala.Null, scala.Unit]) | slinky.core.facade.ReactRef[T] | scala.Null
-  
-  type Requireable[T] = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Requireable<T> */ js.Any
-  
-  //
-  // Class Interfaces
-  // ----------------------------------------------------------------------
-  /**
-    * @deprecated as of recent React versions, function components can no
-    * longer be considered 'stateless'. Please use `FunctionComponent` instead.
-    *
-    * @see [React Hooks](https://reactjs.org/docs/hooks-intro.html)
-    */
-  type SFC[P] = slinky.core.ReactComponentClass[P]
-  
-  /**
-    * @deprecated Please use `FunctionComponentElement`
-    */
-  type SFCElement[P] = typingsSlinky.react.mod.FunctionComponentElement[P]
-  
-  /**
-    * @deprecated Please use `FunctionComponentFactory`
-    */
-  type SFCFactory[P] = typingsSlinky.react.mod.FunctionComponentFactory[P]
-  
-  //
-  // React Hooks
-  // ----------------------------------------------------------------------
-  // based on the code in https://github.com/facebook/react/pull/13968
-  // Unlike the class component setState, the updates are not allowed to be partial
-  type SetStateAction[S] = S | (js.Function1[/* prevState */ S, S])
-  
-  /**
-    * @deprecated as of recent React versions, function components can no
-    * longer be considered 'stateless'. Please use `FunctionComponent` instead.
-    *
-    * @see [React Hooks](https://reactjs.org/docs/hooks-intro.html)
-    */
-  type StatelessComponent[P] = slinky.core.ReactComponentClass[P]
   
   @scala.inline
   def StrictMode: slinky.core.ReactComponentClass[typingsSlinky.react.anon.Children] = typingsSlinky.react.mod.^.asInstanceOf[js.Dynamic].selectDynamic("StrictMode").asInstanceOf[slinky.core.ReactComponentClass[typingsSlinky.react.anon.Children]]
@@ -351,34 +25,6 @@ package object mod {
     */
   @scala.inline
   def Suspense: slinky.core.ReactComponentClass[typingsSlinky.react.mod.SuspenseProps] = typingsSlinky.react.mod.^.asInstanceOf[js.Dynamic].selectDynamic("Suspense").asInstanceOf[slinky.core.ReactComponentClass[typingsSlinky.react.mod.SuspenseProps]]
-  
-  /**
-    * currentTarget - a reference to the element on which the event listener is registered.
-    *
-    * target - a reference to the element from which the event was originally dispatched.
-    * This might be a child element to the element on which the event listener is registered.
-    * If you thought this should be `EventTarget & T`, see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12239
-    */
-  type SyntheticEvent[T, E] = slinky.core.SyntheticEvent[org.scalajs.dom.raw.EventTarget with T, E]
-  
-  type TouchEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticTouchEvent[T]]
-  
-  type TransitionEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticTransitionEvent[T]]
-  
-  type UIEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticUIEvent[T]]
-  
-  type ValidationMap[T] = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.ValidationMap<T> */ js.Any
-  
-  //
-  // React.PropTypes
-  // ----------------------------------------------------------------------
-  type Validator[T] = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<T> */ js.Any
-  
-  type WeakValidationMap[T] = /* import warning: importer.ImportType#apply c Unsupported type mapping: 
-  {[ K in keyof T ]:? null extends T[K]? react.react.Validator<T[K] | null | undefined> : undefined extends T[K]? react.react.Validator<T[K] | null | undefined> : react.react.Validator<T[K]>}
-    */ typingsSlinky.react.reactStrings.WeakValidationMap with org.scalablytyped.runtime.TopLevel[js.Any]
-  
-  type WheelEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticWheelEvent[T]]
   
   // Custom components
   @scala.inline
@@ -994,4 +640,358 @@ package object mod {
   
   @scala.inline
   def version: java.lang.String = typingsSlinky.react.mod.^.asInstanceOf[js.Dynamic].selectDynamic("version").asInstanceOf[java.lang.String]
+  
+  type AnimationEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticAnimationEvent[T]]
+  
+  // tslint:disable-next-line:no-empty-interface
+  type AudioHTMLAttributes[T] = typingsSlinky.react.mod.MediaHTMLAttributes[T]
+  
+  type CElement[P, T /* <: slinky.core.ReactComponentClass[P] */] = typingsSlinky.react.mod.ComponentElement[P, T]
+  
+  type CFactory[P, T /* <: slinky.core.ReactComponentClass[P] */] = typingsSlinky.react.mod.ComponentFactory[P, T]
+  
+  type ChangeEventHandler[T] = typingsSlinky.react.mod.EventHandler[typingsSlinky.react.mod.ChangeEvent[T]]
+  
+  /**
+    * We use an intersection type to infer multiple type parameters from
+    * a single argument, which is useful for many top-level API defs.
+    * See https://github.com/Microsoft/TypeScript/issues/7234 for more info.
+    */
+  type ClassType[P, T /* <: slinky.core.ReactComponentClass[P] */, C /* <: slinky.core.ReactComponentClass[P] */] = C with (org.scalablytyped.runtime.Instantiable2[/* props */ P, /* context */ js.UndefOr[js.Any], T])
+  
+  type ClassicElement[P] = typingsSlinky.react.mod.CElement[P, slinky.core.ReactComponentClass[P]]
+  
+  type ClassicFactory[P] = typingsSlinky.react.mod.CFactory[P, slinky.core.ReactComponentClass[P]]
+  
+  type ClipboardEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticClipboardEvent[T]]
+  
+  type ComponentFactory[P, T /* <: slinky.core.ReactComponentClass[P] */] = js.Function2[
+    /* props */ js.UndefOr[typingsSlinky.react.mod.ClassAttributes[T] with P], 
+    /* repeated */ slinky.core.facade.ReactElement, 
+    typingsSlinky.react.mod.CElement[P, T]
+  ]
+  
+  /**
+    * NOTE: prefer ComponentPropsWithRef, if the ref is forwarded,
+    * or ComponentPropsWithoutRef when refs are not supported.
+    */
+  type ComponentProps[T /* <: typingsSlinky.react.reactStrings.a_ | typingsSlinky.react.reactStrings.abbr | typingsSlinky.react.reactStrings.address | typingsSlinky.react.reactStrings.area | typingsSlinky.react.reactStrings.article | typingsSlinky.react.reactStrings.aside | typingsSlinky.react.reactStrings.audio | typingsSlinky.react.reactStrings.b | typingsSlinky.react.reactStrings.base | typingsSlinky.react.reactStrings.bdi | typingsSlinky.react.reactStrings.bdo | typingsSlinky.react.reactStrings.big | typingsSlinky.react.reactStrings.view | typingsSlinky.react.mod.JSXElementConstructor[_] */] = js.Object | (/* import warning: importer.ImportType#apply Failed type conversion: react.react.<global>.JSX.IntrinsicElements[T] */ js.Any)
+  
+  type ComponentPropsWithRef[T /* <: slinky.core.facade.ReactElement */] = typingsSlinky.react.mod.PropsWithRef[typingsSlinky.react.mod.ComponentProps[T]] | (typingsSlinky.react.mod.PropsWithoutRef[_] with (typingsSlinky.react.mod.RefAttributes[
+    /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify InstanceType<T> */ _
+  ]))
+  
+  type ComponentPropsWithoutRef[T /* <: slinky.core.facade.ReactElement */] = typingsSlinky.react.mod.PropsWithoutRef[typingsSlinky.react.mod.ComponentProps[T]]
+  
+  type ComponentState = js.Any
+  
+  type ComponentType[P] = slinky.core.ReactComponentClass[P]
+  
+  type CompositionEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticCompositionEvent[T]]
+  
+  type Consumer[T] = slinky.core.ReactComponentClass[typingsSlinky.react.mod.ConsumerProps[T]]
+  
+  type ContextType[C /* <: typingsSlinky.react.mod.Context[_] */] = js.Any
+  
+  type DOMFactory[P /* <: typingsSlinky.react.mod.DOMAttributes[T] */, T /* <: org.scalajs.dom.raw.Element */] = js.Function2[
+    /* props */ js.UndefOr[(typingsSlinky.react.mod.ClassAttributes[T] with P) | scala.Null], 
+    /* repeated */ slinky.core.facade.ReactElement, 
+    slinky.core.facade.ReactElement
+  ]
+  
+  // Any prop that has a default prop becomes optional, but its type is unchanged
+  // Undeclared default props are augmented into the resulting allowable attributes
+  // If declared props have indexed properties, ignore default props entirely as keyof gets widened
+  // Wrap in an outer-level conditional type to allow distribution over props that are unions
+  type Defaultize[P, D] = ((typingsSlinky.std.Pick[
+    P, 
+    typingsSlinky.std.Exclude[/* keyof P */ java.lang.String, /* keyof D */ java.lang.String]
+  ]) with (typingsSlinky.std.Partial[
+    typingsSlinky.std.Pick[
+      P, 
+      /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Extract<keyof P, keyof D> */ _
+    ]
+  ]) with (typingsSlinky.std.Partial[
+    typingsSlinky.std.Pick[
+      D, 
+      typingsSlinky.std.Exclude[/* keyof D */ java.lang.String, /* keyof P */ java.lang.String]
+    ]
+  ])) | P
+  
+  // The identity check is done with the SameValue algorithm (Object.is), which is stricter than ===
+  // TODO (TypeScript 3.0): ReadonlyArray<unknown>
+  type DependencyList = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify ReadonlyArray<any> */ js.Any
+  
+  type DetailedHTMLProps[E /* <: typingsSlinky.react.mod.HTMLAttributes[T] */, T] = typingsSlinky.react.mod.ClassAttributes[T] with E
+  
+  // this technically does accept a second argument, but it's already under a deprecation warning
+  // and it's not even released so probably better to not define it.
+  type Dispatch[A] = js.Function1[/* value */ A, scala.Unit]
+  
+  type DragEventHandler[T] = typingsSlinky.react.mod.EventHandler[typingsSlinky.react.mod.DragEvent[T]]
+  
+  // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
+  // The destructor is itself only allowed to return void.
+  type EffectCallback = js.Function0[scala.Unit | js.Function0[js.UndefOr[scala.Unit]]]
+  
+  //
+  // React Elements
+  // ----------------------------------------------------------------------
+  type ElementType[P] = (/* import warning: importer.ImportType#apply Failed type conversion: {[ K in 'a' | 'abbr' | 'address' | 'area' | 'article' | 'aside' | 'audio' | 'b' | 'base' | 'bdi' | 'bdo' | 'big' | 'view' ]: P extends react.react.<global>.JSX.IntrinsicElements[K]? K : never}['a' | 'abbr' | 'address' | 'area' | 'article' | 'aside' | 'audio' | 'b' | 'base' | 'bdi' | 'bdo' | 'big' | 'view'] */ js.Any) | slinky.core.ReactComponentClass[P]
+  
+  //
+  // Event Handler Types
+  // ----------------------------------------------------------------------
+  type EventHandler[E /* <: slinky.core.SyntheticEvent[org.scalajs.dom.raw.Event, _] */] = js.Function1[/* event */ E, scala.Unit]
+  
+  type ExactlyAnyPropertyKeys[T] = /* import warning: importer.ImportType#apply Failed type conversion: {[ K in keyof T ]: react.react.IsExactlyAny<T[K]> extends true? K : never}[keyof T] */ js.Any
+  
+  type FC[P] = slinky.core.ReactComponentClass[P]
+  
+  //
+  // Factories
+  // ----------------------------------------------------------------------
+  type Factory[P] = js.Function2[
+    /* props */ js.UndefOr[typingsSlinky.react.mod.Attributes with P], 
+    /* repeated */ slinky.core.facade.ReactElement, 
+    slinky.core.facade.ReactElement
+  ]
+  
+  type FocusEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticFocusEvent[T]]
+  
+  // tslint:disable-next-line:no-empty-interface
+  type FormEvent[T] = slinky.core.SyntheticEvent[org.scalajs.dom.raw.Event, T]
+  
+  type FormEventHandler[T] = typingsSlinky.react.mod.EventHandler[
+    slinky.core.SyntheticEvent[org.scalajs.dom.raw.EventTarget with T, org.scalajs.dom.raw.Event]
+  ]
+  
+  type FunctionComponentFactory[P] = js.Function2[
+    /* props */ js.UndefOr[typingsSlinky.react.mod.Attributes with P], 
+    /* repeated */ slinky.core.facade.ReactElement, 
+    typingsSlinky.react.mod.FunctionComponentElement[P]
+  ]
+  
+  type GetDerivedStateFromError[P, S] = /**
+    * This lifecycle is invoked after an error has been thrown by a descendant component.
+    * It receives the error that was thrown as a parameter and should return a value to update state.
+    *
+    * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
+    */
+  js.Function1[/* error */ js.Any, typingsSlinky.std.Partial[S] | scala.Null]
+  
+  type GetDerivedStateFromProps[P, S] = /**
+    * Returns an update to a component's state based on its new props and old state.
+    *
+    * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
+    */
+  js.Function2[/* nextProps */ P, /* prevState */ S, typingsSlinky.std.Partial[S] | scala.Null]
+  
+  // tslint:disable-next-line:no-empty-interface
+  type HTMLFactory[T /* <: org.scalajs.dom.raw.HTMLElement */] = typingsSlinky.react.mod.DetailedHTMLFactory[typingsSlinky.react.mod.AllHTMLAttributes[T], T]
+  
+  type JSXElementConstructor[P] = (js.Function1[/* props */ P, slinky.core.facade.ReactElement | scala.Null]) | (org.scalablytyped.runtime.Instantiable1[/* props */ P, slinky.core.ReactComponentClass[P]])
+  
+  type Key = java.lang.String | scala.Double
+  
+  type KeyboardEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticKeyboardEvent[T]]
+  
+  type LazyExoticComponent[T /* <: slinky.core.ReactComponentClass[_] */] = slinky.core.ReactComponentClass[typingsSlinky.react.mod.ComponentPropsWithRef[T]] with typingsSlinky.react.anon.Result[T]
+  
+  type LegacyRef[T] = java.lang.String | typingsSlinky.react.mod.Ref[T]
+  
+  // will show `Memo(${Component.displayName || Component.name})` in devtools by default,
+  // but can be given its own specific name
+  type MemoExoticComponent[T /* <: slinky.core.ReactComponentClass[_] */] = slinky.core.ReactComponentClass[typingsSlinky.react.mod.ComponentPropsWithRef[T]] with typingsSlinky.react.anon.Type[T]
+  
+  // Try to resolve ill-defined props like for JS users: props can be any, or sometimes objects with properties of type any
+  type MergePropTypes[P, T] = ((typingsSlinky.std.Pick[P, typingsSlinky.react.mod.NotExactlyAnyPropertyKeys[P]]) with (typingsSlinky.std.Pick[
+    T, 
+    typingsSlinky.std.Exclude[
+      /* keyof T */ java.lang.String, 
+      typingsSlinky.react.mod.NotExactlyAnyPropertyKeys[P]
+    ]
+  ]) with (typingsSlinky.std.Pick[
+    P, 
+    typingsSlinky.std.Exclude[/* keyof P */ java.lang.String, /* keyof T */ java.lang.String]
+  ])) | P | T
+  
+  type MouseEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticMouseEvent[T]]
+  
+  type NativeAnimationEvent = org.scalajs.dom.raw.AnimationEvent
+  
+  type NativeClipboardEvent = org.scalajs.dom.raw.ClipboardEvent
+  
+  type NativeCompositionEvent = org.scalajs.dom.raw.CompositionEvent
+  
+  type NativeDragEvent = org.scalajs.dom.raw.DragEvent
+  
+  type NativeFocusEvent = org.scalajs.dom.raw.FocusEvent
+  
+  type NativeKeyboardEvent = org.scalajs.dom.raw.KeyboardEvent
+  
+  type NativeMouseEvent = org.scalajs.dom.raw.MouseEvent
+  
+  type NativePointerEvent = org.scalajs.dom.raw.PointerEvent
+  
+  type NativeTouchEvent = org.scalajs.dom.raw.TouchEvent
+  
+  type NativeTransitionEvent = org.scalajs.dom.raw.TransitionEvent
+  
+  type NativeUIEvent = org.scalajs.dom.raw.UIEvent
+  
+  type NativeWheelEvent = org.scalajs.dom.raw.WheelEvent
+  
+  type NotExactlyAnyPropertyKeys[T] = typingsSlinky.std.Exclude[/* keyof T */ java.lang.String, typingsSlinky.react.mod.ExactlyAnyPropertyKeys[T]]
+  
+  type PointerEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticPointerEvent[T]]
+  
+  /**
+    * {@link https://github.com/bvaughn/rfcs/blob/profiler/text/0000-profiler.md#detailed-design | API}
+    */
+  type ProfilerOnRenderCallback = js.Function7[
+    /* id */ java.lang.String, 
+    /* phase */ typingsSlinky.react.reactStrings.mount | typingsSlinky.react.reactStrings.update, 
+    /* actualDuration */ scala.Double, 
+    /* baseDuration */ scala.Double, 
+    /* startTime */ scala.Double, 
+    /* commitTime */ scala.Double, 
+    /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Set<SchedulerInteraction> */ /* interactions */ js.Any, 
+    scala.Unit
+  ]
+  
+  type PropsWithChildren[P] = P with typingsSlinky.react.anon.Children
+  
+  /** Ensures that the props do not include string ref, which cannot be forwarded */
+  type PropsWithRef[P] = P | (typingsSlinky.react.mod.PropsWithoutRef[P] with typingsSlinky.react.anon.`1`)
+  
+  /** Ensures that the props do not include ref at all */
+  type PropsWithoutRef[P] = P | (typingsSlinky.std.Pick[
+    P, 
+    typingsSlinky.std.Exclude[/* keyof P */ java.lang.String, typingsSlinky.react.reactStrings.ref]
+  ])
+  
+  // NOTE: only the Context object itself can get a displayName
+  // https://github.com/facebook/react-devtools/blob/e0b854e4c/backend/attachRendererFiber.js#L310-L325
+  type Provider[T] = slinky.core.ReactComponentClass[typingsSlinky.react.mod.ProviderProps[T]]
+  
+  type ReactChild = slinky.core.facade.ReactElement | typingsSlinky.react.mod.ReactText
+  
+  type ReactComponentElement[T /* <: typingsSlinky.react.reactStrings.a_ | typingsSlinky.react.reactStrings.abbr | typingsSlinky.react.reactStrings.address | typingsSlinky.react.reactStrings.area | typingsSlinky.react.reactStrings.article | typingsSlinky.react.reactStrings.aside | typingsSlinky.react.reactStrings.audio | typingsSlinky.react.reactStrings.b | typingsSlinky.react.reactStrings.base | typingsSlinky.react.reactStrings.bdi | typingsSlinky.react.reactStrings.bdo | typingsSlinky.react.reactStrings.big | typingsSlinky.react.reactStrings.view | typingsSlinky.react.mod.JSXElementConstructor[_] */, P] = slinky.core.facade.ReactElement
+  
+  type ReactEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.core.SyntheticEvent[org.scalajs.dom.raw.Event, T]]
+  
+  type ReactFragment = js.Object | typingsSlinky.react.mod.ReactNodeArray
+  
+  // ReactHTML for ReactHTMLElement
+  // tslint:disable-next-line:no-empty-interface
+  type ReactHTMLElement[T /* <: org.scalajs.dom.raw.HTMLElement */] = typingsSlinky.react.mod.DetailedReactHTMLElement[typingsSlinky.react.mod.AllHTMLAttributes[T], T]
+  
+  //
+  // Component API
+  // ----------------------------------------------------------------------
+  type ReactInstance = slinky.core.ReactComponentClass[js.Any] | org.scalajs.dom.raw.Element
+  
+  type ReactManagedAttributes[C, P] = P | (typingsSlinky.react.mod.Defaultize[
+    (typingsSlinky.react.mod.MergePropTypes[
+      P, 
+      /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.InferProps<T> */ js.Any
+    ]) | P, 
+    js.Any
+  ]) | (typingsSlinky.react.mod.MergePropTypes[
+    P, 
+    /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.InferProps<T> */ js.Any
+  ])
+  
+  type ReactNode = js.UndefOr[
+    typingsSlinky.react.mod.ReactChild | typingsSlinky.react.mod.ReactFragment | typingsSlinky.react.mod.ReactPortal | scala.Boolean
+  ]
+  
+  //
+  // React Nodes
+  // http://facebook.github.io/react/docs/glossary.html
+  // ----------------------------------------------------------------------
+  type ReactText = java.lang.String | scala.Double
+  
+  /**
+    * @deprecated Please use `ElementType`
+    */
+  type ReactType[P] = slinky.core.facade.ReactElement
+  
+  // Unlike redux, the actions _can_ be anything
+  type Reducer[S, A] = js.Function2[/* prevState */ S, /* action */ A, S]
+  
+  type ReducerAction[R /* <: typingsSlinky.react.mod.Reducer[_, _] */] = js.Any
+  
+  // types used to try and prevent the compiler from reducing S
+  // to a supertype common with the second argument to useReducer()
+  type ReducerState[R /* <: typingsSlinky.react.mod.Reducer[_, _] */] = js.Any
+  
+  type Ref[T] = (js.Function1[/* instance */ T | scala.Null, scala.Unit]) | slinky.core.facade.ReactRef[T] | scala.Null
+  
+  type Requireable[T] = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Requireable<T> */ js.Any
+  
+  //
+  // Class Interfaces
+  // ----------------------------------------------------------------------
+  /**
+    * @deprecated as of recent React versions, function components can no
+    * longer be considered 'stateless'. Please use `FunctionComponent` instead.
+    *
+    * @see [React Hooks](https://reactjs.org/docs/hooks-intro.html)
+    */
+  type SFC[P] = slinky.core.ReactComponentClass[P]
+  
+  /**
+    * @deprecated Please use `FunctionComponentElement`
+    */
+  type SFCElement[P] = typingsSlinky.react.mod.FunctionComponentElement[P]
+  
+  /**
+    * @deprecated Please use `FunctionComponentFactory`
+    */
+  type SFCFactory[P] = typingsSlinky.react.mod.FunctionComponentFactory[P]
+  
+  //
+  // React Hooks
+  // ----------------------------------------------------------------------
+  // based on the code in https://github.com/facebook/react/pull/13968
+  // Unlike the class component setState, the updates are not allowed to be partial
+  type SetStateAction[S] = S | (js.Function1[/* prevState */ S, S])
+  
+  /**
+    * @deprecated as of recent React versions, function components can no
+    * longer be considered 'stateless'. Please use `FunctionComponent` instead.
+    *
+    * @see [React Hooks](https://reactjs.org/docs/hooks-intro.html)
+    */
+  type StatelessComponent[P] = slinky.core.ReactComponentClass[P]
+  
+  /**
+    * currentTarget - a reference to the element on which the event listener is registered.
+    *
+    * target - a reference to the element from which the event was originally dispatched.
+    * This might be a child element to the element on which the event listener is registered.
+    * If you thought this should be `EventTarget & T`, see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12239
+    */
+  type SyntheticEvent[T, E] = slinky.core.SyntheticEvent[org.scalajs.dom.raw.EventTarget with T, E]
+  
+  type TouchEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticTouchEvent[T]]
+  
+  type TransitionEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticTransitionEvent[T]]
+  
+  type UIEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticUIEvent[T]]
+  
+  type ValidationMap[T] = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.ValidationMap<T> */ js.Any
+  
+  //
+  // React.PropTypes
+  // ----------------------------------------------------------------------
+  type Validator[T] = /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<T> */ js.Any
+  
+  type WeakValidationMap[T] = /* import warning: importer.ImportType#apply c Unsupported type mapping: 
+  {[ K in keyof T ]:? null extends T[K]? react.react.Validator<T[K] | null | undefined> : undefined extends T[K]? react.react.Validator<T[K] | null | undefined> : react.react.Validator<T[K]>}
+    */ typingsSlinky.react.reactStrings.WeakValidationMap with org.scalablytyped.runtime.TopLevel[js.Any]
+  
+  type WheelEventHandler[T] = typingsSlinky.react.mod.EventHandler[slinky.web.SyntheticWheelEvent[T]]
 }

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-26e658"
+version := "0.0-unknown-4dce11"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
   "me.shadaj" %%% "slinky-web" % "0.6.6",
-  "org.scalablytyped" %%% "react" % "16.9.2-ae7e84",
+  "org.scalablytyped" %%% "react" % "16.9.2-f96243",
   "org.scalablytyped" %%% "std" % "0.0-unknown-615776")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-53e256"
+version := "0.38.0-70b652"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
   "me.shadaj" %%% "slinky-web" % "0.6.6",
-  "org.scalablytyped" %%% "react" % "16.9.2-ae7e84",
+  "org.scalablytyped" %%% "react" % "16.9.2-f96243",
   "org.scalablytyped" %%% "std" % "0.0-unknown-615776")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/src/main/scala/typingsSlinky/stardustUiReactComponentEventListener/eventListenerMod.scala
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/src/main/scala/typingsSlinky/stardustUiReactComponentEventListener/eventListenerMod.scala
@@ -13,9 +13,9 @@ object eventListenerMod {
   
   object default {
     
-    @JSImport("@stardust-ui/react-component-event-listener/dist/es/EventListener", JSImport.Default)
-    @js.native
-    def apply[T /* <: EventTypes */](props: EventListenerOptions[T]): js.Any = js.native
+    @scala.inline
+    def apply[T /* <: EventTypes */](props: EventListenerOptions[T]): js.Any = ^.asInstanceOf[js.Dynamic].applyDynamic("default")(props.asInstanceOf[js.Any]).asInstanceOf[js.Any]
+    
     @JSImport("@stardust-ui/react-component-event-listener/dist/es/EventListener", JSImport.Default)
     @js.native
     val ^ : js.Any = js.native

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/src/main/scala/typingsSlinky/stardustUiReactComponentEventListener/mod.scala
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/src/main/scala/typingsSlinky/stardustUiReactComponentEventListener/mod.scala
@@ -12,11 +12,15 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
+  @JSImport("@stardust-ui/react-component-event-listener", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+  
   object EventListener {
     
-    @JSImport("@stardust-ui/react-component-event-listener", "EventListener")
-    @js.native
-    def apply[T /* <: EventTypes */](props: EventListenerOptions[T]): js.Any = js.native
+    @scala.inline
+    def apply[T /* <: EventTypes */](props: EventListenerOptions[T]): js.Any = ^.asInstanceOf[js.Dynamic].applyDynamic("EventListener")(props.asInstanceOf[js.Any]).asInstanceOf[js.Any]
+    
     @JSImport("@stardust-ui/react-component-event-listener", "EventListener")
     @js.native
     val ^ : js.Any = js.native
@@ -53,9 +57,8 @@ object mod {
     /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Node */ js.Any
   ] = js.native
   
-  @JSImport("@stardust-ui/react-component-event-listener", "useEventListener")
-  @js.native
-  def useEventListener[T /* <: /* import warning: LimitUnionLength.leaveTypeRef Was union type with length 91 */ js.Any */](options: EventListenerOptions[T]): Unit = js.native
+  @scala.inline
+  def useEventListener[T /* <: /* import warning: LimitUnionLength.leaveTypeRef Was union type with length 91 */ js.Any */](options: EventListenerOptions[T]): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("useEventListener")(options.asInstanceOf[js.Any]).asInstanceOf[Unit]
   
   @JSImport("@stardust-ui/react-component-event-listener", "windowRef")
   @js.native

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/src/main/scala/typingsSlinky/stardustUiReactComponentEventListener/useEventListenerMod.scala
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/src/main/scala/typingsSlinky/stardustUiReactComponentEventListener/useEventListenerMod.scala
@@ -8,7 +8,10 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object useEventListenerMod {
   
-  @JSImport("@stardust-ui/react-component-event-listener/dist/es/useEventListener", JSImport.Default)
+  @JSImport("@stardust-ui/react-component-event-listener/dist/es/useEventListener", JSImport.Namespace)
   @js.native
-  def default[T /* <: /* import warning: LimitUnionLength.leaveTypeRef Was union type with length 91 */ js.Any */](options: EventListenerOptions[T]): Unit = js.native
+  val ^ : js.Any = js.native
+  
+  @scala.inline
+  def default[T /* <: /* import warning: LimitUnionLength.leaveTypeRef Was union type with length 91 */ js.Any */](options: EventListenerOptions[T]): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("default")(options.asInstanceOf[js.Any]).asInstanceOf[Unit]
 }

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-cd81b0"
+version := "0.38.0-aaff8d"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
   "me.shadaj" %%% "slinky-web" % "0.6.6",
-  "org.scalablytyped" %%% "react" % "16.9.2-ae7e84",
+  "org.scalablytyped" %%% "react" % "16.9.2-f96243",
   "org.scalablytyped" %%% "std" % "0.0-unknown-615776")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/src/main/scala/typingsSlinky/stardustUiReactComponentRef/handleRefMod.scala
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/src/main/scala/typingsSlinky/stardustUiReactComponentRef/handleRefMod.scala
@@ -8,13 +8,16 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object handleRefMod {
   
+  @JSImport("@stardust-ui/react-component-ref/dist/es/handleRef", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+  
   /**
     * The function that correctly handles passing refs.
     *
     * @param ref An ref object or function
     * @param node A node that should be passed by ref
     */
-  @JSImport("@stardust-ui/react-component-ref/dist/es/handleRef", JSImport.Default)
-  @js.native
-  def default[N](ref: Ref[N], node: N): Unit = js.native
+  @scala.inline
+  def default[N](ref: Ref[N], node: N): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("default")(ref.asInstanceOf[js.Any], node.asInstanceOf[js.Any])).asInstanceOf[Unit]
 }

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/src/main/scala/typingsSlinky/stardustUiReactComponentRef/isRefObjectMod.scala
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/src/main/scala/typingsSlinky/stardustUiReactComponentRef/isRefObjectMod.scala
@@ -7,8 +7,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object isRefObjectMod {
   
-  /** Checks that the passed object is a valid React ref object. */
-  @JSImport("@stardust-ui/react-component-ref/dist/es/isRefObject", JSImport.Default)
+  @JSImport("@stardust-ui/react-component-ref/dist/es/isRefObject", JSImport.Namespace)
   @js.native
-  def default(ref: js.Any): /* is react.react.RefObject<any> */ Boolean = js.native
+  val ^ : js.Any = js.native
+  
+  /** Checks that the passed object is a valid React ref object. */
+  @scala.inline
+  def default(ref: js.Any): /* is react.react.RefObject<any> */ Boolean = ^.asInstanceOf[js.Dynamic].applyDynamic("default")(ref.asInstanceOf[js.Any]).asInstanceOf[/* is react.react.RefObject<any> */ Boolean]
 }

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/src/main/scala/typingsSlinky/stardustUiReactComponentRef/mod.scala
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/src/main/scala/typingsSlinky/stardustUiReactComponentRef/mod.scala
@@ -13,6 +13,10 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
+  @JSImport("@stardust-ui/react-component-ref", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+  
   @JSImport("@stardust-ui/react-component-ref", "Ref")
   @js.native
   val Ref: ReactComponentClass[RefProps] = js.native
@@ -70,21 +74,18 @@ object mod {
     * @param ref An ref object or function
     * @param node A node that should be passed by ref
     */
-  @JSImport("@stardust-ui/react-component-ref", "handleRef")
-  @js.native
-  def handleRef[N](ref: typingsSlinky.react.mod.Ref[N], node: N): Unit = js.native
+  @scala.inline
+  def handleRef[N](ref: typingsSlinky.react.mod.Ref[N], node: N): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("handleRef")(ref.asInstanceOf[js.Any], node.asInstanceOf[js.Any])).asInstanceOf[Unit]
   
   /** Checks that the passed object is a valid React ref object. */
-  @JSImport("@stardust-ui/react-component-ref", "isRefObject")
-  @js.native
-  def isRefObject(ref: js.Any): /* is react.react.RefObject<any> */ Boolean = js.native
+  @scala.inline
+  def isRefObject(ref: js.Any): /* is react.react.RefObject<any> */ Boolean = ^.asInstanceOf[js.Dynamic].applyDynamic("isRefObject")(ref.asInstanceOf[js.Any]).asInstanceOf[/* is react.react.RefObject<any> */ Boolean]
   
   @JSImport("@stardust-ui/react-component-ref", "refPropType")
   @js.native
   val refPropType: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Requireable<React.Ref<any>> */ js.Any = js.native
   
   /** Creates a React ref object from existing DOM node. */
-  @JSImport("@stardust-ui/react-component-ref", "toRefObject")
-  @js.native
-  def toRefObject[T /* <: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Node */ js.Any */](node: T): ReactRef[T] = js.native
+  @scala.inline
+  def toRefObject[T /* <: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Node */ js.Any */](node: T): ReactRef[T] = ^.asInstanceOf[js.Dynamic].applyDynamic("toRefObject")(node.asInstanceOf[js.Any]).asInstanceOf[ReactRef[T]]
 }

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/src/main/scala/typingsSlinky/stardustUiReactComponentRef/toRefObjectMod.scala
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/src/main/scala/typingsSlinky/stardustUiReactComponentRef/toRefObjectMod.scala
@@ -8,8 +8,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object toRefObjectMod {
   
-  /** Creates a React ref object from existing DOM node. */
-  @JSImport("@stardust-ui/react-component-ref/dist/es/toRefObject", JSImport.Default)
+  @JSImport("@stardust-ui/react-component-ref/dist/es/toRefObject", JSImport.Namespace)
   @js.native
-  def default[T /* <: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Node */ js.Any */](node: T): ReactRef[T] = js.native
+  val ^ : js.Any = js.native
+  
+  /** Creates a React ref object from existing DOM node. */
+  @scala.inline
+  def default[T /* <: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Node */ js.Any */](node: T): ReactRef[T] = ^.asInstanceOf[js.Dynamic].applyDynamic("default")(node.asInstanceOf[js.Any]).asInstanceOf[ReactRef[T]]
 }

--- a/tests/sax/check/n/node/build.sbt
+++ b/tests/sax/check/n/node/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "9.6.x-c1898a"
+version := "9.6.x-5ddb22"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/sax/check/n/node/src/main/scala/typings/node/bufferMod.scala
+++ b/tests/sax/check/n/node/src/main/scala/typings/node/bufferMod.scala
@@ -71,12 +71,15 @@ object bufferMod {
   /* was `typeof Buffer` */
   object Buffer {
     
+    @JSImport("buffer", "Buffer")
+    @js.native
+    val ^ : js.Any = js.native
+    
     /**
       * Allocates a new Buffer using an {array} of octets.
       */
-    @JSImport("buffer", "Buffer.from")
-    @js.native
-    def from(array: js.Array[_]): typings.node.Buffer = js.native
+    @scala.inline
+    def from(array: js.Array[_]): typings.node.Buffer = ^.asInstanceOf[js.Dynamic].applyDynamic("from")(array.asInstanceOf[js.Any]).asInstanceOf[typings.node.Buffer]
   }
   
   @JSImport("buffer", "INSPECT_MAX_BYTES")
@@ -98,22 +101,21 @@ object bufferMod {
   /* was `typeof SlowBuffer` */
   object SlowBuffer {
     
-    @JSImport("buffer", "SlowBuffer.byteLength")
+    @JSImport("buffer", "SlowBuffer")
     @js.native
-    def byteLength(string: String): Double = js.native
-    @JSImport("buffer", "SlowBuffer.byteLength")
-    @js.native
-    def byteLength(string: String, encoding: String): Double = js.native
+    val ^ : js.Any = js.native
     
-    @JSImport("buffer", "SlowBuffer.concat")
-    @js.native
-    def concat(list: js.Array[typings.node.Buffer]): typings.node.Buffer = js.native
-    @JSImport("buffer", "SlowBuffer.concat")
-    @js.native
-    def concat(list: js.Array[typings.node.Buffer], totalLength: Double): typings.node.Buffer = js.native
+    @scala.inline
+    def byteLength(string: String): Double = ^.asInstanceOf[js.Dynamic].applyDynamic("byteLength")(string.asInstanceOf[js.Any]).asInstanceOf[Double]
+    @scala.inline
+    def byteLength(string: String, encoding: String): Double = (^.asInstanceOf[js.Dynamic].applyDynamic("byteLength")(string.asInstanceOf[js.Any], encoding.asInstanceOf[js.Any])).asInstanceOf[Double]
     
-    @JSImport("buffer", "SlowBuffer.isBuffer")
-    @js.native
-    def isBuffer(obj: js.Any): Boolean = js.native
+    @scala.inline
+    def concat(list: js.Array[typings.node.Buffer]): typings.node.Buffer = ^.asInstanceOf[js.Dynamic].applyDynamic("concat")(list.asInstanceOf[js.Any]).asInstanceOf[typings.node.Buffer]
+    @scala.inline
+    def concat(list: js.Array[typings.node.Buffer], totalLength: Double): typings.node.Buffer = (^.asInstanceOf[js.Dynamic].applyDynamic("concat")(list.asInstanceOf[js.Any], totalLength.asInstanceOf[js.Any])).asInstanceOf[typings.node.Buffer]
+    
+    @scala.inline
+    def isBuffer(obj: js.Any): Boolean = ^.asInstanceOf[js.Dynamic].applyDynamic("isBuffer")(obj.asInstanceOf[js.Any]).asInstanceOf[Boolean]
   }
 }

--- a/tests/sax/check/n/node/src/main/scala/typings/node/eventsMod.scala
+++ b/tests/sax/check/n/node/src/main/scala/typings/node/eventsMod.scala
@@ -19,12 +19,14 @@ object eventsMod {
   /* static members */
   object EventEmitter {
     
-    @JSImport("events", "EventEmitter.listenerCount")
+    @JSImport("events", "EventEmitter")
     @js.native
-    def listenerCount(emitter: EventEmitter, event: String): Double = js.native
-    @JSImport("events", "EventEmitter.listenerCount")
-    @js.native
-    def listenerCount(emitter: EventEmitter, event: js.Symbol): Double = js.native
+    val ^ : js.Any = js.native
+    
+    @scala.inline
+    def listenerCount(emitter: EventEmitter, event: String): Double = (^.asInstanceOf[js.Dynamic].applyDynamic("listenerCount")(emitter.asInstanceOf[js.Any], event.asInstanceOf[js.Any])).asInstanceOf[Double]
+    @scala.inline
+    def listenerCount(emitter: EventEmitter, event: js.Symbol): Double = (^.asInstanceOf[js.Dynamic].applyDynamic("listenerCount")(emitter.asInstanceOf[js.Any], event.asInstanceOf[js.Any])).asInstanceOf[Double]
   }
   
   type internal = typings.node.NodeJS.EventEmitter

--- a/tests/sax/check/n/node/src/main/scala/typings/node/global.scala
+++ b/tests/sax/check/n/node/src/main/scala/typings/node/global.scala
@@ -62,12 +62,15 @@ object global {
     */
   object Buffer {
     
+    @JSGlobal("Buffer")
+    @js.native
+    val ^ : js.Any = js.native
+    
     /**
       * Allocates a new Buffer using an {array} of octets.
       */
-    @JSGlobal("Buffer.from")
-    @js.native
-    def from(array: js.Array[_]): typings.node.Buffer = js.native
+    @scala.inline
+    def from(array: js.Array[_]): typings.node.Buffer = ^.asInstanceOf[js.Dynamic].applyDynamic("from")(array.asInstanceOf[js.Any]).asInstanceOf[typings.node.Buffer]
   }
   
   /************************************************
@@ -95,23 +98,22 @@ object global {
   }
   object SlowBuffer {
     
-    @JSGlobal("SlowBuffer.byteLength")
+    @JSGlobal("SlowBuffer")
     @js.native
-    def byteLength(string: String): Double = js.native
-    @JSGlobal("SlowBuffer.byteLength")
-    @js.native
-    def byteLength(string: String, encoding: String): Double = js.native
+    val ^ : js.Any = js.native
     
-    @JSGlobal("SlowBuffer.concat")
-    @js.native
-    def concat(list: js.Array[typings.node.Buffer]): typings.node.Buffer = js.native
-    @JSGlobal("SlowBuffer.concat")
-    @js.native
-    def concat(list: js.Array[typings.node.Buffer], totalLength: Double): typings.node.Buffer = js.native
+    @scala.inline
+    def byteLength(string: String): Double = ^.asInstanceOf[js.Dynamic].applyDynamic("byteLength")(string.asInstanceOf[js.Any]).asInstanceOf[Double]
+    @scala.inline
+    def byteLength(string: String, encoding: String): Double = (^.asInstanceOf[js.Dynamic].applyDynamic("byteLength")(string.asInstanceOf[js.Any], encoding.asInstanceOf[js.Any])).asInstanceOf[Double]
     
-    @JSGlobal("SlowBuffer.isBuffer")
-    @js.native
-    def isBuffer(obj: js.Any): Boolean = js.native
+    @scala.inline
+    def concat(list: js.Array[typings.node.Buffer]): typings.node.Buffer = ^.asInstanceOf[js.Dynamic].applyDynamic("concat")(list.asInstanceOf[js.Any]).asInstanceOf[typings.node.Buffer]
+    @scala.inline
+    def concat(list: js.Array[typings.node.Buffer], totalLength: Double): typings.node.Buffer = (^.asInstanceOf[js.Dynamic].applyDynamic("concat")(list.asInstanceOf[js.Any], totalLength.asInstanceOf[js.Any])).asInstanceOf[typings.node.Buffer]
+    
+    @scala.inline
+    def isBuffer(obj: js.Any): Boolean = ^.asInstanceOf[js.Dynamic].applyDynamic("isBuffer")(obj.asInstanceOf[js.Any]).asInstanceOf[Boolean]
   }
   
   /************************************************

--- a/tests/sax/check/s/sax/build.sbt
+++ b/tests/sax/check/s/sax/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "sax"
-version := "1.x-0120ea"
+version := "1.x-4bb163"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
-  "org.scalablytyped" %%% "node" % "9.6.x-c1898a",
+  "org.scalablytyped" %%% "node" % "9.6.x-5ddb22",
   "org.scalablytyped" %%% "std" % "0.0-unknown-7e075c")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/sax/check/s/sax/src/main/scala/typings/sax/mod.scala
+++ b/tests/sax/check/s/sax/src/main/scala/typings/sax/mod.scala
@@ -35,13 +35,11 @@ object mod {
     var _parser: SAXParser = js.native
   }
   
-  @JSImport("sax", "createStream")
-  @js.native
-  def createStream(strict: Boolean, opt: SAXOptions): SAXStream = js.native
+  @scala.inline
+  def createStream(strict: Boolean, opt: SAXOptions): SAXStream = (^.asInstanceOf[js.Dynamic].applyDynamic("createStream")(strict.asInstanceOf[js.Any], opt.asInstanceOf[js.Any])).asInstanceOf[SAXStream]
   
-  @JSImport("sax", "parser")
-  @js.native
-  def parser(strict: Boolean, opt: SAXOptions): SAXParser = js.native
+  @scala.inline
+  def parser(strict: Boolean, opt: SAXOptions): SAXParser = (^.asInstanceOf[js.Dynamic].applyDynamic("parser")(strict.asInstanceOf[js.Any], opt.asInstanceOf[js.Any])).asInstanceOf[SAXParser]
   
   @js.native
   trait BaseTag extends StObject {

--- a/tests/serve-static/check/m/mime/build.sbt
+++ b/tests/serve-static/check/m/mime/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "mime"
-version := "2.0-e04173"
+version := "2.0-19d6de"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/serve-static/check/m/mime/src/main/scala/typings/mime/mod.scala
+++ b/tests/serve-static/check/m/mime/src/main/scala/typings/mime/mod.scala
@@ -8,24 +8,24 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
+  @JSImport("mime", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+  
   @JSImport("mime", "default_type")
   @js.native
   val defaultType: String = js.native
   
-  @JSImport("mime", "define")
-  @js.native
-  def define(mimes: TypeMap): Unit = js.native
-  @JSImport("mime", "define")
-  @js.native
-  def define(mimes: TypeMap, force: Boolean): Unit = js.native
+  @scala.inline
+  def define(mimes: TypeMap): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("define")(mimes.asInstanceOf[js.Any]).asInstanceOf[Unit]
+  @scala.inline
+  def define(mimes: TypeMap, force: Boolean): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("define")(mimes.asInstanceOf[js.Any], force.asInstanceOf[js.Any])).asInstanceOf[Unit]
   
-  @JSImport("mime", "getExtension")
-  @js.native
-  def getExtension(mime: String): String | Null = js.native
+  @scala.inline
+  def getExtension(mime: String): String | Null = ^.asInstanceOf[js.Dynamic].applyDynamic("getExtension")(mime.asInstanceOf[js.Any]).asInstanceOf[String | Null]
   
-  @JSImport("mime", "getType")
-  @js.native
-  def getType(path: String): String | Null = js.native
+  @scala.inline
+  def getType(path: String): String | Null = ^.asInstanceOf[js.Dynamic].applyDynamic("getType")(path.asInstanceOf[js.Any]).asInstanceOf[String | Null]
   
   type TypeMap = StringDictionary[js.Array[String]]
 }

--- a/tests/serve-static/check/s/serve-static/build.sbt
+++ b/tests/serve-static/check/s/serve-static/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "serve-static"
-version := "0.0-unknown-d8809c"
+version := "0.0-unknown-9e9316"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.0",
   "org.scalablytyped" %%% "express-serve-static-core" % "0.0-unknown-d68680",
-  "org.scalablytyped" %%% "mime" % "2.0-e04173",
+  "org.scalablytyped" %%% "mime" % "2.0-19d6de",
   "org.scalablytyped" %%% "std" % "0.0-unknown-e56105")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-g:notailcalls", "-language:implicitConversions", "-language:higherKinds", "-language:existentials")

--- a/tests/serve-static/check/s/serve-static/src/main/scala/typings/serveStatic/mod.scala
+++ b/tests/serve-static/check/s/serve-static/src/main/scala/typings/serveStatic/mod.scala
@@ -10,41 +10,41 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
+  @scala.inline
+  def apply(root: String): Handler = ^.asInstanceOf[js.Dynamic].apply(root.asInstanceOf[js.Any]).asInstanceOf[Handler]
+  @scala.inline
+  def apply(root: String, options: ServeStaticOptions): Handler = (^.asInstanceOf[js.Dynamic].apply(root.asInstanceOf[js.Any], options.asInstanceOf[js.Any])).asInstanceOf[Handler]
+  
   @JSImport("serve-static", JSImport.Namespace)
   @js.native
-  def apply(root: String): Handler = js.native
-  @JSImport("serve-static", JSImport.Namespace)
-  @js.native
-  def apply(root: String, options: ServeStaticOptions): Handler = js.native
+  val ^ : js.Any = js.native
   
   object mime {
+    
+    @JSImport("serve-static", "mime")
+    @js.native
+    val ^ : js.Any = js.native
     
     @JSImport("serve-static", "mime.default_type")
     @js.native
     val defaultType: String = js.native
     
-    @JSImport("serve-static", "mime.define")
-    @js.native
-    def define(mimes: TypeMap): Unit = js.native
-    @JSImport("serve-static", "mime.define")
-    @js.native
-    def define(mimes: TypeMap, force: Boolean): Unit = js.native
+    @scala.inline
+    def define(mimes: TypeMap): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("define")(mimes.asInstanceOf[js.Any]).asInstanceOf[Unit]
+    @scala.inline
+    def define(mimes: TypeMap, force: Boolean): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("define")(mimes.asInstanceOf[js.Any], force.asInstanceOf[js.Any])).asInstanceOf[Unit]
     
-    @JSImport("serve-static", "mime.getExtension")
-    @js.native
-    def getExtension(mime: String): String | Null = js.native
+    @scala.inline
+    def getExtension(mime: String): String | Null = ^.asInstanceOf[js.Dynamic].applyDynamic("getExtension")(mime.asInstanceOf[js.Any]).asInstanceOf[String | Null]
     
-    @JSImport("serve-static", "mime.getType")
-    @js.native
-    def getType(path: String): String | Null = js.native
+    @scala.inline
+    def getType(path: String): String | Null = ^.asInstanceOf[js.Dynamic].applyDynamic("getType")(path.asInstanceOf[js.Any]).asInstanceOf[String | Null]
   }
   
-  @JSImport("serve-static", "serveStatic")
-  @js.native
-  def serveStatic(root: String): Handler = js.native
-  @JSImport("serve-static", "serveStatic")
-  @js.native
-  def serveStatic(root: String, options: ServeStaticOptions): Handler = js.native
+  @scala.inline
+  def serveStatic(root: String): Handler = ^.asInstanceOf[js.Dynamic].applyDynamic("serveStatic")(root.asInstanceOf[js.Any]).asInstanceOf[Handler]
+  @scala.inline
+  def serveStatic(root: String, options: ServeStaticOptions): Handler = (^.asInstanceOf[js.Dynamic].applyDynamic("serveStatic")(root.asInstanceOf[js.Any], options.asInstanceOf[js.Any])).asInstanceOf[Handler]
   
   @js.native
   trait ServeStaticOptions extends StObject {

--- a/tests/type-mappings/check/t/type-mappings/build.sbt
+++ b/tests/type-mappings/check/t/type-mappings/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "type-mappings"
-version := "0.0-unknown-6abdea"
+version := "0.0-unknown-4c9a52"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/global.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/global.scala
@@ -8,9 +8,8 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object global {
   
-  @JSGlobal("foo")
-  @js.native
-  def foo(): Person = js.native
+  @scala.inline
+  def foo(): Person = js.Dynamic.global.applyDynamic("foo")().asInstanceOf[Person]
   
   /* This class was inferred from a value with a constructor. In rare cases (like HTMLElement in the DOM) it might not work as you expect. */
   @JSGlobal("newPerson")

--- a/tests/virtual-dom/check/v/virtual-dom/build.sbt
+++ b/tests/virtual-dom/check/v/virtual-dom/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "virtual-dom"
-version := "0.0-unknown-b891be"
+version := "0.0-unknown-995bda"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/virtual-dom/check/v/virtual-dom/src/main/scala/typings/virtualDom/global.scala
+++ b/tests/virtual-dom/check/v/virtual-dom/src/main/scala/typings/virtualDom/global.scala
@@ -9,8 +9,11 @@ object global {
   
   object VirtualDOM {
     
-    @JSGlobal("VirtualDOM.h")
+    @JSGlobal("VirtualDOM")
     @js.native
-    def h(): js.Any = js.native
+    val ^ : js.Any = js.native
+    
+    @scala.inline
+    def h(): js.Any = ^.asInstanceOf[js.Dynamic].applyDynamic("h")().asInstanceOf[js.Any]
   }
 }

--- a/tests/virtual-dom/check/v/virtual-dom/src/main/scala/typings/virtualDom/mod.scala
+++ b/tests/virtual-dom/check/v/virtual-dom/src/main/scala/typings/virtualDom/mod.scala
@@ -7,7 +7,10 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
+  @scala.inline
+  def apply(): js.Any = ^.asInstanceOf[js.Dynamic].apply().asInstanceOf[js.Any]
+  
   @JSImport("virtual-dom/h", JSImport.Namespace)
   @js.native
-  def apply(): js.Any = js.native
+  val ^ : js.Any = js.native
 }

--- a/tests/vue/check/s/storybook__vue/build.sbt
+++ b/tests/vue/check/s/storybook__vue/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "storybook__vue"
-version := "3.3-09971f"
+version := "3.3-6ba554"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/vue/check/s/storybook__vue/src/main/scala/typings/storybookVue/mod.scala
+++ b/tests/vue/check/s/storybook__vue/src/main/scala/typings/storybookVue/mod.scala
@@ -17,25 +17,24 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
-  @JSImport("@storybook/vue", "addDecorator")
+  @JSImport("@storybook/vue", JSImport.Namespace)
   @js.native
-  def addDecorator(decorator: StoryDecorator): Unit = js.native
+  val ^ : js.Any = js.native
   
-  @JSImport("@storybook/vue", "configure")
-  @js.native
-  def configure(loaders: js.Function0[Unit], module: NodeModule): Unit = js.native
+  @scala.inline
+  def addDecorator(decorator: StoryDecorator): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("addDecorator")(decorator.asInstanceOf[js.Any]).asInstanceOf[Unit]
   
-  @JSImport("@storybook/vue", "getStorybook")
-  @js.native
-  def getStorybook(): js.Array[StoryStore] = js.native
+  @scala.inline
+  def configure(loaders: js.Function0[Unit], module: NodeModule): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("configure")(loaders.asInstanceOf[js.Any], module.asInstanceOf[js.Any])).asInstanceOf[Unit]
   
-  @JSImport("@storybook/vue", "setAddon")
-  @js.native
-  def setAddon(addon: Addon): Unit = js.native
+  @scala.inline
+  def getStorybook(): js.Array[StoryStore] = ^.asInstanceOf[js.Dynamic].applyDynamic("getStorybook")().asInstanceOf[js.Array[StoryStore]]
   
-  @JSImport("@storybook/vue", "storiesOf")
-  @js.native
-  def storiesOf(kind: String, module: NodeModule): Story = js.native
+  @scala.inline
+  def setAddon(addon: Addon): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("setAddon")(addon.asInstanceOf[js.Any]).asInstanceOf[Unit]
+  
+  @scala.inline
+  def storiesOf(kind: String, module: NodeModule): Story = (^.asInstanceOf[js.Dynamic].applyDynamic("storiesOf")(kind.asInstanceOf[js.Any], module.asInstanceOf[js.Any])).asInstanceOf[Story]
   
   type Addon = StringDictionary[js.Function2[/* storyName */ String, /* storyFn */ StoryFunction, Unit]]
   

--- a/tests/vue/check/v/vue-resource/build.sbt
+++ b/tests/vue/check/v/vue-resource/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "vue-resource"
-version := "0.9.3-fd8f86"
+version := "0.9.3-eed9c4"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/vue/check/v/vue-resource/src/main/scala/typings/vueResource/mod.scala
+++ b/tests/vue/check/v/vue-resource/src/main/scala/typings/vueResource/mod.scala
@@ -8,7 +8,10 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
+  @scala.inline
+  def apply(vue: VueStatic): Unit = ^.asInstanceOf[js.Dynamic].apply(vue.asInstanceOf[js.Any]).asInstanceOf[Unit]
+  
   @JSImport("vue-resource", JSImport.Namespace)
   @js.native
-  def apply(vue: VueStatic): Unit = js.native
+  val ^ : js.Any = js.native
 }

--- a/tests/with-theme/check/w/with-theme/build.sbt
+++ b/tests/with-theme/check/w/with-theme/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "with-theme"
-version := "0.0-unknown-4fc138"
+version := "0.0-unknown-ffecee"
 scalaVersion := "2.13.3"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/with-theme/check/w/with-theme/src/main/scala/typings/withTheme/mod.scala
+++ b/tests/with-theme/check/w/with-theme/src/main/scala/typings/withTheme/mod.scala
@@ -12,9 +12,12 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
-  @JSImport("with-theme", JSImport.Default)
+  @JSImport("with-theme", JSImport.Namespace)
   @js.native
-  def default(): js.Function1[/* component */ ComponentType[js.Any with WithTheme], ComponentClass[_]] = js.native
+  val ^ : js.Any = js.native
+  
+  @scala.inline
+  def default(): js.Function1[/* component */ ComponentType[js.Any with WithTheme], ComponentClass[_]] = ^.asInstanceOf[js.Dynamic].applyDynamic("default")().asInstanceOf[js.Function1[/* component */ ComponentType[js.Any with WithTheme], ComponentClass[_]]]
   
   type ConsistentWith[T, U] = Pick[U, /* keyof T */ String]
   


### PR DESCRIPTION
This time to generate ensure that when we call methods on a namespace it has a javascript receiver so `this` works.

Fixes #256