### PR TITLE
Drop manually shaded version of circe

### DIFF
--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/ConversionOptions.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/ConversionOptions.scala
@@ -2,7 +2,7 @@ package org.scalablytyped.converter
 package internal
 package importer
 
-import io.circe013.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder}
 import org.scalablytyped.converter.internal.scalajs.{flavours, Name, Versions}
 import org.scalablytyped.converter.internal.ts.TsIdentLibrary
 
@@ -42,7 +42,7 @@ case class ConversionOptions(
 }
 
 object ConversionOptions {
-  import io.circe013.generic.auto._
+  import io.circe.generic.auto._
   import jsonCodecs._
 
   implicit val encodes: Encoder[ConversionOptions] = exportEncoder[ConversionOptions].instance

--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/ScalaJsBundlerDepFile.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/ScalaJsBundlerDepFile.scala
@@ -2,9 +2,9 @@ package org.scalablytyped.converter.internal
 package importer
 
 import org.scalablytyped.converter.internal.ts.TsIdentLibrary
-import io.circe013.generic.semiauto.{deriveDecoder, deriveEncoder}
-import io.circe013.{Decoder, Encoder}
-import io.circe013.syntax._
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
+import io.circe.syntax._
 
 object ScalaJsBundlerDepFile {
 

--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/documentation/Npmjs.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/documentation/Npmjs.scala
@@ -2,8 +2,8 @@ package org.scalablytyped.converter.internal
 package importer.documentation
 
 import com.olvind.logging.Logger
-import io.circe013.generic.semiauto.{deriveDecoder, deriveEncoder}
-import io.circe013.{Decoder, Encoder}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
 import org.scalablytyped.converter.internal.importer.Source
 
 import scala.concurrent.Future

--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/jsonCodecs.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/jsonCodecs.scala
@@ -1,7 +1,7 @@
 package org.scalablytyped.converter.internal
 package importer
 
-import io.circe013._
+import io.circe._
 import org.scalablytyped.converter.internal.ts._
 
 import java.io.File
@@ -34,7 +34,7 @@ object jsonCodecs {
   implicit val TsIdentLibraryKeyDec:  KeyDecoder[TsIdentLibrary] = KeyDecoder[String].map(TsIdentLibrary.apply)
   implicit val TsIdentLibraryKeyEnc:  KeyEncoder[TsIdentLibrary] = KeyEncoder[String].contramap[TsIdentLibrary](_.value)
 
-  import io.circe013.generic.semiauto._
+  import io.circe.generic.semiauto._
 
   implicit val CompilerOptionsEncoder:   Encoder[CompilerOptions]   = deriveEncoder[CompilerOptions]
   implicit val CompilerOptionsDecoder:   Decoder[CompilerOptions]   = deriveDecoder[CompilerOptions]

--- a/importer/src/main/scala/org/scalablytyped/converter/internal/importer/Summary.scala
+++ b/importer/src/main/scala/org/scalablytyped/converter/internal/importer/Summary.scala
@@ -2,9 +2,9 @@ package org.scalablytyped.converter.internal
 package importer
 
 import org.scalablytyped.converter.internal.ts.TsIdentLibrary
-import io.circe013.Decoder.Result
-import io.circe013.generic.semiauto.{deriveDecoder, deriveEncoder}
-import io.circe013.{Decoder, Encoder, HCursor}
+import io.circe.Decoder.Result
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder, HCursor}
 
 case class Summary(
     successes: Set[TsIdentLibrary],

--- a/importer/src/main/scala/org/scalablytyped/converter/internal/importer/build/BinTrayPublisher.scala
+++ b/importer/src/main/scala/org/scalablytyped/converter/internal/importer/build/BinTrayPublisher.scala
@@ -11,7 +11,7 @@ import com.ning.http.client._
 import com.ning.http.client.listenable.AbstractListenableFuture
 import dispatch.{FunctionHandler, Http, StatusCode}
 import gigahorse.Status
-import io.circe013.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder}
 import org.scalablytyped.converter.internal.scalajs.Dep
 import org.scalablytyped.converter.internal.stringUtils.quote
 

--- a/importer/src/test/scala/org/scalablytyped/converter/internal/importer/JsonTests.scala
+++ b/importer/src/test/scala/org/scalablytyped/converter/internal/importer/JsonTests.scala
@@ -1,6 +1,6 @@
 package org.scalablytyped.converter.internal.importer
 
-import io.circe013.parser._
+import io.circe.parser._
 import org.scalablytyped.converter.internal.IArray
 import org.scalablytyped.converter.internal.importer.jsonCodecs._
 import org.scalablytyped.converter.internal.ts._

--- a/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ScalaJsBundlerDepTest.scala
+++ b/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ScalaJsBundlerDepTest.scala
@@ -1,7 +1,7 @@
 package org.scalablytyped.converter.internal.importer
 
-import io.circe013.parser._
-import io.circe013.syntax._
+import io.circe.parser._
+import io.circe.syntax._
 import org.scalablytyped.converter.internal.importer.ScalaJsBundlerDepFile.NpmDependencies
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -15,6 +15,10 @@ object Deps {
   val awssdkS3          = "software.amazon.awssdk" % "s3" % "2.15.28"
   val java8Compat       = "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
 
-  val circe: Seq[ModuleID] =
-    Seq("core", "generic", "parser", "jackson29").map(s => "io.circe013" %% s"circe-$s" % "0.13.0")
+  val circe: List[ModuleID] = {
+    List(
+      "io.circe" %% s"circe-generic" % "0.13.0",
+      "io.circe" %% s"circe-jackson29" % "0.13.0",
+    )
+  }
 }

--- a/sbt-converter/src/main/scala/org/scalablytyped/converter/internal/ImportTypings.scala
+++ b/sbt-converter/src/main/scala/org/scalablytyped/converter/internal/ImportTypings.scala
@@ -4,7 +4,7 @@ package internal
 import java.nio.file.Path
 
 import com.olvind.logging.Logger
-import io.circe013.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder}
 import org.scalablytyped.converter.internal.importer._
 import org.scalablytyped.converter.internal.importer.build.{Compiler, IvyLayout, PublishedSbtProject}
 import org.scalablytyped.converter.internal.importer.documentation.Npmjs
@@ -29,7 +29,7 @@ object ImportTypings {
   }
 
   object Input {
-    import io.circe013.generic.auto._
+    import io.circe.generic.auto._
     import jsonCodecs._
 
     implicit val InputEncoder: Encoder[Input] = exportEncoder[Input].instance
@@ -48,7 +48,7 @@ object ImportTypings {
   }
 
   object Output {
-    import io.circe013.generic.auto._
+    import io.circe.generic.auto._
     import jsonCodecs._
     implicit val OutputEncoder: Encoder[Output] = exportEncoder[Output].instance
     implicit val OutputDecoder: Decoder[Output] = exportDecoder[Output].instance

--- a/sbt-converter/src/main/scala/org/scalablytyped/converter/internal/ImportTypingsGenSources.scala
+++ b/sbt-converter/src/main/scala/org/scalablytyped/converter/internal/ImportTypingsGenSources.scala
@@ -6,7 +6,7 @@ import java.nio.file.Path
 
 import com.olvind.logging
 import com.olvind.logging.{LogLevel, Logger}
-import io.circe013.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder}
 import org.scalablytyped.converter.internal.importer.Source.TsLibSource
 import org.scalablytyped.converter.internal.importer._
 import org.scalablytyped.converter.internal.maps._
@@ -30,7 +30,7 @@ object ImportTypingsGenSources {
   )
 
   object Input {
-    import io.circe013.generic.auto._
+    import io.circe.generic.auto._
     import jsonCodecs._
 
     implicit val ConfigEncoder: Encoder[Input] = exportEncoder[Input].instance

--- a/sbt-converter/src/main/scala/org/scalablytyped/converter/internal/RunCacheKey.scala
+++ b/sbt-converter/src/main/scala/org/scalablytyped/converter/internal/RunCacheKey.scala
@@ -1,7 +1,7 @@
 package org.scalablytyped.converter.internal
 
 import com.olvind.logging.Formatter
-import io.circe013.syntax._
+import io.circe.syntax._
 
 case class RunCacheKey private (digest: Digest) {
   def path(cacheDir: os.Path): os.Path = cacheDir / "runs" / s"${digest.hexString}.json"

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/Dep.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/Dep.scala
@@ -1,6 +1,6 @@
 package org.scalablytyped.converter.internal.scalajs
 
-import io.circe013.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder}
 import org.scalablytyped.converter.internal.stringUtils.quote
 
 import scala.xml.Elem
@@ -75,6 +75,6 @@ object Dep {
     override def version: String = dep.version
   }
 
-  implicit val DepDecoder: Decoder[Dep] = io.circe013.generic.semiauto.deriveDecoder[Dep]
-  implicit val DepEncoder: Encoder[Dep] = io.circe013.generic.semiauto.deriveEncoder[Dep]
+  implicit val DepDecoder: Decoder[Dep] = io.circe.generic.semiauto.deriveDecoder[Dep]
+  implicit val DepEncoder: Encoder[Dep] = io.circe.generic.semiauto.deriveEncoder[Dep]
 }

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/SlinkyTagsLoader.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/SlinkyTagsLoader.scala
@@ -2,7 +2,7 @@ package org.scalablytyped.converter.internal
 package scalajs
 package flavours
 
-import io.circe013.Decoder
+import io.circe.Decoder
 import org.scalablytyped.converter.internal.maps._
 import org.scalablytyped.converter.internal.scalajs.QualifiedName.StdNames
 import org.scalablytyped.converter.internal.scalajs.flavours.SlinkyGenComponents.names.{
@@ -159,9 +159,9 @@ object SlinkyTagsLoader {
   /* extract what we need from the slinky json files */
   type AttrsByTag = Map[TagName.Concrete, (Tag, Set[String])]
   object AttrsByTag {
-    implicit val TagDecoder:       Decoder[Tag]       = io.circe013.generic.semiauto.deriveDecoder[Tag]
-    implicit val AttributeDecoder: Decoder[Attribute] = io.circe013.generic.semiauto.deriveDecoder[Attribute]
-    implicit val TagsModelDecoder: Decoder[TagsModel] = io.circe013.generic.semiauto.deriveDecoder[TagsModel]
+    implicit val TagDecoder:       Decoder[Tag]       = io.circe.generic.semiauto.deriveDecoder[Tag]
+    implicit val AttributeDecoder: Decoder[Attribute] = io.circe.generic.semiauto.deriveDecoder[Attribute]
+    implicit val TagsModelDecoder: Decoder[TagsModel] = io.circe.generic.semiauto.deriveDecoder[TagsModel]
 
     private def massage(model: TagsModel): AttrsByTag =
       model.tags.map { tag =>

--- a/utils/src/main/scala/org/scalablytyped/converter/internal/Json.scala
+++ b/utils/src/main/scala/org/scalablytyped/converter/internal/Json.scala
@@ -4,8 +4,8 @@ import java.io.File
 import java.nio.file.{Files, Path}
 
 import cats.data.ValidatedNel
-import io.circe013._
-import io.circe013.syntax._
+import io.circe._
+import io.circe.syntax._
 
 import scala.io.Source
 import scala.util.control.NonFatal
@@ -18,7 +18,7 @@ object Json {
   object CustomJacksonParser extends Parser {
     import com.fasterxml.jackson.core.{JsonFactory, JsonParser}
     import com.fasterxml.jackson.databind.ObjectMapper
-    import io.circe013.jackson.CirceJsonModule
+    import io.circe.jackson.CirceJsonModule
 
 //    val Features = Set[JsonReadFeature](
 //      JsonReadFeature.ALLOW_JAVA_COMMENTS,


### PR DESCRIPTION
Ok, so this PR is good news and bad news.

The good news is that this will enable publication to maven central (partially solving #262  ).

For the bad news, it'll break builds. Let's start with some background:

Circe is an amazing json library, and it's used in this sbt plugin and many others. However, it's not binary compatible across versions, and earlier on it caused a lot of friction where adding the ST plugin to a build would break other plugins (using an older version of circe). Before I fixed it, binary incompatibility with older versions of circe was the number one issue with the sbt plugin.

My fix was to manually shade all the circe modules, see https://github.com/ScalablyTyped/circe and https://github.com/ScalablyTyped/circe-jackson . All these modules were published to Bintray along with the converter. Note that this was *not* done lightly, because it's obviously not a very nice thing to do. I spent much time on this, and no amount of other methods seemed to work. I really have enjoyed developing plugins for sbt - it's a fantastic tool - but this single issue ruins the experience.

Now that bintray is going away we'll need a new solution here. I don't want to publish the shaded version to maven central where it'll be for all eternity. I would also have to change the maven coordinates to be allowed to publish it, which is putting more work into an evolutionary dead end.

So now I'm reverting that fix.

If you read this issue I guess it'll have broken your build. These are you options:
- generate your ST artifacts in a separate sbt project with the [source generation plugin](https://scalablytyped.org/docs/library-developer)
- use the [CLI tool](https://scalablytyped.org/docs/cli) to generate your artifacts, it doesn't suffer from this problem. Note that the publication part of the CLI tool also needs to be rewritten as part of #262)
- identify your plugins with conflicting versions of circe and kindly ask them to upgrade
- figure out how to shade dependencies and send a PR 
- port ST to use another json library without this problem. Note in that case that it *has* to be a lenient parser, because we're parsing json manually written by javascript developers
- gently give the sbt maintainers a hint that you'd like to see a permanent fix with a classloader per sbt plugin
