### PR TITLE
Add support for labeled tuple elements

### DIFF
--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/ImportType.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/ImportType.scala
@@ -213,7 +213,7 @@ class ImportType(stdNames: QualifiedName.StdNames) {
 
       case TsTypeTuple(targs) =>
         targs match {
-          case IArray.initLast(init, TsTypeRepeated(repeated)) =>
+          case IArray.initLast(init, TsTupleElement(_, TsTypeRepeated(repeated))) =>
             ts.FollowAliases(scope)(repeated) match {
               case TsTypeRef(
                   _,
@@ -222,7 +222,7 @@ class ImportType(stdNames: QualifiedName.StdNames) {
                   ) =>
                 TypeRef(
                   importName(TsQIdent.Array),
-                  IArray(apply(wildcards, scope, importName)(TsTypeUnion(init :+ elem))).distinct,
+                  IArray(apply(wildcards, scope, importName)(TsTypeUnion(init.map(_.tpe) :+ elem))).distinct,
                   NoComments,
                 )
               case other =>
@@ -230,7 +230,7 @@ class ImportType(stdNames: QualifiedName.StdNames) {
                 TypeRef(importName(TsQIdent.Array), Empty, Comments(c))
             }
           case nonRepeating =>
-            TypeRef.Tuple(nonRepeating.map(apply(wildcards.maybeAllow, scope, importName)))
+            TypeRef.Tuple(nonRepeating.map(elem => apply(wildcards.maybeAllow, scope, importName)(elem.tpe)))
         }
 
       case TsTypeRepeated(underlying) =>

--- a/importer/src/test/scala/org/scalablytyped/converter/internal/ts/parser/ParserTests.scala
+++ b/importer/src/test/scala/org/scalablytyped/converter/internal/ts/parser/ParserTests.scala
@@ -2243,7 +2243,11 @@ type Readonly<T> = {
                   TsFunParam(
                     NoComments,
                     TsIdentSimple("hasKeyVal"),
-                    Some(TsTypeTuple(IArray(TsTypeRef.any, TsTypeRef.any))),
+                    Some(
+                      TsTypeTuple(
+                        IArray(TsTupleElement.unlabeled(TsTypeRef.any), TsTupleElement.unlabeled(TsTypeRef.any)),
+                      ),
+                    ),
                   ),
                 ),
                 Some(TsTypeRef.any),
@@ -2289,7 +2293,12 @@ type Readonly<T> = {
       "[number, number?]",
       TsParser.tsType,
     )(
-      TsTypeTuple(IArray(TsTypeRef.number, TsTypeUnion(IArray(TsTypeRef.number, TsTypeRef.undefined)))),
+      TsTypeTuple(
+        IArray(
+          TsTupleElement.unlabeled(TsTypeRef.number),
+          TsTupleElement.unlabeled(TsTypeUnion(IArray(TsTypeRef.number, TsTypeRef.undefined))),
+        ),
+      ),
     )
   }
 
@@ -2300,9 +2309,13 @@ type Readonly<T> = {
     )(
       TsTypeTuple(
         IArray(
-          TsTypeRef(NoComments, TsQIdent.number, Empty),
-          TsTypeRef(NoComments, TsQIdent.number, Empty),
-          TsTypeRepeated(TsTypeRef(NoComments, TsQIdent.Array, IArray(TsTypeRef(NoComments, TsQIdent.of("T"), Empty)))),
+          TsTupleElement.unlabeled(TsTypeRef(NoComments, TsQIdent.number, Empty)),
+          TsTupleElement.unlabeled(TsTypeRef(NoComments, TsQIdent.number, Empty)),
+          TsTupleElement.unlabeled(
+            TsTypeRepeated(
+              TsTypeRef(NoComments, TsQIdent.Array, IArray(TsTypeRef(NoComments, TsQIdent.of("T"), Empty))),
+            ),
+          ),
         ),
       ),
     )
@@ -2370,8 +2383,8 @@ type Readonly<T> = {
         IArray(
           TsTypeTuple(
             IArray(
-              TsTypeRef(NoComments, TsQIdent(IArray(TsIdentSimple("K"))), Empty),
-              TsTypeRef(NoComments, TsQIdent(IArray(TsIdentSimple("V"))), Empty),
+              TsTupleElement.unlabeled(TsTypeRef(NoComments, TsQIdent(IArray(TsIdentSimple("K"))), Empty)),
+              TsTupleElement.unlabeled(TsTypeRef(NoComments, TsQIdent(IArray(TsIdentSimple("V"))), Empty)),
             ),
           ),
         ),
@@ -2500,7 +2513,85 @@ export {};
 
   test("[string, ...PrimitiveArray]") {
     shouldParseAs("""[string, ...PrimitiveArray]""", TsParser.tsTypeTuple)(
-      TsTypeTuple(IArray(TsTypeRef.string, TsTypeRepeated(TsTypeRef(TsIdentSimple("PrimitiveArray"))))),
+      TsTypeTuple(
+        IArray(
+          TsTupleElement.unlabeled(TsTypeRef.string),
+          TsTupleElement.unlabeled(TsTypeRepeated(TsTypeRef(TsIdentSimple("PrimitiveArray")))),
+        ),
+      ),
+    )
+  }
+
+  test("[x: string, y: number]") {
+    shouldParseAs("""[x: string, y: number]""", TsParser.tsTypeTuple)(
+      TsTypeTuple(
+        IArray(
+          TsTupleElement(label = Some(TsIdentSimple("x")), TsTypeRef.string),
+          TsTupleElement(label = Some(TsIdentSimple("y")), TsTypeRef.number),
+        ),
+      ),
+    )
+  }
+
+  test("[x: string, y?: number]") {
+    shouldParseAs("""[x: string, y?: number]""", TsParser.tsTypeTuple)(
+      TsTypeTuple(
+        IArray(
+          TsTupleElement(label = Some(TsIdentSimple("x")), TsTypeRef.string),
+          TsTupleElement(label = Some(TsIdentSimple("y")), TsTypeUnion(IArray(TsTypeRef.number, TsTypeRef.undefined))),
+        ),
+      ),
+    )
+  }
+
+  test("[x: string, ...ys: PrimitiveArray]") {
+    shouldParseAs("""[x: string, ...ys: PrimitiveArray]""", TsParser.tsTypeTuple)(
+      TsTypeTuple(
+        IArray(
+          TsTupleElement(label = Some(TsIdentSimple("x")), TsTypeRef.string),
+          TsTupleElement(
+            label = Some(TsIdentSimple("ys")),
+            TsTypeRepeated(TsTypeRef(TsIdentSimple("PrimitiveArray"))),
+          ),
+        ),
+      ),
+    )
+  }
+
+  test("[...xs: PrimitiveArray, y: number]") {
+    shouldParseAs("""[...xs: PrimitiveArray, y: number]""", TsParser.tsTypeTuple)(
+      TsTypeTuple(
+        IArray(
+          TsTupleElement(
+            label = Some(TsIdentSimple("xs")),
+            TsTypeRepeated(TsTypeRef(TsIdentSimple("PrimitiveArray"))),
+          ),
+          TsTupleElement(label = Some(TsIdentSimple("y")), TsTypeRef.number),
+        ),
+      ),
+    )
+  }
+
+  test("[string, ...PrimitiveArray, number]") {
+    shouldParseAs("""[string, ...PrimitiveArray, number]""", TsParser.tsTypeTuple)(
+      TsTypeTuple(
+        IArray(
+          TsTupleElement.unlabeled(TsTypeRef.string),
+          TsTupleElement.unlabeled(TsTypeRepeated(TsTypeRef(TsIdentSimple("PrimitiveArray")))),
+          TsTupleElement.unlabeled(TsTypeRef.number),
+        ),
+      ),
+    )
+  }
+
+  test("[...PrimitiveArray, number]") {
+    shouldParseAs("""[...PrimitiveArray, number]""", TsParser.tsTypeTuple)(
+      TsTypeTuple(
+        IArray(
+          TsTupleElement.unlabeled(TsTypeRepeated(TsTypeRef(TsIdentSimple("PrimitiveArray")))),
+          TsTupleElement.unlabeled(TsTypeRef.number),
+        ),
+      ),
     )
   }
 

--- a/ts/src/main/scala/org/scalablytyped/converter/internal/ts/TreeTransformation.scala
+++ b/ts/src/main/scala/org/scalablytyped/converter/internal/ts/TreeTransformation.scala
@@ -467,7 +467,7 @@ trait TreeTransformation[T] { self =>
     val xx = enterTsTypeTuple(withTree(t, x))(x)
     val tt = withTree(t, xx)
     xx match {
-      case TsTypeTuple(_1) => TsTypeTuple(_1.map(visitTsType(tt)))
+      case TsTypeTuple(_1) => TsTypeTuple(_1.map(visitTsTupleElem(tt)))
     }
   }
   final def visitTsTypeUnion(t: T)(x: TsTypeUnion): TsTypeUnion = {
@@ -587,6 +587,9 @@ trait TreeTransformation[T] { self =>
       case x: TsTypeTuple       => visitTsTypeTuple(t)(x)
       case x: TsTypeUnion       => visitTsTypeUnion(t)(x)
     })
+
+  final def visitTsTupleElem(t: T)(tupleElem: TsTupleElement): TsTupleElement =
+    TsTupleElement(tupleElem.label, visitTsType(t)(tupleElem.tpe))
 
   final def visitTsMember(t: T)(x: TsMember): TsMember =
     enterTsMember(withTree(t, x))(x) match {

--- a/ts/src/main/scala/org/scalablytyped/converter/internal/ts/TsTypeFormatter.scala
+++ b/ts/src/main/scala/org/scalablytyped/converter/internal/ts/TsTypeFormatter.scala
@@ -113,6 +113,11 @@ class TsTypeFormatter(val keepComments: Boolean) {
     case TsLiteralNumber(num)   => num
   }
 
+  def tupleElement(elem: TsTupleElement): String = {
+    val label = elem.label.map(_.value + ": ").getOrElse("")
+    label + apply(elem.tpe)
+  }
+
   def apply(tpe: TsType): String =
     tpe match {
       case TsTypeRef(cs, name, ts) =>
@@ -122,7 +127,7 @@ class TsTypeFormatter(val keepComments: Boolean) {
       case TsTypeFunction(s)                        => s"${sig(s)}"
       case TsTypeConstructor(f)                     => s"new ${apply(f)}"
       case TsTypeIs(ident, x)                       => s"${ident.value} is ${apply(x)}"
-      case TsTypeTuple(tparams)                     => s"[${tparams.map(apply).mkString(", ")}]"
+      case TsTypeTuple(elems)                       => s"[${elems.map(tupleElement).mkString(", ")}]"
       case TsTypeQuery(expr)                        => s"typeof ${qident(expr)}"
       case TsTypeRepeated(underlying)               => s"...${apply(underlying)}"
       case TsTypeKeyOf(key)                         => s"keyof ${apply(key)}"

--- a/ts/src/main/scala/org/scalablytyped/converter/internal/ts/transforms/ResolveTypeLookups.scala
+++ b/ts/src/main/scala/org/scalablytyped/converter/internal/ts/transforms/ResolveTypeLookups.scala
@@ -8,7 +8,7 @@ import org.scalablytyped.converter.internal.ts.transforms.ExpandTypeMappings.Tag
 object ResolveTypeLookups extends TreeTransformationScopedChanges {
   override def leaveTsType(scope: TsTreeScope)(x: TsType): TsType =
     x match {
-      case TsTypeLookup(TsTypeTuple(tparams), TsTypeRef.number) => TsTypeUnion(tparams)
+      case TsTypeLookup(TsTypeTuple(elems), TsTypeRef.number) => TsTypeUnion(elems.map(_.tpe))
       case lookup: TsTypeLookup =>
         expandLookupType(scope, lookup).getOrElse(x)
 

--- a/ts/src/main/scala/org/scalablytyped/converter/internal/ts/trees.scala
+++ b/ts/src/main/scala/org/scalablytyped/converter/internal/ts/trees.scala
@@ -541,7 +541,13 @@ final case class TsTypeIs(ident: TsIdent, tpe: TsType) extends TsType
 
 final case class TsTypeAsserts(ident: TsIdentSimple, isOpt: Option[TsTypeRef]) extends TsType
 
-final case class TsTypeTuple(tparams: IArray[TsType]) extends TsType
+final case class TsTupleElement(label: Option[TsIdent], tpe: TsType)
+
+object TsTupleElement {
+  def unlabeled(tpe: TsType): TsTupleElement = TsTupleElement(label = None, tpe)
+}
+
+final case class TsTypeTuple(elems: IArray[TsTupleElement]) extends TsType
 
 final case class TsTypeQuery(expr: TsQIdent) extends TsType
 


### PR DESCRIPTION
This PR adds support for labeled tuple elements that were [introduced](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#labeled-tuple-elements
) in Typescript 4.0 and further [enhanced](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-2.html#leadingmiddle-rest-elements-in-tuple-types) in 4.2. I first encountered them in [react-map-gl](https://github.com/visgl/react-map-gl/blob/db08714945b106062a9e8b87722a8c0e343eb3de/src/components/interactive-map.d.ts#L12).

The label is not used for anything when producing Scala code but I decided not to ignore it and parse it and so I introduced `TsTupleElement` in place of bare `TsType`.

Many of the demo set tests succeeded but then entire run failed with an error that doesn't seem to be related to my changes.

```
[error] 2021-03-19T22:34:35.510642336Z Cmd.scala:28  '/home/povder/.cache/scalablytyped/npm: npm add --ignore-scripts --no-cache --no-audit --no-bin-links stellar-base stellar-sdk storm-react-diagrams stream-mock string-argv string-length string-width stringify-attributes strip-ansi strip-bom strip-indent strip-json-comments stripe striptags styled-components stylelint-webpack-plugin subsume sudo-block sugar superagent-proxy superstruct survey-knockout svg-pan-zoom svg.js sw-toolbox swagger-parser swap-case sweetalert sync-request systeminformation tabris tabris-plugin-firebase tcomb temp-dir temp-write tempfile tempy tensorflow tensorscript term-size terminal-image terminal-link terser text-clipper theming tildify time-span timezonecomplete title-case to-fast-properties to-semver transliteration trash treat trim-newlines ts-mockito ts-toolbelt ts3-nodejs-library tslint tsmonad tus-js-client tween.js twilio-chat typed-github-api typed-graphql typed-rest-client typed-undo typed.js typedoc typeorm typesafe-actions typescript typescript-optional typescript-services typestub-ipfs ua-string ui-box uk.co.workingedge.phonegap.plugin.istablet uk.co.workingedge.phonegap.plugin.launchnavigator unique-random unique-random-array unique-string unist-util-is universal-cookie universal-router unsplash-js untildify unused-filename upper-case upper-case-first url-regex urllib use-dark-mode use-deep-compare-effect username uuidjs uuidv4 validate.js vanilla-tilt vega'

[error] npm ERR! Error while executing:
[error] npm ERR! /usr/bin/git ls-remote -h -t ssh://git@github.com/hugomrdias/pull-ws.git
[error] npm ERR!
[error] npm ERR! ERROR: Repository not found.
[error] npm ERR! fatal: Could not read from remote repository.
```



