### PR TITLE
New implementation of Minimization (fixes #270)

### DIFF
--- a/sbt-converter/src/main/scala/org/scalablytyped/converter/internal/ImportTypingsGenSources.scala
+++ b/sbt-converter/src/main/scala/org/scalablytyped/converter/internal/ImportTypingsGenSources.scala
@@ -105,10 +105,12 @@ object ImportTypingsGenSources {
           false,
         )
 
-        lazy val referencesToKeep: Minimization.KeepIndex =
-          Minimization.findReferences(globalScope, input.minimizeKeep, IArray.fromTraversable(libs).map {
-            case (s, l) => (minimize(s.libName), l.packageTree)
-          })
+        lazy val referencesToKeep: Minimization.KeepIndex = {
+          val packagesWithShouldMinimize: IArray[(PackageTree, Boolean)] =
+            IArray.fromTraversable(libs).map { case (s, l) => (l.packageTree, minimize(s.libName)) }
+
+          Minimization.findReferences(globalScope, input.minimizeKeep, packagesWithShouldMinimize)
+        }
 
         val outFiles: Map[os.Path, Array[Byte]] =
           libs.par.flatMap {

--- a/utils/src/main/scala/org/scalablytyped/converter/internal/IArray.scala
+++ b/utils/src/main/scala/org/scalablytyped/converter/internal/IArray.scala
@@ -439,7 +439,7 @@ object IArray {
   }
 }
 
-final class IArray[+A <: AnyRef](private val array: Array[AnyRef], val length: Int) extends Serializable {
+final class IArray[+A <: AnyRef](private val array: Array[AnyRef], val length: Int) extends Serializable { self =>
   @inline def isEmpty: Boolean =
     length == 0
 
@@ -844,7 +844,7 @@ final class IArray[+A <: AnyRef](private val array: Array[AnyRef], val length: I
 
   def iterator: Iterator[A] = new Iterator[A] {
     var idx = 0
-    override def hasNext: Boolean = idx < length
+    override def hasNext: Boolean = idx < self.length
 
     override def next(): A = {
       val ret = array(idx).asInstanceOf[A]


### PR DESCRIPTION
- make `Minimization.Related` work like advertised, so it's also considered when including parent trees
- add a `Minimization.Related` tag to the `To`, `_to` and `^` members so it works with the new encoding