### PR TITLE
Enable `@ScalaJSDefined` by default for Scala 3

### DIFF
--- a/cli/src/main/scala/org/scalablytyped/converter/cli/Main.scala
+++ b/cli/src/main/scala/org/scalablytyped/converter/cli/Main.scala
@@ -34,7 +34,7 @@ object Main {
   val DefaultOptions = ConversionOptions(
     useScalaJsDomTypes     = true,
     outputPackage          = Name.typings,
-    enableScalaJsDefined   = Selection.None,
+    enableScalaJsDefined   = Selection.All,
     flavour                = Flavour.Normal,
     ignored                = SortedSet("typescript"),
     stdLibs                = SortedSet("es6"),

--- a/docs/conversion-options.md
+++ b/docs/conversion-options.md
@@ -56,7 +56,7 @@ project.settings(
 )
 ```
 
-By default this is off, that is `Selection.None()`
+By default this is *on* for Scala 3, and *off* for Scala 2.
 
 ### `stStdLib`
 This mirrors the `--lib` option to typescript, see 

--- a/docs/devel/running.md
+++ b/docs/devel/running.md
@@ -26,8 +26,8 @@ For development you'll always use "debug mode".
 | `-dontCleanProject`   | Normally the CI build aggressively resets the ScalablyTyped git repo. Enabling this will skip that
 | `-enableParseCache`   | The Typescript parser is somewhat slow. Enabling this uses java serialization to cache when possible 
 | `-forceCommit`        | Commit and build sbt plugin in debug mode 
-| `-scala212`           | Build libraries with Scala 2.12 instead of 2.13
-| `-scalajs06`          | Build libraries with Scala.js 0.6 instead of 1 
+| `-scala212`           | Build libraries with Scala 2.12 instead of 3.0.0
+| `-scala213`           | Build libraries with Scala 2.13 instead of 3.0.0
 | `-offline`            | Skip pulling newest DefinitelyTyped and running `npm update`
 | `-pedantic`           | Make the converter more strict. Most things don't work yet in this mode
 | `-softWrites`         | Will only write changed/deleted files. This is essential if you want to keep ScalablyTyped products open in an IDE to avoid reindexing the world.

--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/IsUserImplementable.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/IsUserImplementable.scala
@@ -17,7 +17,8 @@ import org.scalablytyped.converter.internal.ts._
   */
 object IsUserImplementable {
   def apply(interface: WithParents[TsDeclInterface]): Boolean =
-    pred(interface.value) && interface.parents.forall(pred)
+    if (interface.unresolved.nonEmpty) false
+    else pred(interface.value) && interface.parents.forall(pred)
 
   def legalName(name: TsIdent): Boolean =
     name =/= TsIdent.Apply && name =/= TsIdent.namespaced

--- a/importer/src/main/scala/org/scalablytyped/converter/internal/importer/Ci.scala
+++ b/importer/src/main/scala/org/scalablytyped/converter/internal/importer/Ci.scala
@@ -97,17 +97,12 @@ object Ci {
                 "org.scalablytyped",
               )
 
-          val enableScalaJsDefined: Selection[TsIdentLibrary] =
-            if (flags contains "-enableScalaJsDefined")
-              Selection.AllExcept(Libraries.Slow.to[Seq]: _*)
-            else Selection.None
-
           Some(
             Config(
               conversion = ConversionOptions(
                 useScalaJsDomTypes   = shouldUseScalaJsDomTypes,
                 outputPackage        = outputPackage,
-                enableScalaJsDefined = enableScalaJsDefined,
+                enableScalaJsDefined = Selection.All,
                 flavour              = flavour,
                 ignored              = Libraries.ignored.map(_.value),
                 stdLibs              = SortedSet("esnext.full"),

--- a/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterHarness.scala
+++ b/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterHarness.scala
@@ -72,7 +72,7 @@ trait ImporterHarness extends AnyFunSuite {
           new Phase2ToScalaJs(
             pedantic,
             scalaVersion         = version.scala,
-            enableScalaJsDefined = Selection.None,
+            enableScalaJsDefined = Selection.All,
             outputPkg            = flavour.outputPkg,
             flavour              = flavour,
           ),

--- a/sbt-converter/src/main/scala/org/scalablytyped/converter/plugin/ScalablyTypedPluginBase.scala
+++ b/sbt-converter/src/main/scala/org/scalablytyped/converter/plugin/ScalablyTypedPluginBase.scala
@@ -60,7 +60,9 @@ object ScalablyTypedPluginBase extends AutoPlugin {
   override lazy val projectSettings =
     Seq(
       stInternalExpandTypeMappings := EnabledTypeMappingExpansion.DefaultSelection.map(_.value),
-      stEnableScalaJsDefined := converter.Selection.None,
+      stEnableScalaJsDefined := {
+        if ((Compile / Keys.scalaVersion).value.startsWith("3")) converter.Selection.All else converter.Selection.None
+      },
       stFlavour := converter.Flavour.Normal,
       stIgnore := List("typescript"),
       stOutputPackage := Name.typings.unescaped,

--- a/tests/antd/check/a/antd/build.sbt
+++ b/tests/antd/check/a/antd/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "antd"
-version := "4.3.1-8e4ccb"
+version := "4.3.1-f83bb0"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/antd/check/a/antd/src/main/scala/typings/antd/mod.scala
+++ b/tests/antd/check/a/antd/src/main/scala/typings/antd/mod.scala
@@ -7,12 +7,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 object mod {
   
   /* Inlined parent std.Omit<rc-field-form.rc-field-form/es/Form.FormProps, 'form'> */
-  @js.native
   trait FormProps extends StObject {
     
-    var name: js.UndefOr[String] = js.native
+    var name: js.UndefOr[String] = js.undefined
     
-    var prefixCls: js.UndefOr[String] = js.native
+    var prefixCls: js.UndefOr[String] = js.undefined
   }
   object FormProps {
     

--- a/tests/antd/check/r/rc-field-form/build.sbt
+++ b/tests/antd/check/r/rc-field-form/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "rc-field-form"
-version := "1.4.4-f48d99"
+version := "1.4.4-d9cd5b"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/antd/check/r/rc-field-form/src/main/scala/typings/rcFieldForm/mod.scala
+++ b/tests/antd/check/r/rc-field-form/src/main/scala/typings/rcFieldForm/mod.scala
@@ -6,10 +6,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
-  @js.native
   trait FormProps extends StObject {
     
-    var name: js.UndefOr[String] = js.native
+    var name: js.UndefOr[String] = js.undefined
   }
   object FormProps {
     

--- a/tests/augment-module/check/l/lodash/build.sbt
+++ b/tests/augment-module/check/l/lodash/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "lodash"
-version := "4.14-f636d6"
+version := "4.14-5cc4a6"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-58cf91")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-434525")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/augment-module/check/l/lodash/src/main/scala/typings/lodash/fpMod.scala
+++ b/tests/augment-module/check/l/lodash/src/main/scala/typings/lodash/fpMod.scala
@@ -14,13 +14,12 @@ object fpMod extends Shortcut {
   @js.native
   val ^ : LoDashFp = js.native
   
-  @js.native
   trait LoDashFp extends StObject {
     
-    def curry[T1, R](func: js.Function1[/* t1 */ T1, R]): CurriedFunction1[T1, R] = js.native
-    def curry[T1, T2, R](func: js.Function2[/* t1 */ T1, /* t2 */ T2, R]): CurriedFunction2[T1, T2, R] = js.native
+    def curry[T1, R](func: js.Function1[/* t1 */ T1, R]): CurriedFunction1[T1, R]
+    def curry[T1, T2, R](func: js.Function2[/* t1 */ T1, /* t2 */ T2, R]): CurriedFunction2[T1, T2, R]
     @JSName("curry")
-    var curry_Original: Curry = js.native
+    var curry_Original: Curry
   }
   object LoDashFp {
     
@@ -47,19 +46,15 @@ object fpMod extends Shortcut {
   object global {
     
     // tslint:disable-next-line:no-empty-interface
-    @js.native
     trait Map[K, V] extends StObject
     
     // tslint:disable-next-line:no-empty-interface
-    @js.native
     trait Set[T] extends StObject
     
     // tslint:disable-next-line:no-empty-interface
-    @js.native
     trait WeakMap[K /* <: js.Object */, V] extends StObject
     
     // tslint:disable-next-line:no-empty-interface
-    @js.native
     trait WeakSet[T] extends StObject
   }
 }

--- a/tests/augment-module/check/l/lodash/src/main/scala/typings/lodash/mod.scala
+++ b/tests/augment-module/check/l/lodash/src/main/scala/typings/lodash/mod.scala
@@ -88,19 +88,15 @@ object mod extends Shortcut {
   object global {
     
     // tslint:disable-next-line:no-empty-interface
-    @js.native
     trait Map[K, V] extends StObject
     
     // tslint:disable-next-line:no-empty-interface
-    @js.native
     trait Set[T] extends StObject
     
     // tslint:disable-next-line:no-empty-interface
-    @js.native
     trait WeakMap[K /* <: js.Object */, V] extends StObject
     
     // tslint:disable-next-line:no-empty-interface
-    @js.native
     trait WeakSet[T] extends StObject
   }
 }

--- a/tests/augment-module/check/s/std/build.sbt
+++ b/tests/augment-module/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-58cf91"
+version := "0.0-unknown-434525"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/augment-module/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/augment-module/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/augment-module/check/s/std/src/main/scala/typings/std/ArrayLike.scala
+++ b/tests/augment-module/check/s/std/src/main/scala/typings/std/ArrayLike.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ArrayLike[T] extends StObject

--- a/tests/aws-sdk/check/a/aws-sdk/build.sbt
+++ b/tests/aws-sdk/check/a/aws-sdk/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "aws-sdk"
-version := "2.247.1-8dbdeb"
+version := "2.247.1-8fb9b0"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsSdk/configMod.scala
+++ b/tests/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsSdk/configMod.scala
@@ -28,18 +28,17 @@ object configMod {
     def loadFromPath(path: String): Config & ConfigurationServicePlaceholders & APIVersions = js.native
   }
   
-  @js.native
   trait APIVersions extends StObject {
     
     /**
       * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in all services (unless overridden by apiVersions). Specify \'latest\' to use the latest possible version.
       */
-    var apiVersion: js.UndefOr[latest | String] = js.native
+    var apiVersion: js.UndefOr[latest | String] = js.undefined
     
     /**
       * A map of service identifiers (the lowercase service class name) with the API version to use when instantiating a service. Specify 'latest' for each individual that can use the latest available version.
       */
-    var apiVersions: js.UndefOr[ConfigurationServiceApiVersions] = js.native
+    var apiVersions: js.UndefOr[ConfigurationServiceApiVersions] = js.undefined
   }
   object APIVersions {
     

--- a/tests/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsSdk/configServicePlaceholdersMod.scala
+++ b/tests/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsSdk/configServicePlaceholdersMod.scala
@@ -15,10 +15,9 @@ object configServicePlaceholdersMod {
     var dynamodb: js.UndefOr[ClientConfiguration] = js.native
   }
   
-  @js.native
   trait ConfigurationServiceApiVersions extends StObject {
     
-    var dynamodb: js.UndefOr[apiVersion] = js.native
+    var dynamodb: js.UndefOr[apiVersion] = js.undefined
   }
   object ConfigurationServiceApiVersions {
     

--- a/tests/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsSdk/documentClientMod.scala
+++ b/tests/aws-sdk/check/a/aws-sdk/src/main/scala/typings/awsSdk/documentClientMod.scala
@@ -28,21 +28,20 @@ object documentClientMod {
     */
     type AttributeAction = _AttributeAction | String
     
-    @js.native
     trait ConverterOptions extends StObject {
       
       /**
         * An optional flag indicating that the document client should cast
         * empty strings, buffers, and sets to NULL shapes
         */
-      var convertEmptyValues: js.UndefOr[Boolean] = js.native
+      var convertEmptyValues: js.UndefOr[Boolean] = js.undefined
       
       /**
         * Whether to return numbers as a NumberValue object instead of
         * converting them to native JavaScript numbers. This allows for the
         * safe round-trip transport of numbers of arbitrary size.
         */
-      var wrapNumbers: js.UndefOr[Boolean] = js.native
+      var wrapNumbers: js.UndefOr[Boolean] = js.undefined
     }
     object ConverterOptions {
       
@@ -69,7 +68,6 @@ object documentClientMod {
       }
     }
     
-    @js.native
     trait DocumentClientOptions
       extends StObject
          with ConverterOptions {
@@ -77,12 +75,12 @@ object documentClientMod {
       /**
         * An optional map of parameters to bind to every request sent by this service object.
         */
-      var params: js.UndefOr[StringDictionary[js.Any]] = js.native
+      var params: js.UndefOr[StringDictionary[js.Any]] = js.undefined
       
       /**
         * An optional pre-configured instance of the AWS.DynamoDB service object to use for requests. The object may bound parameters used by the document client.
         */
-      var service: js.UndefOr[^] = js.native
+      var service: js.UndefOr[^] = js.undefined
     }
     object DocumentClientOptions {
       

--- a/tests/bigint/check/b/bigint/build.sbt
+++ b/tests/bigint/check/b/bigint/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "bigint"
-version := "v5.5.3-27693a"
+version := "v5.5.3-3a5bb3"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-1c9490")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-b11d9a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/bigint/check/b/bigint/src/main/scala/typings/bigint/Test.scala
+++ b/tests/bigint/check/b/bigint/src/main/scala/typings/bigint/Test.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Test extends StObject {
   
-  var a: js.BigInt = js.native
+  var a: js.BigInt
   
-  var b: js.BigInt = js.native
+  var b: js.BigInt
   
-  var c: typings.bigint.BigInt.BigInt = js.native
+  var c: typings.bigint.BigInt.BigInt
 }
 object Test {
   

--- a/tests/bigint/check/s/std/build.sbt
+++ b/tests/bigint/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-1c9490"
+version := "0.0-unknown-b11d9a"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/bigint/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/bigint/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/bigint/check/s/std/src/main/scala/typings/std/BigInt.scala
+++ b/tests/bigint/check/s/std/src/main/scala/typings/std/BigInt.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait BigInt extends StObject

--- a/tests/chart.js/check/c/chart_dot_js/build.sbt
+++ b/tests/chart.js/check/c/chart_dot_js/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "chart_dot_js"
-version := "0.0-unknown-6a0b5b"
+version := "0.0-unknown-9b65c8"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-06ca5c")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7d3007")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/chart.js/check/c/chart_dot_js/src/main/scala/typings/chartJs/mod.scala
+++ b/tests/chart.js/check/c/chart_dot_js/src/main/scala/typings/chartJs/mod.scala
@@ -98,10 +98,9 @@ object mod extends Shortcut {
     def global_=(x: ChartOptions & ChartFontOptions): Unit = ^.asInstanceOf[js.Dynamic].updateDynamic("global")(x.asInstanceOf[js.Any])
   }
   
-  @js.native
   trait ChartData extends StObject {
     
-    var labels: js.UndefOr[js.Array[String | js.Array[String]]] = js.native
+    var labels: js.UndefOr[js.Array[String | js.Array[String]]] = js.undefined
   }
   object ChartData {
     
@@ -125,10 +124,9 @@ object mod extends Shortcut {
     }
   }
   
-  @js.native
   trait ChartFontOptions extends StObject {
     
-    var foo: Boolean = js.native
+    var foo: Boolean
   }
   object ChartFontOptions {
     
@@ -146,13 +144,12 @@ object mod extends Shortcut {
     }
   }
   
-  @js.native
   trait ChartOptions extends StObject {
     
     // Plugins can require any options
-    var plugins: js.UndefOr[StringDictionary[js.Any]] = js.native
+    var plugins: js.UndefOr[StringDictionary[js.Any]] = js.undefined
     
-    var responsive: js.UndefOr[Boolean] = js.native
+    var responsive: js.UndefOr[Boolean] = js.undefined
   }
   object ChartOptions {
     

--- a/tests/chart.js/check/s/std/build.sbt
+++ b/tests/chart.js/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-06ca5c"
+version := "0.0-unknown-7d3007"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/chart.js/check/s/std/src/main/scala/typings/std/CanvasRenderingContext2D.scala
+++ b/tests/chart.js/check/s/std/src/main/scala/typings/std/CanvasRenderingContext2D.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait CanvasRenderingContext2D extends StObject

--- a/tests/chart.js/check/s/std/src/main/scala/typings/std/HTMLCanvasElement.scala
+++ b/tests/chart.js/check/s/std/src/main/scala/typings/std/HTMLCanvasElement.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HTMLCanvasElement extends StObject

--- a/tests/cldrjs/check/c/cldrjs/build.sbt
+++ b/tests/cldrjs/check/c/cldrjs/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "cldrjs"
-version := "0.4.4-b4bf38"
+version := "0.4.4-373dc2"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-823ce5")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-53c51d")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/cldrjs/check/c/cldrjs/src/main/scala/typings/cldrjs/mod.scala
+++ b/tests/cldrjs/check/c/cldrjs/src/main/scala/typings/cldrjs/mod.scala
@@ -11,10 +11,9 @@ object mod extends Shortcut {
   @js.native
   val ^ : CldrFactory = js.native
   
-  @js.native
   trait Attributes extends StObject {
     
-    var language: js.Any = js.native
+    var language: js.Any
   }
   object Attributes {
     
@@ -32,16 +31,15 @@ object mod extends Shortcut {
     }
   }
   
-  @js.native
   trait CldrFactory extends StObject {
     
-    def load(json: js.Any, otherJson: js.Any*): Unit = js.native
+    def load(json: js.Any, otherJson: js.Any*): Unit
     
-    def off(event: String, listener: js.Function2[/* path */ String, /* value */ js.Any, Unit]): Unit = js.native
+    def off(event: String, listener: js.Function2[/* path */ String, /* value */ js.Any, Unit]): Unit
     
-    def on(event: String, listener: js.Function2[/* path */ String, /* value */ js.Any, Unit]): Unit = js.native
+    def on(event: String, listener: js.Function2[/* path */ String, /* value */ js.Any, Unit]): Unit
     
-    def once(event: String, listener: js.Function2[/* path */ String, /* value */ js.Any, Unit]): Unit = js.native
+    def once(event: String, listener: js.Function2[/* path */ String, /* value */ js.Any, Unit]): Unit
   }
   object CldrFactory {
     
@@ -81,21 +79,20 @@ object mod extends Shortcut {
     * @description
     * The cldr class definition.
     */
-  @js.native
   trait CldrStatic extends StObject {
     
-    def get(path: String): js.Any = js.native
+    def get(path: String): js.Any
     
-    def off(event: String, listener: js.Function2[/* path */ String, /* value */ js.Any, Unit]): Unit = js.native
+    def off(event: String, listener: js.Function2[/* path */ String, /* value */ js.Any, Unit]): Unit
     
-    def on(event: String, listener: js.Function2[/* path */ String, /* value */ js.Any, Unit]): Unit = js.native
+    def on(event: String, listener: js.Function2[/* path */ String, /* value */ js.Any, Unit]): Unit
     
-    def once(event: String, listener: js.Function2[/* path */ String, /* value */ js.Any, Unit]): Unit = js.native
+    def once(event: String, listener: js.Function2[/* path */ String, /* value */ js.Any, Unit]): Unit
     
-    def supplemental(path: String): js.Any = js.native
-    def supplemental(paths: js.Array[String]): js.Any = js.native
+    def supplemental(path: String): js.Any
+    def supplemental(paths: js.Array[String]): js.Any
     @JSName("supplemental")
-    var supplemental_Original: SupplementalStatic = js.native
+    var supplemental_Original: SupplementalStatic
   }
   object CldrStatic {
     
@@ -142,12 +139,11 @@ object mod extends Shortcut {
     var weekData: WeekDataStatic = js.native
   }
   
-  @js.native
   trait TimeDataStatic extends StObject {
     
-    def allowed(): String = js.native
+    def allowed(): String
     
-    def preferred(): String = js.native
+    def preferred(): String
   }
   object TimeDataStatic {
     
@@ -168,12 +164,11 @@ object mod extends Shortcut {
     }
   }
   
-  @js.native
   trait WeekDataStatic extends StObject {
     
-    def firstDay(): String = js.native
+    def firstDay(): String
     
-    def minDays(): Double = js.native
+    def minDays(): Double
   }
   object WeekDataStatic {
     

--- a/tests/cldrjs/check/s/std/build.sbt
+++ b/tests/cldrjs/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-823ce5"
+version := "0.0-unknown-53c51d"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/cldrjs/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/cldrjs/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/commander/check/c/commander/build.sbt
+++ b/tests/commander/check/c/commander/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "commander"
-version := "2.15.1-4fb0d8"
+version := "2.15.1-2a005c"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "node" % "0.0-unknown-b93f15",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-266d1d")
+  "org.scalablytyped" %%% "node" % "0.0-unknown-f84c5d",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-50fda2")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/commander/check/c/commander/src/main/scala/typings/commander/mod.scala
+++ b/tests/commander/check/c/commander/src/main/scala/typings/commander/mod.scala
@@ -44,16 +44,33 @@ object mod extends Shortcut {
       */
     def this(flags: String) = this()
     def this(flags: String, description: String) = this()
+    
+    /* CompleteClass */
+    var bool: Boolean = js.native
+    
+    /* CompleteClass */
+    var description: String = js.native
+    
+    /* CompleteClass */
+    var flags: String = js.native
+    
+    /* CompleteClass */
+    var long: String = js.native
+    
+    /* CompleteClass */
+    var optional: Boolean = js.native
+    
+    /* CompleteClass */
+    var required: Boolean = js.native
   }
   
   type Command = typings.commander.mod.local.Command
   
-  @js.native
   trait CommandOptions extends StObject {
     
-    var isDefault: js.UndefOr[Boolean] = js.native
+    var isDefault: js.UndefOr[Boolean] = js.undefined
     
-    var noHelp: js.UndefOr[Boolean] = js.native
+    var noHelp: js.UndefOr[Boolean] = js.undefined
   }
   object CommandOptions {
     
@@ -100,12 +117,11 @@ object mod extends Shortcut {
   
   type Option = typings.commander.mod.local.Option
   
-  @js.native
   trait ParseOptionsResult extends StObject {
     
-    var args: js.Array[String] = js.native
+    var args: js.Array[String]
     
-    var unknown: js.Array[String] = js.native
+    var unknown: js.Array[String]
   }
   object ParseOptionsResult {
     
@@ -418,22 +434,21 @@ object mod extends Shortcut {
       def version(str: String, flags: String): typings.commander.mod.local.Command = js.native
     }
     
-    @js.native
     trait Option extends StObject {
       
-      var bool: Boolean = js.native
+      var bool: Boolean
       
-      var description: String = js.native
+      var description: String
       
-      var flags: String = js.native
+      var flags: String
       
-      var long: String = js.native
+      var long: String
       
-      var optional: Boolean = js.native
+      var optional: Boolean
       
-      var required: Boolean = js.native
+      var required: Boolean
       
-      var short: js.UndefOr[String] = js.native
+      var short: js.UndefOr[String] = js.undefined
     }
     object Option {
       

--- a/tests/commander/check/n/node/build.sbt
+++ b/tests/commander/check/n/node/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "0.0-unknown-b93f15"
+version := "0.0-unknown-f84c5d"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/commander/check/n/node/src/main/scala/typings/node/NodeJS.scala
+++ b/tests/commander/check/n/node/src/main/scala/typings/node/NodeJS.scala
@@ -6,6 +6,5 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object NodeJS {
   
-  @js.native
   trait EventEmitter extends StObject
 }

--- a/tests/commander/check/s/std/build.sbt
+++ b/tests/commander/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-266d1d"
+version := "0.0-unknown-50fda2"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/commander/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/commander/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/commander/check/s/std/src/main/scala/typings/std/RegExp.scala
+++ b/tests/commander/check/s/std/src/main/scala/typings/std/RegExp.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait RegExp extends StObject

--- a/tests/create-error/check/c/create-error/build.sbt
+++ b/tests/create-error/check/c/create-error/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "create-error"
-version := "0.3.1-323ddd"
+version := "0.3.1-1369d4"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-9e5011")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d558f7")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/create-error/check/s/std/build.sbt
+++ b/tests/create-error/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-9e5011"
+version := "0.0-unknown-d558f7"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/create-error/check/s/std/src/main/scala/typings/std/Error.scala
+++ b/tests/create-error/check/s/std/src/main/scala/typings/std/Error.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Error extends StObject

--- a/tests/defaulted-tparams/check/d/defaulted-tparams/build.sbt
+++ b/tests/defaulted-tparams/check/d/defaulted-tparams/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "defaulted-tparams"
-version := "0.0-unknown-b7abd1"
+version := "0.0-unknown-b7d54c"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-e53cc7")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-e084d2")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/defaulted-tparams/check/d/defaulted-tparams/src/main/scala/typings/defaultedTparams/Queue.scala
+++ b/tests/defaulted-tparams/check/d/defaulted-tparams/src/main/scala/typings/defaultedTparams/Queue.scala
@@ -4,33 +4,32 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Queue[S, T] extends StObject {
   
   /**
     * Whether the queue is empty
     */
-  val empty: Boolean = js.native
+  val empty: Boolean
   
   /**
     * Whether the queue is full
     */
-  val full: Boolean = js.native
+  val full: Boolean
   
   /**
     * The length of the queue
     */
-  val length: Double = js.native
+  val length: Double
   
   /**
     * Removes and returns an element from the beginning
     */
-  def pop(): js.UndefOr[T] = js.native
+  def pop(): js.UndefOr[T]
   
   /**
     * Inserts a new element at the end
     */
-  def push(x: S): this.type = js.native
+  def push(x: S): this.type
 }
 object Queue {
   

--- a/tests/defaulted-tparams/check/d/defaulted-tparams/src/main/scala/typings/defaultedTparams/global.scala
+++ b/tests/defaulted-tparams/check/d/defaulted-tparams/src/main/scala/typings/defaultedTparams/global.scala
@@ -11,7 +11,38 @@ object global {
   @js.native
   class Queue[S, T] ()
     extends StObject
-       with typings.defaultedTparams.Queue[S, T]
+       with typings.defaultedTparams.Queue[S, T] {
+    
+    /**
+      * Whether the queue is empty
+      */
+    /* CompleteClass */
+    override val empty: Boolean = js.native
+    
+    /**
+      * Whether the queue is full
+      */
+    /* CompleteClass */
+    override val full: Boolean = js.native
+    
+    /**
+      * The length of the queue
+      */
+    /* CompleteClass */
+    override val length: Double = js.native
+    
+    /**
+      * Removes and returns an element from the beginning
+      */
+    /* CompleteClass */
+    override def pop(): js.UndefOr[T] = js.native
+    
+    /**
+      * Inserts a new element at the end
+      */
+    /* CompleteClass */
+    override def push(x: S): this.type = js.native
+  }
   object Queue {
     
     @JSGlobal("Queue")

--- a/tests/defaulted-tparams/check/s/std/build.sbt
+++ b/tests/defaulted-tparams/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-e53cc7"
+version := "0.0-unknown-e084d2"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/defaulted-tparams/check/s/std/src/main/scala/typings/std/Iterable.scala
+++ b/tests/defaulted-tparams/check/s/std/src/main/scala/typings/std/Iterable.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Iterable[T] extends StObject

--- a/tests/documentation/check/d/documentation/build.sbt
+++ b/tests/documentation/check/d/documentation/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "documentation"
-version := "0.0-unknown-7201fd"
+version := "0.0-unknown-374bdd"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/documentation/check/d/documentation/src/main/scala/typings/documentation/Branch.scala
+++ b/tests/documentation/check/d/documentation/src/main/scala/typings/documentation/Branch.scala
@@ -4,16 +4,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Branch[T]
   extends StObject
      with Tree[T] {
   
-  var left: T = js.native
+  var left: T
   
-  var right: T = js.native
+  var right: T
   
-  var `type`: typings.documentation.documentationStrings.Branch = js.native
+  var `type`: typings.documentation.documentationStrings.Branch
 }
 object Branch {
   

--- a/tests/documentation/check/d/documentation/src/main/scala/typings/documentation/Child.scala
+++ b/tests/documentation/check/d/documentation/src/main/scala/typings/documentation/Child.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Child[T1, T2]
   extends StObject
      with Parent[T1] {
   
-  var t2: js.UndefOr[T2] = js.native
+  var t2: js.UndefOr[T2] = js.undefined
 }
 object Child {
   

--- a/tests/documentation/check/d/documentation/src/main/scala/typings/documentation/Complex.scala
+++ b/tests/documentation/check/d/documentation/src/main/scala/typings/documentation/Complex.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Complex extends StObject {
   
-  var a: (js.Function1[/* n */ Double, Unit]) | String = js.native
+  var a: (js.Function1[/* n */ Double, Unit]) | String
 }
 object Complex {
   

--- a/tests/documentation/check/d/documentation/src/main/scala/typings/documentation/Leaf.scala
+++ b/tests/documentation/check/d/documentation/src/main/scala/typings/documentation/Leaf.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Leaf[T]
   extends StObject
      with Tree[T] {
   
-  var `type`: typings.documentation.documentationStrings.Leaf = js.native
+  var `type`: typings.documentation.documentationStrings.Leaf
   
-  var value: T = js.native
+  var value: T
 }
 object Leaf {
   

--- a/tests/documentation/check/d/documentation/src/main/scala/typings/documentation/Nullability.scala
+++ b/tests/documentation/check/d/documentation/src/main/scala/typings/documentation/Nullability.scala
@@ -4,16 +4,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Nullability extends StObject {
   
-  var a: Double = js.native
+  var a: Double
   
-  var b: js.UndefOr[Double] = js.native
+  var b: js.UndefOr[Double] = js.undefined
   
-  var c: Double | Null = js.native
+  var c: Double | Null
   
-  var d: js.UndefOr[Double | Null] = js.native
+  var d: js.UndefOr[Double | Null] = js.undefined
 }
 object Nullability {
   

--- a/tests/documentation/check/d/documentation/src/main/scala/typings/documentation/Parent.scala
+++ b/tests/documentation/check/d/documentation/src/main/scala/typings/documentation/Parent.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Parent[T] extends StObject {
   
-  var t: T = js.native
+  var t: T
 }
 object Parent {
   

--- a/tests/echarts/check/e/echarts/build.sbt
+++ b/tests/echarts/check/e/echarts/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "echarts"
-version := "0.0-unknown-28c21e"
+version := "0.0-unknown-7b983f"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/echarts/check/e/echarts/src/main/scala/typings/echarts/echarts.scala
+++ b/tests/echarts/check/e/echarts/src/main/scala/typings/echarts/echarts.scala
@@ -15,16 +15,15 @@ object echarts {
     trait DataZoom extends StObject
     object DataZoom {
       
-      @js.native
       trait Inside
         extends StObject
            with DataZoom {
         
-        var disabled: js.UndefOr[Boolean] = js.native
+        var disabled: js.UndefOr[Boolean] = js.undefined
         
-        var id: js.UndefOr[String] = js.native
+        var id: js.UndefOr[String] = js.undefined
         
-        var `type`: js.UndefOr[String] = js.native
+        var `type`: js.UndefOr[String] = js.undefined
       }
       object Inside {
         
@@ -57,14 +56,13 @@ object echarts {
         }
       }
       
-      @js.native
       trait Slider
         extends StObject
            with DataZoom {
         
-        var id: js.UndefOr[String] = js.native
+        var id: js.UndefOr[String] = js.undefined
         
-        var `type`: js.UndefOr[String] = js.native
+        var `type`: js.UndefOr[String] = js.undefined
       }
       object Slider {
         

--- a/tests/elasticsearch-js/check/e/elasticsearch-js/build.sbt
+++ b/tests/elasticsearch-js/check/e/elasticsearch-js/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "elasticsearch-js"
-version := "0.0-unknown-739d1d"
+version := "0.0-unknown-8341e9"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-a735b1")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-a8ce80")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/elasticsearch-js/check/e/elasticsearch-js/src/main/scala/typings/elasticsearchJs/mod.scala
+++ b/tests/elasticsearch-js/check/e/elasticsearch-js/src/main/scala/typings/elasticsearchJs/mod.scala
@@ -6,11 +6,10 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
-  @js.native
   trait TransportRequestPromise[T]
     extends js.Promise[T] {
     
-    def abort(): Unit = js.native
+    def abort(): Unit
   }
   object TransportRequestPromise {
     

--- a/tests/elasticsearch-js/check/s/std/build.sbt
+++ b/tests/elasticsearch-js/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-a735b1"
+version := "0.0-unknown-a8ce80"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/elasticsearch-js/check/s/std/src/main/scala/typings/std/Promise.scala
+++ b/tests/elasticsearch-js/check/s/std/src/main/scala/typings/std/Promise.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Promise[T] extends StObject

--- a/tests/electron/check/e/electron/build.sbt
+++ b/tests/electron/check/e/electron/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "electron"
-version := "2.0.0-8fd0b5"
+version := "2.0.0-1b3869"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "node" % "0.0-unknown-869fbe",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-56b710")
+  "org.scalablytyped" %%% "node" % "0.0-unknown-0317c0",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-82a9a7")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/electron/check/e/electron/src/main/scala/typings/electron/Electron.scala
+++ b/tests/electron/check/e/electron/src/main/scala/typings/electron/Electron.scala
@@ -9,7 +9,6 @@ object Electron {
   
   type AllElectron = MainInterface
   
-  @js.native
   trait App
     extends StObject
        with EventEmitter {
@@ -22,7 +21,7 @@ object Electron {
       * details.
       */
     @JSName("on")
-    def on_accessibilitysupportchanged(event: `accessibility-support-changed`, listener: js.Any): String = js.native
+    def on_accessibilitysupportchanged(event: `accessibility-support-changed`, listener: js.Any): String
   }
   object App {
     
@@ -40,25 +39,23 @@ object Electron {
     }
   }
   
-  @js.native
   trait CommonInterface extends StObject
   
-  @js.native
   trait Event
     extends StObject
        with typings.std.Event {
     
-    var altKey: js.UndefOr[Boolean] = js.native
+    var altKey: js.UndefOr[Boolean] = js.undefined
     
-    var ctrlKey: js.UndefOr[Boolean] = js.native
+    var ctrlKey: js.UndefOr[Boolean] = js.undefined
     
-    var metaKey: js.UndefOr[Boolean] = js.native
+    var metaKey: js.UndefOr[Boolean] = js.undefined
     
-    def preventDefault(): Unit = js.native
+    def preventDefault(): Unit
     
-    var returnValue: js.Any = js.native
+    var returnValue: js.Any
     
-    var shiftKey: js.UndefOr[Boolean] = js.native
+    var shiftKey: js.UndefOr[Boolean] = js.undefined
   }
   object Event {
     
@@ -103,10 +100,9 @@ object Electron {
     }
   }
   
-  @js.native
   trait EventEmitter extends StObject {
     
-    def addListener(event: String, listener: js.Function): this.type = js.native
+    def addListener(event: String, listener: js.Function): this.type
   }
   object EventEmitter {
     
@@ -124,12 +120,11 @@ object Electron {
     }
   }
   
-  @js.native
   trait MainInterface
     extends StObject
        with CommonInterface {
     
-    var app: App = js.native
+    var app: App
   }
   object MainInterface {
     

--- a/tests/electron/check/e/electron/src/main/scala/typings/electron/global.scala
+++ b/tests/electron/check/e/electron/src/main/scala/typings/electron/global.scala
@@ -13,7 +13,11 @@ object global {
     @js.native
     class EventEmitter ()
       extends StObject
-         with typings.electron.Electron.EventEmitter
+         with typings.electron.Electron.EventEmitter {
+      
+      /* CompleteClass */
+      override def addListener(event: String, listener: js.Function): this.type = js.native
+    }
     
     @JSGlobal("Electron.app")
     @js.native

--- a/tests/electron/check/e/electron/src/main/scala/typings/electron/mod.scala
+++ b/tests/electron/check/e/electron/src/main/scala/typings/electron/mod.scala
@@ -11,7 +11,11 @@ object mod {
   @js.native
   class EventEmitter ()
     extends StObject
-       with typings.electron.Electron.EventEmitter
+       with typings.electron.Electron.EventEmitter {
+    
+    /* CompleteClass */
+    override def addListener(event: String, listener: js.Function): this.type = js.native
+  }
   
   @JSImport("electron", "app")
   @js.native

--- a/tests/electron/check/n/node/build.sbt
+++ b/tests/electron/check/n/node/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "0.0-unknown-869fbe"
+version := "0.0-unknown-0317c0"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-56b710")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-82a9a7")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/electron/check/n/node/src/main/scala/typings/node/Error.scala
+++ b/tests/electron/check/n/node/src/main/scala/typings/node/Error.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Error extends StObject {
   
-  var stack: js.UndefOr[String] = js.native
+  var stack: js.UndefOr[String] = js.undefined
 }
 object Error {
   

--- a/tests/electron/check/n/node/src/main/scala/typings/node/NodeJS.scala
+++ b/tests/electron/check/n/node/src/main/scala/typings/node/NodeJS.scala
@@ -7,18 +7,17 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object NodeJS {
   
-  @js.native
   trait ErrnoException
     extends StObject
        with Error {
     
-    var code: js.UndefOr[String] = js.native
+    var code: js.UndefOr[String] = js.undefined
     
-    var errno: js.UndefOr[Double] = js.native
+    var errno: js.UndefOr[Double] = js.undefined
     
-    var path: js.UndefOr[String] = js.native
+    var path: js.UndefOr[String] = js.undefined
     
-    var syscall: js.UndefOr[String] = js.native
+    var syscall: js.UndefOr[String] = js.undefined
   }
   object ErrnoException {
     

--- a/tests/electron/check/n/node/src/main/scala/typings/node/SymbolConstructor.scala
+++ b/tests/electron/check/n/node/src/main/scala/typings/node/SymbolConstructor.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SymbolConstructor extends StObject {
   
-  val asyncIterator: js.Symbol = js.native
+  val asyncIterator: js.Symbol
   
-  val iterator: js.Symbol = js.native
+  val iterator: js.Symbol
 }
 object SymbolConstructor {
   

--- a/tests/electron/check/s/std/build.sbt
+++ b/tests/electron/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-56b710"
+version := "0.0-unknown-82a9a7"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/electron/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/electron/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/electron/check/s/std/src/main/scala/typings/std/Boolean.scala
+++ b/tests/electron/check/s/std/src/main/scala/typings/std/Boolean.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Boolean extends StObject

--- a/tests/electron/check/s/std/src/main/scala/typings/std/Event.scala
+++ b/tests/electron/check/s/std/src/main/scala/typings/std/Event.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Event extends StObject

--- a/tests/electron/check/s/std/src/main/scala/typings/std/IArguments.scala
+++ b/tests/electron/check/s/std/src/main/scala/typings/std/IArguments.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait IArguments extends StObject

--- a/tests/electron/check/s/std/src/main/scala/typings/std/Number.scala
+++ b/tests/electron/check/s/std/src/main/scala/typings/std/Number.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Number extends StObject

--- a/tests/electron/check/s/std/src/main/scala/typings/std/Object.scala
+++ b/tests/electron/check/s/std/src/main/scala/typings/std/Object.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Object extends StObject

--- a/tests/electron/check/s/std/src/main/scala/typings/std/RegExp.scala
+++ b/tests/electron/check/s/std/src/main/scala/typings/std/RegExp.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait RegExp extends StObject

--- a/tests/electron/check/s/std/src/main/scala/typings/std/String.scala
+++ b/tests/electron/check/s/std/src/main/scala/typings/std/String.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait String extends StObject

--- a/tests/expand-type-parameters/check/e/expand-type-parameters/build.sbt
+++ b/tests/expand-type-parameters/check/e/expand-type-parameters/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "expand-type-parameters"
-version := "0.0-unknown-2e5559"
+version := "0.0-unknown-a21eb9"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/expand-type-parameters/check/e/expand-type-parameters/src/main/scala/typings/expandTypeParameters/A.scala
+++ b/tests/expand-type-parameters/check/e/expand-type-parameters/src/main/scala/typings/expandTypeParameters/A.scala
@@ -5,12 +5,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* import warning: transforms.RemoveMultipleInheritance#findNewParents newComments Dropped parents 
-- typings.expandTypeParameters.TA because Already inherited */ @js.native
-trait A
+- typings.expandTypeParameters.TA because Already inherited */ trait A
   extends StObject
      with B {
   
-  var a: Double = js.native
+  var a: Double
 }
 object A {
   

--- a/tests/expand-type-parameters/check/e/expand-type-parameters/src/main/scala/typings/expandTypeParameters/B.scala
+++ b/tests/expand-type-parameters/check/e/expand-type-parameters/src/main/scala/typings/expandTypeParameters/B.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait B
   extends StObject
      with TA {
   
-  var b: String = js.native
+  var b: String
 }
 object B {
   

--- a/tests/expand-type-parameters/check/e/expand-type-parameters/src/main/scala/typings/expandTypeParameters/C.scala
+++ b/tests/expand-type-parameters/check/e/expand-type-parameters/src/main/scala/typings/expandTypeParameters/C.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait C extends StObject {
   
-  var c: js.UndefOr[Double] = js.native
+  var c: js.UndefOr[Double] = js.undefined
 }
 object C {
   

--- a/tests/export-as-namespace/check/a/angular-agility/build.sbt
+++ b/tests/export-as-namespace/check/a/angular-agility/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "angular-agility"
-version := "0.0-unknown-8474f4"
+version := "0.0-unknown-e23b5d"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "angular" % "1.6-11267b",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-fa4ba3")
+  "org.scalablytyped" %%% "angular" % "1.6-c8b594",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-c0fb1a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/export-as-namespace/check/a/angular-agility/src/main/scala/typings/angularAgility/aa.scala
+++ b/tests/export-as-namespace/check/a/angular-agility/src/main/scala/typings/angularAgility/aa.scala
@@ -7,16 +7,15 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object aa {
   
-  @js.native
   trait INotifyConfigProvider
     extends StObject
        with IServiceProvider {
     
-    var defaultNotifyConfig: String = js.native
+    var defaultNotifyConfig: String
     
-    var defaultTargetContainerName: String = js.native
+    var defaultTargetContainerName: String
     
-    var notifyConfigs: js.Any = js.native
+    var notifyConfigs: js.Any
   }
   object INotifyConfigProvider {
     

--- a/tests/export-as-namespace/check/a/angular/build.sbt
+++ b/tests/export-as-namespace/check/a/angular/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "angular"
-version := "1.6-11267b"
+version := "1.6-c8b594"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-fa4ba3")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-c0fb1a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/export-as-namespace/check/a/angular/src/main/scala/typings/angular/JQLite.scala
+++ b/tests/export-as-namespace/check/a/angular/src/main/scala/typings/angular/JQLite.scala
@@ -7,7 +7,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait JQLite
   extends StObject
      with JQuery

--- a/tests/export-as-namespace/check/a/angular/src/main/scala/typings/angular/JQuery.scala
+++ b/tests/export-as-namespace/check/a/angular/src/main/scala/typings/angular/JQuery.scala
@@ -5,7 +5,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait JQuery extends StObject {
   
   /**
@@ -14,9 +13,9 @@ trait JQuery extends StObject {
     * @param className One or more space-separated classes to be added to the class attribute of each matched element.
     * @see {@link https://api.jquery.com/addClass/#addClass-className}
     */
-  def addClass(className: String): this.type = js.native
+  def addClass(className: String): this.type
   
-  def injector(): IInjectorService = js.native
+  def injector(): IInjectorService
 }
 object JQuery {
   

--- a/tests/export-as-namespace/check/a/angular/src/main/scala/typings/angular/mod.scala
+++ b/tests/export-as-namespace/check/a/angular/src/main/scala/typings/angular/mod.scala
@@ -21,7 +21,6 @@ object mod extends Shortcut {
   // AngularStatic
   // see http://docs.angularjs.org/api
   ///////////////////////////////////////////////////////////////////////////
-  @js.native
   trait IAngularStatic extends StObject {
     
     /**
@@ -29,29 +28,29 @@ object mod extends Shortcut {
       *
       * If jQuery is available, angular.element is an alias for the jQuery function. If jQuery is not available, angular.element delegates to Angular's built-in subset of jQuery, called "jQuery lite" or "jqLite."
       */
-    def element(element: String): JQLite = js.native
-    def element(element: js.Function0[Unit]): JQLite = js.native
-    def element(element: JQuery): JQLite = js.native
-    def element(element: ArrayLike[Element]): JQLite = js.native
-    def element(element: Document): JQLite = js.native
-    def element(element: Element): JQLite = js.native
+    def element(element: String): JQLite
+    def element(element: js.Function0[Unit]): JQLite
+    def element(element: JQuery): JQLite
+    def element(element: ArrayLike[Element]): JQLite
+    def element(element: Document): JQLite
+    def element(element: Element): JQLite
     /**
       * Wraps a raw DOM element or HTML string as a jQuery element.
       *
       * If jQuery is available, angular.element is an alias for the jQuery function. If jQuery is not available, angular.element delegates to Angular's built-in subset of jQuery, called "jQuery lite" or "jqLite."
       */
     @JSName("element")
-    var element_Original: JQueryStatic = js.native
+    var element_Original: JQueryStatic
     
-    def equals(value1: js.Any, value2: js.Any): Boolean = js.native
+    def equals(value1: js.Any, value2: js.Any): Boolean
     
-    def extend(destination: js.Any, sources: js.Any*): js.Any = js.native
+    def extend(destination: js.Any, sources: js.Any*): js.Any
     
     /**
       * If window.name contains prefix NG_DEFER_BOOTSTRAP! when angular.bootstrap is called, the bootstrap process will be paused until angular.resumeBootstrap() is called.
       * @param extraModules An optional array of modules that should be added to the original list of modules that the app was about to be bootstrapped with.
       */
-    var resumeBootstrap: js.UndefOr[js.Function1[/* extraModules */ js.UndefOr[js.Array[String]], IInjectorService]] = js.native
+    var resumeBootstrap: js.UndefOr[js.Function1[/* extraModules */ js.UndefOr[js.Array[String]], IInjectorService]] = js.undefined
   }
   object IAngularStatic {
     
@@ -89,11 +88,10 @@ object mod extends Shortcut {
   }
   
   // All service providers extend this interface
-  @js.native
   trait IServiceProvider extends StObject {
     
     @JSName("$get")
-    var $get: js.Any = js.native
+    var $get: js.Any
   }
   object IServiceProvider {
     

--- a/tests/export-as-namespace/check/s/std/build.sbt
+++ b/tests/export-as-namespace/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-fa4ba3"
+version := "0.0-unknown-c0fb1a"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/export-as-namespace/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/export-as-namespace/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/export-as-namespace/check/s/std/src/main/scala/typings/std/ArrayLike.scala
+++ b/tests/export-as-namespace/check/s/std/src/main/scala/typings/std/ArrayLike.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ArrayLike[T] extends StObject

--- a/tests/export-as-namespace/check/s/std/src/main/scala/typings/std/Document.scala
+++ b/tests/export-as-namespace/check/s/std/src/main/scala/typings/std/Document.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Document extends StObject

--- a/tests/export-as-namespace/check/s/std/src/main/scala/typings/std/Element.scala
+++ b/tests/export-as-namespace/check/s/std/src/main/scala/typings/std/Element.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Element extends StObject

--- a/tests/export-as-namespace/check/s/std/src/main/scala/typings/std/ReadonlyArray.scala
+++ b/tests/export-as-namespace/check/s/std/src/main/scala/typings/std/ReadonlyArray.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ReadonlyArray[T] extends StObject

--- a/tests/firebase-admin/check/f/firebase-admin/build.sbt
+++ b/tests/firebase-admin/check/f/firebase-admin/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "firebase-admin"
-version := "8.2.0-af1834"
+version := "8.2.0-c05334"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "google-cloud__firestore" % "2.2.3-33f451")
+  "org.scalablytyped" %%% "google-cloud__firestore" % "2.2.3-ee1efe")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/firebase-admin/check/f/firebase-admin/src/main/scala/typings/firebaseAdmin/mod.scala
+++ b/tests/firebase-admin/check/f/firebase-admin/src/main/scala/typings/firebaseAdmin/mod.scala
@@ -28,6 +28,21 @@ object mod {
       extends StObject
          with typings.googleCloudFirestore.FirebaseFirestore.Firestore {
       def this(settings: Settings) = this()
+      
+      /**
+        * Specifies custom settings to be used to configure the `Firestore`
+        * instance. Can only be invoked once and before any other Firestore
+        * method.
+        *
+        * If settings are provided via both `settings()` and the `Firestore`
+        * constructor, both settings objects are merged and any settings provided
+        * via `settings()` take precedence.
+        *
+        * @param {object} settings The settings to use for all Firestore
+        * operations.
+        */
+      /* CompleteClass */
+      override def settings(settings: Settings): Unit = js.native
     }
   }
 }

--- a/tests/firebase-admin/check/g/google-cloud__firestore/build.sbt
+++ b/tests/firebase-admin/check/g/google-cloud__firestore/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "google-cloud__firestore"
-version := "2.2.3-33f451"
+version := "2.2.3-ee1efe"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/firebase-admin/check/g/google-cloud__firestore/src/main/scala/typings/googleCloudFirestore/FirebaseFirestore.scala
+++ b/tests/firebase-admin/check/g/google-cloud__firestore/src/main/scala/typings/googleCloudFirestore/FirebaseFirestore.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object FirebaseFirestore {
   
-  @js.native
   trait Firestore extends StObject {
     
     /**
@@ -21,7 +20,7 @@ object FirebaseFirestore {
       * @param {object} settings The settings to use for all Firestore
       * operations.
       */
-    def settings(settings: Settings): Unit = js.native
+    def settings(settings: Settings): Unit
   }
   object Firestore {
     
@@ -39,10 +38,9 @@ object FirebaseFirestore {
     }
   }
   
-  @js.native
   trait Settings extends StObject {
     
-    var projectId: js.UndefOr[String] = js.native
+    var projectId: js.UndefOr[String] = js.undefined
   }
   object Settings {
     

--- a/tests/firebase-admin/check/g/google-cloud__firestore/src/main/scala/typings/googleCloudFirestore/global.scala
+++ b/tests/firebase-admin/check/g/google-cloud__firestore/src/main/scala/typings/googleCloudFirestore/global.scala
@@ -19,6 +19,21 @@ object global {
       extends StObject
          with typings.googleCloudFirestore.FirebaseFirestore.Firestore {
       def this(settings: Settings) = this()
+      
+      /**
+        * Specifies custom settings to be used to configure the `Firestore`
+        * instance. Can only be invoked once and before any other Firestore
+        * method.
+        *
+        * If settings are provided via both `settings()` and the `Firestore`
+        * constructor, both settings objects are merged and any settings provided
+        * via `settings()` take precedence.
+        *
+        * @param {object} settings The settings to use for all Firestore
+        * operations.
+        */
+      /* CompleteClass */
+      override def settings(settings: Settings): Unit = js.native
     }
   }
 }

--- a/tests/firebase-admin/check/g/google-cloud__firestore/src/main/scala/typings/googleCloudFirestore/mod.scala
+++ b/tests/firebase-admin/check/g/google-cloud__firestore/src/main/scala/typings/googleCloudFirestore/mod.scala
@@ -17,5 +17,20 @@ object mod {
     extends StObject
        with typings.googleCloudFirestore.FirebaseFirestore.Firestore {
     def this(settings: Settings) = this()
+    
+    /**
+      * Specifies custom settings to be used to configure the `Firestore`
+      * instance. Can only be invoked once and before any other Firestore
+      * method.
+      *
+      * If settings are provided via both `settings()` and the `Firestore`
+      * constructor, both settings objects are merged and any settings provided
+      * via `settings()` take precedence.
+      *
+      * @param {object} settings The settings to use for all Firestore
+      * operations.
+      */
+    /* CompleteClass */
+    override def settings(settings: Settings): Unit = js.native
   }
 }

--- a/tests/fp-ts/check/f/fp-ts/build.sbt
+++ b/tests/fp-ts/check/f/fp-ts/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "fp-ts"
-version := "1.2.0-b3fd10"
+version := "1.2.0-048c51"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/fp-ts/check/f/fp-ts/src/main/scala/typings/fpTs/constMod.scala
+++ b/tests/fp-ts/check/f/fp-ts/src/main/scala/typings/fpTs/constMod.scala
@@ -36,10 +36,9 @@ object constMod {
   /* augmented module */
   object fpTsLibHKTAugmentingMod {
     
-    @js.native
     trait URI2HKT2[L, A] extends StObject {
       
-      var Const: typings.fpTs.constMod.Const[L, A] = js.native
+      var Const: typings.fpTs.constMod.Const[L, A]
     }
     object URI2HKT2 {
       

--- a/tests/fp-ts/check/f/fp-ts/src/main/scala/typings/fpTs/eitherTMod.scala
+++ b/tests/fp-ts/check/f/fp-ts/src/main/scala/typings/fpTs/eitherTMod.scala
@@ -9,12 +9,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object eitherTMod {
   
-  @js.native
   trait EitherT[F]
     extends StObject
        with Foo[F, URI] {
     
-    def chain[L, A, B](f: js.Function1[/* a */ A, HKT[F, Either[L, B]]], fa: HKT[F, Either[L, A]]): HKT[F, Either[L, B]] = js.native
+    def chain[L, A, B](f: js.Function1[/* a */ A, HKT[F, Either[L, B]]], fa: HKT[F, Either[L, A]]): HKT[F, Either[L, B]]
   }
   object EitherT {
     
@@ -36,6 +35,5 @@ object eitherTMod {
     }
   }
   
-  @js.native
   trait Foo[T, U] extends StObject
 }

--- a/tests/fp-ts/check/f/fp-ts/src/main/scala/typings/fpTs/hktMod.scala
+++ b/tests/fp-ts/check/f/fp-ts/src/main/scala/typings/fpTs/hktMod.scala
@@ -7,12 +7,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object hktMod {
   
-  @js.native
   trait HKT[URI, A] extends StObject {
     
-    val _A: A = js.native
+    val _A: A
     
-    val _URI: URI = js.native
+    val _URI: URI
   }
   object HKT {
     
@@ -35,13 +34,11 @@ object hktMod {
   
   type Type[URI /* <: URIS */, A] = /* import warning: importer.ImportType#apply Failed type conversion: fp-ts.fp-ts/lib/HKT.URI2HKT<A>[URI] */ js.Any
   
-  @js.native
   trait URI2HKT[A] extends StObject
   
-  @js.native
   trait URI2HKT2[L, A] extends StObject {
     
-    var Const: typings.fpTs.constMod.Const[L, A] = js.native
+    var Const: typings.fpTs.constMod.Const[L, A]
   }
   object URI2HKT2 {
     

--- a/tests/fullcalendar/check/f/fullcalendar/build.sbt
+++ b/tests/fullcalendar/check/f/fullcalendar/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "fullcalendar"
-version := "0.0-unknown-466733"
+version := "0.0-unknown-0089ae"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/fullcalendar/check/f/fullcalendar/src/main/scala/typings/fullcalendar/mod.scala
+++ b/tests/fullcalendar/check/f/fullcalendar/src/main/scala/typings/fullcalendar/mod.scala
@@ -14,12 +14,15 @@ object mod {
   @js.native
   class Default_ ()
     extends typings.fullcalendar.mixinMod.default
-       with EmitterInterface
+       with EmitterInterface {
+    
+    /* CompleteClass */
+    override def on(types: js.Any, handler: js.Any): js.Any = js.native
+  }
   
-  @js.native
   trait EmitterInterface extends StObject {
     
-    def on(types: js.Any, handler: js.Any): js.Any = js.native
+    def on(types: js.Any, handler: js.Any): js.Any
   }
   object EmitterInterface {
     

--- a/tests/insight/check/i/insight/build.sbt
+++ b/tests/insight/check/i/insight/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "insight"
-version := "0.0-unknown-4c02b0"
+version := "0.0-unknown-1ce86b"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/insight/check/i/insight/src/main/scala/typings/insight/mod.scala
+++ b/tests/insight/check/i/insight/src/main/scala/typings/insight/mod.scala
@@ -14,18 +14,29 @@ object mod {
     extends StObject
        with Insight_ {
     def this(options: IOptions) = this()
-  }
-  
-  @js.native
-  trait Insight_ extends StObject {
     
+    /* CompleteClass */
     var clientId: String = js.native
     
+    /* CompleteClass */
     var config: IConfigstore = js.native
     
+    /* CompleteClass */
     var optOut: Boolean = js.native
     
-    def track(args: String*): Unit = js.native
+    /* CompleteClass */
+    override def track(args: String*): Unit = js.native
+  }
+  
+  trait Insight_ extends StObject {
+    
+    var clientId: String
+    
+    var config: IConfigstore
+    
+    var optOut: Boolean
+    
+    def track(args: String*): Unit
   }
   object Insight_ {
     
@@ -54,18 +65,17 @@ object mod {
   
   object insight {
     
-    @js.native
     trait IConfigstore extends StObject {
       
-      var all: js.Any = js.native
+      var all: js.Any
       
-      def del(key: String): Unit = js.native
+      def del(key: String): Unit
       
-      def get(key: String): js.Any = js.native
+      def get(key: String): js.Any
       
-      var path: String = js.native
+      var path: String
       
-      def set(key: String, `val`: js.Any): Unit = js.native
+      def set(key: String, `val`: js.Any): Unit
     }
     object IConfigstore {
       
@@ -101,10 +111,9 @@ object mod {
       }
     }
     
-    @js.native
     trait IOptions extends StObject {
       
-      var trackingCode: String = js.native
+      var trackingCode: String
     }
     object IOptions {
       

--- a/tests/interface-package/check/i/interface-package/build.sbt
+++ b/tests/interface-package/check/i/interface-package/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "interface-package"
-version := "0.0-unknown-912f05"
+version := "0.0-unknown-777b89"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/interface-package/check/i/interface-package/src/main/scala/typings/interfacePackage/mod.scala
+++ b/tests/interface-package/check/i/interface-package/src/main/scala/typings/interfacePackage/mod.scala
@@ -8,6 +8,5 @@ object mod {
   
   type DummyInt = Double
   
-  @js.native
   trait Package extends StObject
 }

--- a/tests/keyof/check/k/keyof/build.sbt
+++ b/tests/keyof/check/k/keyof/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "keyof"
-version := "0.0-unknown-3c169d"
+version := "0.0-unknown-975e82"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/keyof/check/k/keyof/src/main/scala/typings/keyof/A.scala
+++ b/tests/keyof/check/k/keyof/src/main/scala/typings/keyof/A.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait A extends StObject {
   
-  var a: Double = js.native
+  var a: Double
   
-  var b: Double = js.native
+  var b: Double
   
-  var c: Double = js.native
+  var c: Double
 }
 object A {
   

--- a/tests/keyof/check/k/keyof/src/main/scala/typings/keyof/anon.scala
+++ b/tests/keyof/check/k/keyof/src/main/scala/typings/keyof/anon.scala
@@ -7,12 +7,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 object anon {
   
   /* Inlined std.Pick<keyof.A, 'c' | 'b'> */
-  @js.native
   trait PickAcb extends StObject {
     
-    var b: Double = js.native
+    var b: Double
     
-    var c: Double = js.native
+    var c: Double
   }
   object PickAcb {
     

--- a/tests/material-ui/check-japgolly/m/material-ui/build.sbt
+++ b/tests/material-ui/check-japgolly/m/material-ui/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "material-ui"
-version := "0.0-unknown-24d390"
+version := "0.0-unknown-df2bbf"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-1e7568",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-0211d7",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-c0637e",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-b1cbf6",
   ("com.github.japgolly.scalajs-react" %%% "core" % "1.7.5").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/material-ui/check-japgolly/m/material-ui/src/main/scala/typingsJapgolly/materialUi/MaterialUI.scala
+++ b/tests/material-ui/check-japgolly/m/material-ui/src/main/scala/typingsJapgolly/materialUi/MaterialUI.scala
@@ -11,12 +11,11 @@ object MaterialUI {
     
     type BottomNavigationItem = Component[BottomNavigationItemProps & js.Object, js.Object]
     
-    @js.native
     trait BottomNavigationItemProps extends StObject {
       
-      var children: Double = js.native
+      var children: Double
       
-      var className: js.UndefOr[String] = js.native
+      var className: js.UndefOr[String] = js.undefined
     }
     object BottomNavigationItemProps {
       
@@ -43,10 +42,9 @@ object MaterialUI {
   
   object Styles {
     
-    @js.native
     trait MuiTheme extends StObject {
       
-      var spacing: js.UndefOr[js.Any] = js.native
+      var spacing: js.UndefOr[js.Any] = js.undefined
     }
     object MuiTheme {
       

--- a/tests/material-ui/check-japgolly/r/react/build.sbt
+++ b/tests/material-ui/check-japgolly/r/react/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-1e7568"
+version := "0.0-unknown-c0637e"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-0211d7",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-b1cbf6",
   ("com.github.japgolly.scalajs-react" %%% "core" % "1.7.5").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/material-ui/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/anon.scala
+++ b/tests/material-ui/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/anon.scala
@@ -12,10 +12,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Children extends StObject {
     
-    var children: js.UndefOr[Node] = js.native
+    var children: js.UndefOr[Node] = js.undefined
   }
   object Children {
     
@@ -45,10 +44,9 @@ object anon {
     }
   }
   
-  @js.native
   trait Html extends StObject {
     
-    var __html: String = js.native
+    var __html: String
   }
   object Html {
     

--- a/tests/material-ui/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod.scala
+++ b/tests/material-ui/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod.scala
@@ -20,14 +20,13 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
-  @js.native
   trait AllHTMLAttributes[T]
     extends StObject
        with HTMLAttributes[T] {
     
-    var accept: js.UndefOr[String] = js.native
+    var accept: js.UndefOr[String] = js.undefined
     
-    var acceptCharset: js.UndefOr[String] = js.native
+    var acceptCharset: js.UndefOr[String] = js.undefined
   }
   object AllHTMLAttributes {
     
@@ -54,7 +53,6 @@ object mod {
     }
   }
   
-  @js.native
   trait Component[P, S] extends StObject
   
   @js.native
@@ -79,14 +77,13 @@ object mod {
   
   type ComponentType[P] = (ComponentClassP[P & js.Object]) | StatelessComponent[P]
   
-  @js.native
   trait DOMAttributes[T] extends StObject {
     
-    var children: js.UndefOr[Node] = js.native
+    var children: js.UndefOr[Node] = js.undefined
     
-    var dangerouslySetInnerHTML: js.UndefOr[Html] = js.native
+    var dangerouslySetInnerHTML: js.UndefOr[Html] = js.undefined
     
-    var onClick: js.UndefOr[Double | (js.Function1[/* x */ String, Unit])] = js.native
+    var onClick: js.UndefOr[Double | (js.Function1[/* x */ String, Unit])] = js.undefined
   }
   object DOMAttributes {
     
@@ -131,12 +128,11 @@ object mod {
     }
   }
   
-  @js.native
   trait HTMLAttributes[T]
     extends StObject
        with DOMAttributes[T] {
     
-    var defaultChecked: js.UndefOr[Boolean] = js.native
+    var defaultChecked: js.UndefOr[Boolean] = js.undefined
   }
   object HTMLAttributes {
     
@@ -157,18 +153,17 @@ object mod {
     }
   }
   
-  @js.native
   trait HTMLProps[T]
     extends StObject
        with AllHTMLAttributes[T] {
     
-    var defaultValue: foo = js.native
+    var defaultValue: foo
     
-    var onChange: foo = js.native
+    var onChange: foo
     
-    var `type`: foo = js.native
+    var `type`: foo
     
-    var value: foo = js.native
+    var value: foo
   }
   object HTMLProps {
     
@@ -198,14 +193,13 @@ object mod {
   
   type Key = String | Double
   
-  @js.native
   trait ReactElement extends StObject {
     
-    var key: Key | Null = js.native
+    var key: Key | Null
     
-    var props: js.Any = js.native
+    var props: js.Any
     
-    var `type`: String | (ComponentClassP[js.Any & js.Object]) | SFC[js.Any] = js.native
+    var `type`: String | (ComponentClassP[js.Any & js.Object]) | SFC[js.Any]
   }
   object ReactElement {
     

--- a/tests/material-ui/check-japgolly/s/std/build.sbt
+++ b/tests/material-ui/check-japgolly/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-0211d7"
+version := "0.0-unknown-b1cbf6"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/material-ui/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Array.scala
+++ b/tests/material-ui/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/material-ui/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/HTMLElementTagNameMap.scala
+++ b/tests/material-ui/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/HTMLElementTagNameMap.scala
@@ -4,22 +4,21 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HTMLElementTagNameMap extends StObject {
   
-  var a: org.scalajs.dom.raw.HTMLAnchorElement = js.native
+  var a: org.scalajs.dom.raw.HTMLAnchorElement
   
-  var abbr: org.scalajs.dom.raw.HTMLElement = js.native
+  var abbr: org.scalajs.dom.raw.HTMLElement
   
-  var address: org.scalajs.dom.raw.HTMLElement = js.native
+  var address: org.scalajs.dom.raw.HTMLElement
   
-  var area: org.scalajs.dom.raw.HTMLAreaElement = js.native
+  var area: org.scalajs.dom.raw.HTMLAreaElement
   
-  var article: org.scalajs.dom.raw.HTMLElement = js.native
+  var article: org.scalajs.dom.raw.HTMLElement
   
-  var aside: org.scalajs.dom.raw.HTMLElement = js.native
+  var aside: org.scalajs.dom.raw.HTMLElement
   
-  var audio: org.scalajs.dom.raw.HTMLAudioElement = js.native
+  var audio: org.scalajs.dom.raw.HTMLAudioElement
 }
 object HTMLElementTagNameMap {
   

--- a/tests/material-ui/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Node.scala
+++ b/tests/material-ui/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Node.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Node extends StObject

--- a/tests/material-ui/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/SVGElementTagNameMap.scala
+++ b/tests/material-ui/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/SVGElementTagNameMap.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SVGElementTagNameMap extends StObject {
   
-  var circle: org.scalajs.dom.raw.SVGCircleElement = js.native
+  var circle: org.scalajs.dom.raw.SVGCircleElement
 }
 object SVGElementTagNameMap {
   

--- a/tests/material-ui/check-slinky/m/material-ui/build.sbt
+++ b/tests/material-ui/check-slinky/m/material-ui/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "material-ui"
-version := "0.0-unknown-b9c100"
+version := "0.0-unknown-8c3e91"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-1081a6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-d75e2a",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-8a3bdb",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-0811a6",
   ("me.shadaj" %%% "slinky-web" % "0.6.7").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/material-ui/check-slinky/m/material-ui/src/main/scala/typingsSlinky/materialUi/MaterialUI.scala
+++ b/tests/material-ui/check-slinky/m/material-ui/src/main/scala/typingsSlinky/materialUi/MaterialUI.scala
@@ -11,12 +11,11 @@ object MaterialUI {
     
     type BottomNavigationItem = ReactComponentClass[BottomNavigationItemProps]
     
-    @js.native
     trait BottomNavigationItemProps extends StObject {
       
-      var children: Double = js.native
+      var children: Double
       
-      var className: js.UndefOr[String] = js.native
+      var className: js.UndefOr[String] = js.undefined
     }
     object BottomNavigationItemProps {
       
@@ -43,10 +42,9 @@ object MaterialUI {
   
   object Styles {
     
-    @js.native
     trait MuiTheme extends StObject {
       
-      var spacing: js.UndefOr[js.Any] = js.native
+      var spacing: js.UndefOr[js.Any] = js.undefined
     }
     object MuiTheme {
       

--- a/tests/material-ui/check-slinky/r/react/build.sbt
+++ b/tests/material-ui/check-slinky/r/react/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-1081a6"
+version := "0.0-unknown-8a3bdb"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-d75e2a",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-0811a6",
   ("me.shadaj" %%% "slinky-web" % "0.6.7").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/material-ui/check-slinky/r/react/src/main/scala/typingsSlinky/react/anon.scala
+++ b/tests/material-ui/check-slinky/r/react/src/main/scala/typingsSlinky/react/anon.scala
@@ -7,10 +7,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Children extends StObject {
     
-    var children: js.UndefOr[ReactElement] = js.native
+    var children: js.UndefOr[ReactElement] = js.undefined
   }
   object Children {
     
@@ -31,10 +30,9 @@ object anon {
     }
   }
   
-  @js.native
   trait Html extends StObject {
     
-    var __html: String = js.native
+    var __html: String
   }
   object Html {
     

--- a/tests/material-ui/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod.scala
+++ b/tests/material-ui/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod.scala
@@ -13,14 +13,13 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
-  @js.native
   trait AllHTMLAttributes[T]
     extends StObject
        with HTMLAttributes[T] {
     
-    var accept: js.UndefOr[String] = js.native
+    var accept: js.UndefOr[String] = js.undefined
     
-    var acceptCharset: js.UndefOr[String] = js.native
+    var acceptCharset: js.UndefOr[String] = js.undefined
   }
   object AllHTMLAttributes {
     
@@ -47,7 +46,6 @@ object mod {
     }
   }
   
-  @js.native
   trait Component[P, S] extends StObject
   
   @js.native
@@ -65,14 +63,13 @@ object mod {
   
   type ComponentType[P] = ReactComponentClass[P]
   
-  @js.native
   trait DOMAttributes[T] extends StObject {
     
-    var children: js.UndefOr[slinky.core.facade.ReactElement] = js.native
+    var children: js.UndefOr[slinky.core.facade.ReactElement] = js.undefined
     
-    var dangerouslySetInnerHTML: js.UndefOr[Html] = js.native
+    var dangerouslySetInnerHTML: js.UndefOr[Html] = js.undefined
     
-    var onClick: js.UndefOr[Double | (js.Function1[/* x */ String, Unit])] = js.native
+    var onClick: js.UndefOr[Double | (js.Function1[/* x */ String, Unit])] = js.undefined
   }
   object DOMAttributes {
     
@@ -108,12 +105,11 @@ object mod {
     }
   }
   
-  @js.native
   trait HTMLAttributes[T]
     extends StObject
        with DOMAttributes[T] {
     
-    var defaultChecked: js.UndefOr[Boolean] = js.native
+    var defaultChecked: js.UndefOr[Boolean] = js.undefined
   }
   object HTMLAttributes {
     
@@ -134,18 +130,17 @@ object mod {
     }
   }
   
-  @js.native
   trait HTMLProps[T]
     extends StObject
        with AllHTMLAttributes[T] {
     
-    var defaultValue: foo = js.native
+    var defaultValue: foo
     
-    var onChange: foo = js.native
+    var onChange: foo
     
-    var `type`: foo = js.native
+    var `type`: foo
     
-    var value: foo = js.native
+    var value: foo
   }
   object HTMLProps {
     
@@ -175,14 +170,13 @@ object mod {
   
   type Key = String | Double
   
-  @js.native
   trait ReactElement extends StObject {
     
-    var key: Key | Null = js.native
+    var key: Key | Null
     
-    var props: js.Any = js.native
+    var props: js.Any
     
-    var `type`: String | ReactComponentClass[js.Any] = js.native
+    var `type`: String | ReactComponentClass[js.Any]
   }
   object ReactElement {
     

--- a/tests/material-ui/check-slinky/s/std/build.sbt
+++ b/tests/material-ui/check-slinky/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-d75e2a"
+version := "0.0-unknown-0811a6"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/material-ui/check-slinky/s/std/src/main/scala/typingsSlinky/std/Array.scala
+++ b/tests/material-ui/check-slinky/s/std/src/main/scala/typingsSlinky/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/material-ui/check-slinky/s/std/src/main/scala/typingsSlinky/std/HTMLElementTagNameMap.scala
+++ b/tests/material-ui/check-slinky/s/std/src/main/scala/typingsSlinky/std/HTMLElementTagNameMap.scala
@@ -4,22 +4,21 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HTMLElementTagNameMap extends StObject {
   
-  var a: org.scalajs.dom.raw.HTMLAnchorElement = js.native
+  var a: org.scalajs.dom.raw.HTMLAnchorElement
   
-  var abbr: org.scalajs.dom.raw.HTMLElement = js.native
+  var abbr: org.scalajs.dom.raw.HTMLElement
   
-  var address: org.scalajs.dom.raw.HTMLElement = js.native
+  var address: org.scalajs.dom.raw.HTMLElement
   
-  var area: org.scalajs.dom.raw.HTMLAreaElement = js.native
+  var area: org.scalajs.dom.raw.HTMLAreaElement
   
-  var article: org.scalajs.dom.raw.HTMLElement = js.native
+  var article: org.scalajs.dom.raw.HTMLElement
   
-  var aside: org.scalajs.dom.raw.HTMLElement = js.native
+  var aside: org.scalajs.dom.raw.HTMLElement
   
-  var audio: org.scalajs.dom.raw.HTMLAudioElement = js.native
+  var audio: org.scalajs.dom.raw.HTMLAudioElement
 }
 object HTMLElementTagNameMap {
   

--- a/tests/material-ui/check-slinky/s/std/src/main/scala/typingsSlinky/std/Node.scala
+++ b/tests/material-ui/check-slinky/s/std/src/main/scala/typingsSlinky/std/Node.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Node extends StObject

--- a/tests/material-ui/check-slinky/s/std/src/main/scala/typingsSlinky/std/SVGElementTagNameMap.scala
+++ b/tests/material-ui/check-slinky/s/std/src/main/scala/typingsSlinky/std/SVGElementTagNameMap.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SVGElementTagNameMap extends StObject {
   
-  var circle: org.scalajs.dom.raw.SVGCircleElement = js.native
+  var circle: org.scalajs.dom.raw.SVGCircleElement
 }
 object SVGElementTagNameMap {
   

--- a/tests/monaco-editor/check/m/monaco-editor/build.sbt
+++ b/tests/monaco-editor/check/m/monaco-editor/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "monaco-editor"
-version := "0.0-unknown-29a14a"
+version := "0.0-unknown-f245bf"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/monaco-editor/check/m/monaco-editor/src/main/scala/typings/monacoEditor/anon.scala
+++ b/tests/monaco-editor/check/m/monaco-editor/src/main/scala/typings/monacoEditor/anon.scala
@@ -7,12 +7,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Key[T] extends StObject {
     
-    var key: String = js.native
+    var key: String
     
-    var value: Promise[T, js.Any] = js.native
+    var value: Promise[T, js.Any]
   }
   object Key {
     

--- a/tests/monaco-editor/check/m/monaco-editor/src/main/scala/typings/monacoEditor/monaco.scala
+++ b/tests/monaco-editor/check/m/monaco-editor/src/main/scala/typings/monacoEditor/monaco.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object monaco {
   
-  @js.native
   trait Promise[T, TProgress] extends StObject
   
   type Thenable[T] = js.Thenable[T]

--- a/tests/mongoose-simple-random/check/m/mongoose-simple-random/build.sbt
+++ b/tests/mongoose-simple-random/check/m/mongoose-simple-random/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "mongoose-simple-random"
-version := "0.4-616bd6"
+version := "0.4-62b547"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "mongoose" % "0.0-unknown-8de7ef",
-  "org.scalablytyped" %%% "node" % "0.0-unknown-b93f15",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-5f966a")
+  "org.scalablytyped" %%% "mongoose" % "0.0-unknown-ec2f25",
+  "org.scalablytyped" %%% "node" % "0.0-unknown-f84c5d",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-54bbe1")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/mongoose-simple-random/check/m/mongoose/build.sbt
+++ b/tests/mongoose-simple-random/check/m/mongoose/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "mongoose"
-version := "0.0-unknown-8de7ef"
+version := "0.0-unknown-ec2f25"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/mongoose-simple-random/check/m/mongoose/src/main/scala/typings/mongoose/mod.scala
+++ b/tests/mongoose-simple-random/check/m/mongoose/src/main/scala/typings/mongoose/mod.scala
@@ -6,12 +6,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
-  @js.native
   trait Document extends StObject
   
-  @js.native
   trait ModelProperties extends StObject
   
-  @js.native
   trait Schema extends StObject
 }

--- a/tests/mongoose-simple-random/check/n/node/build.sbt
+++ b/tests/mongoose-simple-random/check/n/node/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "0.0-unknown-b93f15"
+version := "0.0-unknown-f84c5d"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/mongoose-simple-random/check/n/node/src/main/scala/typings/node/NodeJS.scala
+++ b/tests/mongoose-simple-random/check/n/node/src/main/scala/typings/node/NodeJS.scala
@@ -6,6 +6,5 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object NodeJS {
   
-  @js.native
   trait EventEmitter extends StObject
 }

--- a/tests/mongoose-simple-random/check/s/std/build.sbt
+++ b/tests/mongoose-simple-random/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-5f966a"
+version := "0.0-unknown-54bbe1"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/mongoose-simple-random/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/mongoose-simple-random/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/mongoose-simple-random/check/s/std/src/main/scala/typings/std/Object.scala
+++ b/tests/mongoose-simple-random/check/s/std/src/main/scala/typings/std/Object.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Object extends StObject

--- a/tests/numjs/check/n/ndarray/build.sbt
+++ b/tests/numjs/check/n/ndarray/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "ndarray"
-version := "0.0-unknown-e67db6"
+version := "0.0-unknown-99428c"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-823ce5")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-53c51d")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/numjs/check/n/ndarray/src/main/scala/typings/ndarray/mod.scala
+++ b/tests/numjs/check/n/ndarray/src/main/scala/typings/ndarray/mod.scala
@@ -31,12 +31,11 @@ object mod {
   
   type DataType = String
   
-  @js.native
   trait ndarray[T] extends StObject {
     
-    var T: typings.ndarray.mod.ndarray[T] = js.native
+    var T: typings.ndarray.mod.ndarray[T]
     
-    var data: Data[T] = js.native
+    var data: Data[T]
   }
   object ndarray {
     

--- a/tests/numjs/check/n/numjs/build.sbt
+++ b/tests/numjs/check/n/numjs/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "numjs"
-version := "0.0-unknown-110864"
+version := "0.0-unknown-eaec41"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "ndarray" % "0.0-unknown-e67db6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-823ce5")
+  "org.scalablytyped" %%% "ndarray" % "0.0-unknown-99428c",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-53c51d")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/numjs/check/n/numjs/src/main/scala/typings/numjs/mod.scala
+++ b/tests/numjs/check/n/numjs/src/main/scala/typings/numjs/mod.scala
@@ -9,17 +9,16 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
-  @js.native
   trait NdArray[T]
     extends StObject
        with ndarray[T] {
     
     @JSName("T")
-    var T_NdArray: NdArray[T] = js.native
+    var T_NdArray: NdArray[T]
     
-    var ndim: Double = js.native
+    var ndim: Double
     
-    def slice(args: Double*): NdArray[T] = js.native
+    def slice(args: Double*): NdArray[T]
   }
   object NdArray {
     

--- a/tests/numjs/check/s/std/build.sbt
+++ b/tests/numjs/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-823ce5"
+version := "0.0-unknown-53c51d"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/numjs/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/numjs/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/punchcard/check/p/punchcard/build.sbt
+++ b/tests/punchcard/check/p/punchcard/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "punchcard"
-version := "0.0-unknown-483860"
+version := "0.0-unknown-613c7e"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-98f024")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d50f3a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/punchcard/check/p/punchcard/src/main/scala/typings/punchcard/mod.scala
+++ b/tests/punchcard/check/p/punchcard/src/main/scala/typings/punchcard/mod.scala
@@ -18,12 +18,9 @@ object mod {
   ]
   
   /* Inlined std.Readonly<{[member: string] : punchcard.punchcard.Shape}> */
-  @js.native
   trait Fields extends StObject
   
-  @js.native
   trait Shape extends StObject
   
-  @js.native
   trait TypeShape[A, B] extends StObject
 }

--- a/tests/punchcard/check/s/std/build.sbt
+++ b/tests/punchcard/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-98f024"
+version := "0.0-unknown-d50f3a"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/punchcard/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/punchcard/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/react-icons/check/r/react-icon-base/build.sbt
+++ b/tests/react-icons/check/r/react-icon-base/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-icon-base"
-version := "2.1-e78d68"
+version := "2.1-02632e"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-1cd26b",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-d3ae3a")
+  "org.scalablytyped" %%% "react" % "0.0-unknown-863110",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-179abd")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-icons/check/r/react-icon-base/src/main/scala/typings/reactIconBase/mod.scala
+++ b/tests/react-icons/check/r/react-icon-base/src/main/scala/typings/reactIconBase/mod.scala
@@ -17,12 +17,11 @@ object mod {
   
   type IconBaseClass = Component[IconBaseProps, js.Object]
   
-  @js.native
   trait IconBaseProps
     extends StObject
        with ClassAttributes[ReactSVGElement] {
     
-    var size: js.UndefOr[String | Double] = js.native
+    var size: js.UndefOr[String | Double] = js.undefined
   }
   object IconBaseProps {
     

--- a/tests/react-icons/check/r/react-icons/build.sbt
+++ b/tests/react-icons/check/r/react-icons/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-icons"
-version := "2.2-c8750d"
+version := "2.2-50b761"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-1cd26b",
-  "org.scalablytyped" %%% "react-icon-base" % "2.1-e78d68",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-d3ae3a")
+  "org.scalablytyped" %%% "react" % "0.0-unknown-863110",
+  "org.scalablytyped" %%% "react-icon-base" % "2.1-02632e",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-179abd")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-icons/check/r/react/build.sbt
+++ b/tests/react-icons/check/r/react/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-1cd26b"
+version := "0.0-unknown-863110"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-d3ae3a")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-179abd")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-icons/check/r/react/src/main/scala/typings/react/anon.scala
+++ b/tests/react-icons/check/r/react/src/main/scala/typings/react/anon.scala
@@ -7,10 +7,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Children extends StObject {
     
-    var children: js.UndefOr[ReactNode] = js.native
+    var children: js.UndefOr[ReactNode] = js.undefined
   }
   object Children {
     
@@ -31,10 +30,9 @@ object anon {
     }
   }
   
-  @js.native
   trait Html extends StObject {
     
-    var __html: String = js.native
+    var __html: String
   }
   object Html {
     

--- a/tests/react-icons/check/r/react/src/main/scala/typings/react/mod.scala
+++ b/tests/react-icons/check/r/react/src/main/scala/typings/react/mod.scala
@@ -16,14 +16,13 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
-  @js.native
   trait AllHTMLAttributes[T]
     extends StObject
        with HTMLAttributes[T] {
     
-    var accept: js.UndefOr[String] = js.native
+    var accept: js.UndefOr[String] = js.undefined
     
-    var acceptCharset: js.UndefOr[String] = js.native
+    var acceptCharset: js.UndefOr[String] = js.undefined
   }
   object AllHTMLAttributes {
     
@@ -50,10 +49,9 @@ object mod {
     }
   }
   
-  @js.native
   trait Attributes extends StObject {
     
-    var key: js.UndefOr[Key] = js.native
+    var key: js.UndefOr[Key] = js.undefined
   }
   object Attributes {
     
@@ -74,12 +72,11 @@ object mod {
     }
   }
   
-  @js.native
   trait ClassAttributes[T]
     extends StObject
        with Attributes {
     
-    var ref: js.UndefOr[Ref[T]] = js.native
+    var ref: js.UndefOr[Ref[T]] = js.undefined
   }
   object ClassAttributes {
     
@@ -103,7 +100,6 @@ object mod {
     }
   }
   
-  @js.native
   trait Component[P, S] extends StObject
   
   @js.native
@@ -126,12 +122,11 @@ object mod {
   */
   trait ComponentType[P] extends StObject
   
-  @js.native
   trait DOMAttributes[T] extends StObject {
     
-    var children: js.UndefOr[ReactNode] = js.native
+    var children: js.UndefOr[ReactNode] = js.undefined
     
-    var dangerouslySetInnerHTML: js.UndefOr[Html] = js.native
+    var dangerouslySetInnerHTML: js.UndefOr[Html] = js.undefined
   }
   object DOMAttributes {
     
@@ -159,15 +154,14 @@ object mod {
   }
   
   // string fallback for custom web-components
-  @js.native
   trait DOMElement[P /* <: HTMLAttributes[T] | SVGAttributes[T] */, T /* <: Element */]
     extends StObject
        with ReactElement {
     
-    var ref: Ref[T] = js.native
+    var ref: Ref[T]
     
     @JSName("type")
-    var type_DOMElement: String = js.native
+    var type_DOMElement: String
   }
   object DOMElement {
     
@@ -200,12 +194,11 @@ object mod {
     def apply(props: Unit, children: ReactNode*): DOMElement[P, T] = js.native
   }
   
-  @js.native
   trait HTMLAttributes[T]
     extends StObject
        with DOMAttributes[T] {
     
-    var defaultChecked: js.UndefOr[Boolean] = js.native
+    var defaultChecked: js.UndefOr[Boolean] = js.undefined
   }
   object HTMLAttributes {
     
@@ -228,14 +221,13 @@ object mod {
   
   type Key = String | Double
   
-  @js.native
   trait ReactElement extends StObject {
     
-    var key: Key | Null = js.native
+    var key: Key | Null
     
-    var props: js.Any = js.native
+    var props: js.Any
     
-    var `type`: String | ComponentClass[js.Any] = js.native
+    var `type`: String | ComponentClass[js.Any]
   }
   object ReactElement {
     
@@ -265,14 +257,13 @@ object mod {
   
   type ReactNode = js.UndefOr[String | Double | Boolean]
   
-  @js.native
   trait ReactSVG extends StObject {
     
-    var animate: SVGFactory = js.native
+    var animate: SVGFactory
     
-    var circle: SVGFactory = js.native
+    var circle: SVGFactory
     
-    var clipPath: SVGFactory = js.native
+    var clipPath: SVGFactory
   }
   object ReactSVG {
     
@@ -297,13 +288,12 @@ object mod {
   }
   
   // ReactSVG for ReactSVGElement
-  @js.native
   trait ReactSVGElement
     extends StObject
        with DOMElement[SVGAttributes[SVGElement], SVGElement] {
     
     @JSName("type")
-    var type_ReactSVGElement: animate | circle | clipPath = js.native
+    var type_ReactSVGElement: animate | circle | clipPath
   }
   object ReactSVGElement {
     
@@ -326,18 +316,17 @@ object mod {
   
   type SFC[P] = StatelessComponent[P]
   
-  @js.native
   trait SVGAttributes[T]
     extends StObject
        with DOMAttributes[T] {
     
     // Attributes which also defined in HTMLAttributes
     // See comment in SVGDOMPropertyConfig.js
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
-    var color: js.UndefOr[String] = js.native
+    var color: js.UndefOr[String] = js.undefined
     
-    var height: js.UndefOr[Double | String] = js.native
+    var height: js.UndefOr[Double | String] = js.undefined
   }
   object SVGAttributes {
     

--- a/tests/react-icons/check/s/std/build.sbt
+++ b/tests/react-icons/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-d3ae3a"
+version := "0.0-unknown-179abd"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-icons/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/react-icons/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/react-icons/check/s/std/src/main/scala/typings/std/Element.scala
+++ b/tests/react-icons/check/s/std/src/main/scala/typings/std/Element.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Element extends StObject

--- a/tests/react-icons/check/s/std/src/main/scala/typings/std/Event.scala
+++ b/tests/react-icons/check/s/std/src/main/scala/typings/std/Event.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Event extends StObject

--- a/tests/react-integration-test/check-japgolly/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-japgolly/c/componentstest/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-34d87e"
+version := "0.0-unknown-5439bc"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d6e1e0",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-46b6e2",
+  "org.scalablytyped" %%% "react" % "16.9.2-242f5f",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7863fe",
   ("com.github.japgolly.scalajs-react" %%% "core" % "1.7.5").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-japgolly/c/componentstest/src/main/scala/typingsJapgolly/componentstest/anon.scala
+++ b/tests/react-integration-test/check-japgolly/c/componentstest/src/main/scala/typingsJapgolly/componentstest/anon.scala
@@ -6,16 +6,15 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Equals extends StObject {
     
     @JSName("equals")
-    var equals_FEquals: js.UndefOr[Boolean] = js.native
+    var equals_FEquals: js.UndefOr[Boolean] = js.undefined
     
-    def finalize(other: js.Object): Boolean = js.native
+    def finalize(other: js.Object): Boolean
     
     @JSName("ne")
-    var ne_FEquals: js.UndefOr[js.Function1[/* other */ js.Object, Boolean]] = js.native
+    var ne_FEquals: js.UndefOr[js.Function1[/* other */ js.Object, Boolean]] = js.undefined
   }
   object Equals {
     

--- a/tests/react-integration-test/check-japgolly/c/componentstest/src/main/scala/typingsJapgolly/componentstest/mod.scala
+++ b/tests/react-integration-test/check-japgolly/c/componentstest/src/main/scala/typingsJapgolly/componentstest/mod.scala
@@ -33,14 +33,13 @@ object mod {
   @js.native
   val ObjectNames: FC[Equals] = js.native
   
-  @js.native
   trait A
     extends StObject
        with Props {
     
-    def aCallback(): Double = js.native
+    def aCallback(): Double
     
-    var aMember: Double = js.native
+    var aMember: Double
   }
   object A {
     
@@ -61,14 +60,13 @@ object mod {
     }
   }
   
-  @js.native
   trait B
     extends StObject
        with Props {
     
-    var bCallback: js.UndefOr[js.Function0[String]] = js.native
+    var bCallback: js.UndefOr[js.Function0[String]] = js.undefined
     
-    var bMember: String = js.native
+    var bMember: String
   }
   object B {
     
@@ -92,16 +90,15 @@ object mod {
     }
   }
   
-  @js.native
   trait CardGridProps extends StObject {
     
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
-    var hoverable: js.UndefOr[Boolean] = js.native
+    var hoverable: js.UndefOr[Boolean] = js.undefined
     
-    var prefixCls: js.UndefOr[String] = js.native
+    var prefixCls: js.UndefOr[String] = js.undefined
     
-    var style: js.UndefOr[CSSProperties] = js.native
+    var style: js.UndefOr[CSSProperties] = js.undefined
   }
   object CardGridProps {
     
@@ -149,12 +146,11 @@ object mod {
   }
   
   /* Inlined parent std.Omit<std.Pick<react.react.HTMLAttributes<std.HTMLDivElement>, 'title' | 'onClick'>, 'title'> */
-  @js.native
   trait CardProps extends StObject {
     
-    var onClick: js.UndefOr[MouseEventHandler[HTMLDivElement]] = js.native
+    var onClick: js.UndefOr[MouseEventHandler[HTMLDivElement]] = js.undefined
     
-    var prefixCls: js.UndefOr[String] = js.native
+    var prefixCls: js.UndefOr[String] = js.undefined
   }
   object CardProps {
     

--- a/tests/react-integration-test/check-japgolly/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-bootstrap/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-799c49"
+version := "0.32-8102ec"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d6e1e0",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-46b6e2",
+  "org.scalablytyped" %%% "react" % "16.9.2-242f5f",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7863fe",
   ("com.github.japgolly.scalajs-react" %%% "core" % "1.7.5").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/bootstrapUtilsMod.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/bootstrapUtilsMod.scala
@@ -13,10 +13,9 @@ object bootstrapUtilsMod {
   @scala.inline
   def getBsProps(props: js.Any): BSProps = ^.asInstanceOf[js.Dynamic].applyDynamic("getBsProps")(props.asInstanceOf[js.Any]).asInstanceOf[BSProps]
   
-  @js.native
   trait BSProps extends StObject {
     
-    var bsClass: js.Any = js.native
+    var bsClass: js.Any
   }
   object BSProps {
     

--- a/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/buttonGroupMod.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/buttonGroupMod.scala
@@ -18,20 +18,19 @@ object buttonGroupMod {
   trait ButtonGroup
     extends Component[ButtonGroupProps, js.Object, js.Any]
   
-  @js.native
   trait ButtonGroupProps
     extends StObject
        with HTMLProps[ButtonGroup] {
     
-    var block: js.UndefOr[Boolean] = js.native
+    var block: js.UndefOr[Boolean] = js.undefined
     
-    var bsSize: js.UndefOr[Sizes] = js.native
+    var bsSize: js.UndefOr[Sizes] = js.undefined
     
-    var bsStyle: js.UndefOr[String] = js.native
+    var bsStyle: js.UndefOr[String] = js.undefined
     
-    var justified: js.UndefOr[Boolean] = js.native
+    var justified: js.UndefOr[Boolean] = js.undefined
     
-    var vertical: js.UndefOr[Boolean] = js.native
+    var vertical: js.UndefOr[Boolean] = js.undefined
   }
   object ButtonGroupProps {
     

--- a/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/toggleButtonGroupMod.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/toggleButtonGroupMod.scala
@@ -22,20 +22,19 @@ object toggleButtonGroupMod {
   class ^ ()
     extends Component[ToggleButtonGroupProps, js.Object, js.Any]
   
-  @js.native
   trait BaseProps extends StObject {
     
     /**
       * You'll usually want to use string|number|string[]|number[] here,
       * but you can technically use any|any[].
       */
-    var defaultValue: js.UndefOr[js.Any] = js.native
+    var defaultValue: js.UndefOr[js.Any] = js.undefined
     
     /**
       * You'll usually want to use string|number|string[]|number[] here,
       * but you can technically use any|any[].
       */
-    var value: js.UndefOr[js.Any] = js.native
+    var value: js.UndefOr[js.Any] = js.undefined
   }
   object BaseProps {
     
@@ -62,14 +61,13 @@ object toggleButtonGroupMod {
     }
   }
   
-  @js.native
   trait CheckboxProps extends StObject {
     
-    var name: js.UndefOr[String] = js.native
+    var name: js.UndefOr[String] = js.undefined
     
-    var onChange: js.UndefOr[js.Function1[/* values */ js.Array[js.Any], Unit]] = js.native
+    var onChange: js.UndefOr[js.Function1[/* values */ js.Array[js.Any], Unit]] = js.undefined
     
-    var `type`: checkbox = js.native
+    var `type`: checkbox
   }
   object CheckboxProps {
     
@@ -100,15 +98,14 @@ object toggleButtonGroupMod {
     }
   }
   
-  @js.native
   trait RadioProps extends StObject {
     
     /** Required if `type` is set to "radio" */
-    var name: String = js.native
+    var name: String
     
-    var onChange: js.UndefOr[js.Function1[/* value */ js.Any, Unit]] = js.native
+    var onChange: js.UndefOr[js.Function1[/* value */ js.Any, Unit]] = js.undefined
     
-    var `type`: radio = js.native
+    var `type`: radio
   }
   object RadioProps {
     

--- a/tests/react-integration-test/check-japgolly/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-contextmenu/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-61a102"
+version := "2.13.0-dbf62f"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d6e1e0",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-46b6e2",
+  "org.scalablytyped" %%% "react" % "16.9.2-242f5f",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7863fe",
   ("com.github.japgolly.scalajs-react" %%% "core" % "1.7.5").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-japgolly/r/react-contextmenu/src/main/scala/typingsJapgolly/reactContextmenu/mod.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-contextmenu/src/main/scala/typingsJapgolly/reactContextmenu/mod.scala
@@ -91,18 +91,17 @@ object mod {
   @scala.inline
   def showMenu(opts: Unit, target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
   
-  @js.native
   trait ContextMenuProps extends StObject {
     
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
-    var data: js.UndefOr[js.Any] = js.native
+    var data: js.UndefOr[js.Any] = js.undefined
     
-    var hideOnLeave: js.UndefOr[Boolean] = js.native
+    var hideOnLeave: js.UndefOr[Boolean] = js.undefined
     
-    var id: String = js.native
+    var id: String
     
-    var onHide: js.UndefOr[js.Function1[/* event */ js.Any, Unit]] = js.native
+    var onHide: js.UndefOr[js.Function1[/* event */ js.Any, Unit]] = js.undefined
     
     var onMouseLeave: js.UndefOr[
         (js.Function3[
@@ -111,11 +110,11 @@ object mod {
           /* target */ HTMLElement, 
           Unit
         ]) | js.Function
-      ] = js.native
+      ] = js.undefined
     
-    var onShow: js.UndefOr[js.Function1[/* event */ js.Any, Unit]] = js.native
+    var onShow: js.UndefOr[js.Function1[/* event */ js.Any, Unit]] = js.undefined
     
-    var rtl: js.UndefOr[Boolean] = js.native
+    var rtl: js.UndefOr[Boolean] = js.undefined
   }
   object ContextMenuProps {
     
@@ -187,20 +186,19 @@ object mod {
     }
   }
   
-  @js.native
   trait ContextMenuTriggerProps extends StObject {
     
-    var attributes: js.UndefOr[HTMLAttributes[js.Any]] = js.native
+    var attributes: js.UndefOr[HTMLAttributes[js.Any]] = js.undefined
     
-    var collect: js.UndefOr[js.Function1[/* data */ js.Any, js.Any]] = js.native
+    var collect: js.UndefOr[js.Function1[/* data */ js.Any, js.Any]] = js.undefined
     
-    var disable: js.UndefOr[Boolean] = js.native
+    var disable: js.UndefOr[Boolean] = js.undefined
     
-    var holdToDisplay: js.UndefOr[Double] = js.native
+    var holdToDisplay: js.UndefOr[Double] = js.undefined
     
-    var id: String = js.native
+    var id: String
     
-    var renderTag: js.UndefOr[ReactType[js.Any]] = js.native
+    var renderTag: js.UndefOr[ReactType[js.Any]] = js.undefined
   }
   object ContextMenuTriggerProps {
     
@@ -248,20 +246,19 @@ object mod {
     }
   }
   
-  @js.native
   trait MenuItemProps extends StObject {
     
-    var attributes: js.UndefOr[HTMLAttributes[HTMLDivElement]] = js.native
+    var attributes: js.UndefOr[HTMLAttributes[HTMLDivElement]] = js.undefined
     
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     var data: js.UndefOr[
         /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Object */ js.Any
-      ] = js.native
+      ] = js.undefined
     
-    var disabled: js.UndefOr[Boolean] = js.native
+    var disabled: js.UndefOr[Boolean] = js.undefined
     
-    var divider: js.UndefOr[Boolean] = js.native
+    var divider: js.UndefOr[Boolean] = js.undefined
     
     var onClick: js.UndefOr[
         (js.Function3[
@@ -270,9 +267,9 @@ object mod {
           /* target */ HTMLElement, 
           Unit
         ]) | js.Function
-      ] = js.native
+      ] = js.undefined
     
-    var preventClose: js.UndefOr[Boolean] = js.native
+    var preventClose: js.UndefOr[Boolean] = js.undefined
   }
   object MenuItemProps {
     
@@ -343,14 +340,13 @@ object mod {
     }
   }
   
-  @js.native
   trait SubMenuProps extends StObject {
     
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
-    var disabled: js.UndefOr[Boolean] = js.native
+    var disabled: js.UndefOr[Boolean] = js.undefined
     
-    var hoverDelay: js.UndefOr[Double] = js.native
+    var hoverDelay: js.UndefOr[Double] = js.undefined
     
     var onClick: js.UndefOr[
         (js.Function3[
@@ -359,13 +355,13 @@ object mod {
           /* target */ HTMLElement, 
           Unit
         ]) | js.Function
-      ] = js.native
+      ] = js.undefined
     
-    var preventCloseOnClick: js.UndefOr[Boolean] = js.native
+    var preventCloseOnClick: js.UndefOr[Boolean] = js.undefined
     
-    var rtl: js.UndefOr[Boolean] = js.native
+    var rtl: js.UndefOr[Boolean] = js.undefined
     
-    var title: Element | ReactText = js.native
+    var title: Element | ReactText
   }
   object SubMenuProps {
     

--- a/tests/react-integration-test/check-japgolly/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-dropzone/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-e2a16f"
+version := "10.1.10-504a5f"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d6e1e0",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-46b6e2",
+  "org.scalablytyped" %%% "react" % "16.9.2-242f5f",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7863fe",
   ("com.github.japgolly.scalajs-react" %%% "core" % "1.7.5").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-japgolly/r/react-dropzone/src/main/scala/typingsJapgolly/reactDropzone/mod.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-dropzone/src/main/scala/typingsJapgolly/reactDropzone/mod.scala
@@ -34,12 +34,11 @@ object mod {
   
   type DropEvent = ReactDragEventFrom[HTMLElement] | ReactEventFrom[HTMLInputElement] | DragEvent | Event
   
-  @js.native
   trait DropzoneInputProps
     extends StObject
        with InputHTMLAttributes[HTMLInputElement] {
     
-    var refKey: js.UndefOr[String] = js.native
+    var refKey: js.UndefOr[String] = js.undefined
   }
   object DropzoneInputProps {
     
@@ -61,39 +60,38 @@ object mod {
   }
   
   /* Inlined std.Pick<react.react.HTMLProps<std.HTMLElement>, react-dropzone.react-dropzone.PropTypes> & {  accept :string | std.Array<string> | undefined,   minSize :number | undefined,   maxSize :number | undefined,   preventDropOnDocument :boolean | undefined,   noClick :boolean | undefined,   noKeyboard :boolean | undefined,   noDrag :boolean | undefined,   noDragEventsBubbling :boolean | undefined,   disabled :boolean | undefined,   onDrop :<T extends / * import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify File * / any>(acceptedFiles : std.Array<T>, rejectedFiles : std.Array<T>, event : react-dropzone.react-dropzone.DropEvent): void | undefined,   onDropAccepted :<T extends / * import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify File * / any>(files : std.Array<T>, event : react-dropzone.react-dropzone.DropEvent): void | undefined,   onDropRejected :<T extends / * import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify File * / any>(files : std.Array<T>, event : react-dropzone.react-dropzone.DropEvent): void | undefined,   getFilesFromEvent :(event : react-dropzone.react-dropzone.DropEvent): / * import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Promise<Array<File | DataTransferItem>> * / any | undefined,   onFileDialogCancel :(): void | undefined} */
-  @js.native
   trait DropzoneOptions extends StObject {
     
-    var accept: js.UndefOr[String | js.Array[String]] = js.native
+    var accept: js.UndefOr[String | js.Array[String]] = js.undefined
     
-    var disabled: js.UndefOr[Boolean] = js.native
+    var disabled: js.UndefOr[Boolean] = js.undefined
     
     var getFilesFromEvent: js.UndefOr[
         js.Function1[
           /* event */ DropEvent, 
           /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Promise<Array<File | DataTransferItem>> */ js.Any
         ]
-      ] = js.native
+      ] = js.undefined
     
-    var maxSize: js.UndefOr[Double] = js.native
+    var maxSize: js.UndefOr[Double] = js.undefined
     
-    var minSize: js.UndefOr[Double] = js.native
+    var minSize: js.UndefOr[Double] = js.undefined
     
-    var multiple: js.UndefOr[Boolean] = js.native
+    var multiple: js.UndefOr[Boolean] = js.undefined
     
-    var noClick: js.UndefOr[Boolean] = js.native
+    var noClick: js.UndefOr[Boolean] = js.undefined
     
-    var noDrag: js.UndefOr[Boolean] = js.native
+    var noDrag: js.UndefOr[Boolean] = js.undefined
     
-    var noDragEventsBubbling: js.UndefOr[Boolean] = js.native
+    var noDragEventsBubbling: js.UndefOr[Boolean] = js.undefined
     
-    var noKeyboard: js.UndefOr[Boolean] = js.native
+    var noKeyboard: js.UndefOr[Boolean] = js.undefined
     
-    var onDragEnter: js.UndefOr[DragEventHandler[HTMLElement]] = js.native
+    var onDragEnter: js.UndefOr[DragEventHandler[HTMLElement]] = js.undefined
     
-    var onDragLeave: js.UndefOr[DragEventHandler[HTMLElement]] = js.native
+    var onDragLeave: js.UndefOr[DragEventHandler[HTMLElement]] = js.undefined
     
-    var onDragOver: js.UndefOr[DragEventHandler[HTMLElement]] = js.native
+    var onDragOver: js.UndefOr[DragEventHandler[HTMLElement]] = js.undefined
     
     var onDrop: js.UndefOr[
         js.Function3[
@@ -106,7 +104,7 @@ object mod {
           /* event */ DropEvent, 
           Unit
         ]
-      ] = js.native
+      ] = js.undefined
     
     var onDropAccepted: js.UndefOr[
         js.Function2[
@@ -116,7 +114,7 @@ object mod {
           /* event */ DropEvent, 
           Unit
         ]
-      ] = js.native
+      ] = js.undefined
     
     var onDropRejected: js.UndefOr[
         js.Function2[
@@ -126,11 +124,11 @@ object mod {
           /* event */ DropEvent, 
           Unit
         ]
-      ] = js.native
+      ] = js.undefined
     
-    var onFileDialogCancel: js.UndefOr[js.Function0[Unit]] = js.native
+    var onFileDialogCancel: js.UndefOr[js.Function0[Unit]] = js.undefined
     
-    var preventDropOnDocument: js.UndefOr[Boolean] = js.native
+    var preventDropOnDocument: js.UndefOr[Boolean] = js.undefined
   }
   object DropzoneOptions {
     
@@ -280,12 +278,11 @@ object mod {
     }
   }
   
-  @js.native
   trait DropzoneProps
     extends StObject
        with DropzoneOptions {
     
-    var children: js.UndefOr[js.Function1[/* state */ DropzoneState, Element]] = js.native
+    var children: js.UndefOr[js.Function1[/* state */ DropzoneState, Element]] = js.undefined
   }
   object DropzoneProps {
     
@@ -306,10 +303,9 @@ object mod {
     }
   }
   
-  @js.native
   trait DropzoneRef extends StObject {
     
-    def open(): Unit = js.native
+    def open(): Unit
   }
   object DropzoneRef {
     
@@ -327,13 +323,12 @@ object mod {
     }
   }
   
-  @js.native
   trait DropzoneRootProps
     extends StObject
        with HTMLAttributes[HTMLElement]
        with /* key */ StringDictionary[js.Any] {
     
-    var refKey: js.UndefOr[String] = js.native
+    var refKey: js.UndefOr[String] = js.undefined
   }
   object DropzoneRootProps {
     

--- a/tests/react-integration-test/check-japgolly/r/react-markdown/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-markdown/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-markdown"
-version := "0.0-unknown-7c0da8"
+version := "0.0-unknown-629dee"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d6e1e0",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-46b6e2",
+  "org.scalablytyped" %%% "react" % "16.9.2-242f5f",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7863fe",
   ("com.github.japgolly.scalajs-react" %%% "core" % "1.7.5").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-japgolly/r/react-markdown/src/main/scala/typingsJapgolly/reactMarkdown/mod.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-markdown/src/main/scala/typingsJapgolly/reactMarkdown/mod.scala
@@ -25,10 +25,9 @@ object mod {
   @scala.inline
   def uriTransformer(uri: String): String = ^.asInstanceOf[js.Dynamic].applyDynamic("uriTransformer")(uri.asInstanceOf[js.Any]).asInstanceOf[String]
   
-  @js.native
   trait ChildrenProp extends StObject {
     
-    val children: String = js.native
+    val children: String
   }
   object ChildrenProp {
     
@@ -56,14 +55,13 @@ object mod {
   
   type ReactMarkdownProps = ReactMarkdownPropsBase & (MutuallyExclusive[ChildrenProp, SourceProp])
   
-  @js.native
   trait ReactMarkdownPropsBase extends StObject {
     
-    val allowNode: js.UndefOr[js.Function1[/* index */ Double, Boolean]] = js.native
+    val allowNode: js.UndefOr[js.Function1[/* index */ Double, Boolean]] = js.undefined
     
-    val className: js.UndefOr[String] = js.native
+    val className: js.UndefOr[String] = js.undefined
     
-    val linkTarget: js.UndefOr[String | LinkTargetResolver] = js.native
+    val linkTarget: js.UndefOr[String | LinkTargetResolver] = js.undefined
     
     val transformLinkUri: js.UndefOr[
         (js.Function3[
@@ -72,7 +70,7 @@ object mod {
           /* title */ js.UndefOr[String], 
           String
         ]) | Null
-      ] = js.native
+      ] = js.undefined
   }
   object ReactMarkdownPropsBase {
     
@@ -123,11 +121,10 @@ object mod {
   
   type Renderers_ = StringDictionary[String | Renderer[js.Any]]
   
-  @js.native
   trait SourceProp extends StObject {
     
     /** @deprecated use children */
-    val source: String = js.native
+    val source: String
   }
   object SourceProp {
     

--- a/tests/react-integration-test/check-japgolly/r/react-native/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-native/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "react-native"
-version := "0.0-unknown-2ae43b"
+version := "0.0-unknown-d7e672"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-46b6e2",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7863fe",
   ("com.github.japgolly.scalajs-react" %%% "core" % "1.7.5").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-japgolly/r/react-native/src/main/scala/typingsJapgolly/reactNative/ViewToken.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-native/src/main/scala/typingsJapgolly/reactNative/ViewToken.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ViewToken extends StObject

--- a/tests/react-integration-test/check-japgolly/r/react-native/src/main/scala/typingsJapgolly/reactNative/ViewabilityConfig.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-native/src/main/scala/typingsJapgolly/reactNative/ViewabilityConfig.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ViewabilityConfig extends StObject

--- a/tests/react-integration-test/check-japgolly/r/react-native/src/main/scala/typingsJapgolly/reactNative/ViewabilityConfigCallbackPair.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-native/src/main/scala/typingsJapgolly/reactNative/ViewabilityConfigCallbackPair.scala
@@ -6,12 +6,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ViewabilityConfigCallbackPair extends StObject {
   
-  var onViewableItemsChanged: (js.Function1[/* info */ Changed, Unit]) | Null = js.native
+  var onViewableItemsChanged: (js.Function1[/* info */ Changed, Unit]) | Null
   
-  var viewabilityConfig: ViewabilityConfig = js.native
+  var viewabilityConfig: ViewabilityConfig
 }
 object ViewabilityConfigCallbackPair {
   

--- a/tests/react-integration-test/check-japgolly/r/react-native/src/main/scala/typingsJapgolly/reactNative/anon.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-native/src/main/scala/typingsJapgolly/reactNative/anon.scala
@@ -6,12 +6,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Changed extends StObject {
     
-    var changed: js.Array[ViewToken] = js.native
+    var changed: js.Array[ViewToken]
     
-    var viewableItems: js.Array[ViewToken] = js.native
+    var viewableItems: js.Array[ViewToken]
   }
   object Changed {
     

--- a/tests/react-integration-test/check-japgolly/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react-select/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-49ffdd"
+version := "0.0-unknown-96852a"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d6e1e0",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-46b6e2",
+  "org.scalablytyped" %%% "react" % "16.9.2-242f5f",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7863fe",
   ("com.github.japgolly.scalajs-react" %%% "core" % "1.7.5").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-japgolly/r/react-select/src/main/scala/typingsJapgolly/reactSelect/mod.scala
+++ b/tests/react-integration-test/check-japgolly/r/react-select/src/main/scala/typingsJapgolly/reactSelect/mod.scala
@@ -13,7 +13,6 @@ object mod {
   @js.native
   class default[TValue] () extends ReactSelectClass[TValue]
   
-  @js.native
   trait Option[TValue]
     extends StObject
        with /**
@@ -23,7 +22,7 @@ object mod {
   /* property */ StringDictionary[js.Any] {
     
     /** Value for searching */
-    var value: js.UndefOr[TValue] = js.native
+    var value: js.UndefOr[TValue] = js.undefined
   }
   object Option {
     
@@ -55,7 +54,6 @@ object mod {
     def setValue(value: Option[TValue]): Unit = js.native
   }
   
-  @js.native
   trait ReactSelectProps[TValue]
     extends StObject
        with Props[ReactSelectClass[TValue]] {
@@ -64,7 +62,7 @@ object mod {
       * text to display when `allowCreate` is true.
       * @default 'Add "{label}"?'
       */
-    var addLabelText: js.UndefOr[String] = js.native
+    var addLabelText: js.UndefOr[String] = js.undefined
   }
   object ReactSelectProps {
     

--- a/tests/react-integration-test/check-japgolly/r/react/build.sbt
+++ b/tests/react-integration-test/check-japgolly/r/react/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-d6e1e0"
+version := "16.9.2-242f5f"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-46b6e2",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7863fe",
   ("com.github.japgolly.scalajs-react" %%% "core" % "1.7.5").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/anon.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/anon.scala
@@ -13,10 +13,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait `0` extends StObject {
     
-    var defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any = js.native
+    var defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any
   }
   object `0` {
     
@@ -36,10 +35,9 @@ object anon {
     }
   }
   
-  @js.native
   trait `1` extends StObject {
     
-    var ref: js.UndefOr[Exclude[js.Any, String]] = js.native
+    var ref: js.UndefOr[Exclude[js.Any, String]] = js.undefined
   }
   object `1` {
     
@@ -60,10 +58,9 @@ object anon {
     }
   }
   
-  @js.native
   trait Children extends StObject {
     
-    var children: js.UndefOr[Node] = js.native
+    var children: js.UndefOr[Node] = js.undefined
   }
   object Children {
     
@@ -93,12 +90,11 @@ object anon {
     }
   }
   
-  @js.native
   trait DefaultProps extends StObject {
     
-    var defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any = js.native
+    var defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any
     
-    var propTypes: /* import warning: importer.ImportType#apply Failed type conversion: infer T */ js.Any = js.native
+    var propTypes: /* import warning: importer.ImportType#apply Failed type conversion: infer T */ js.Any
   }
   object DefaultProps {
     
@@ -122,10 +118,9 @@ object anon {
     }
   }
   
-  @js.native
   trait Html extends StObject {
     
-    var __html: String = js.native
+    var __html: String
   }
   object Html {
     
@@ -143,10 +138,9 @@ object anon {
     }
   }
   
-  @js.native
   trait PropTypes extends StObject {
     
-    var propTypes: /* import warning: importer.ImportType#apply Failed type conversion: infer T */ js.Any = js.native
+    var propTypes: /* import warning: importer.ImportType#apply Failed type conversion: infer T */ js.Any
   }
   object PropTypes {
     
@@ -164,12 +158,11 @@ object anon {
     }
   }
   
-  @js.native
   trait Ref extends StObject {
     
     var ref: js.UndefOr[
         /* import warning: importer.ImportType#apply Failed type conversion: infer R */ js.Any
-      ] = js.native
+      ] = js.undefined
   }
   object Ref {
     

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/AbstractView.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/AbstractView.scala
@@ -10,12 +10,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 // Browser Interfaces
 // https://github.com/nikeee/2048-typescript/blob/master/2048/js/touch.d.ts
 // ----------------------------------------------------------------------
-@js.native
 trait AbstractView extends StObject {
   
-  var document: Document = js.native
+  var document: Document
   
-  var styleMedia: StyleMedia = js.native
+  var styleMedia: StyleMedia
 }
 object AbstractView {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/AllHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/AllHTMLAttributes.scala
@@ -4,221 +4,220 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait AllHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var default: js.UndefOr[Boolean] = js.native
+  var default: js.UndefOr[Boolean] = js.undefined
   
   // Standard HTML Attributes
-  var accept: js.UndefOr[String] = js.native
+  var accept: js.UndefOr[String] = js.undefined
   
-  var acceptCharset: js.UndefOr[String] = js.native
+  var acceptCharset: js.UndefOr[String] = js.undefined
   
-  var action: js.UndefOr[String] = js.native
+  var action: js.UndefOr[String] = js.undefined
   
-  var allowFullScreen: js.UndefOr[Boolean] = js.native
+  var allowFullScreen: js.UndefOr[Boolean] = js.undefined
   
-  var allowTransparency: js.UndefOr[Boolean] = js.native
+  var allowTransparency: js.UndefOr[Boolean] = js.undefined
   
-  var alt: js.UndefOr[String] = js.native
+  var alt: js.UndefOr[String] = js.undefined
   
-  var as: js.UndefOr[String] = js.native
+  var as: js.UndefOr[String] = js.undefined
   
-  var async: js.UndefOr[Boolean] = js.native
+  var async: js.UndefOr[Boolean] = js.undefined
   
-  var autoComplete: js.UndefOr[String] = js.native
+  var autoComplete: js.UndefOr[String] = js.undefined
   
-  var autoFocus: js.UndefOr[Boolean] = js.native
+  var autoFocus: js.UndefOr[Boolean] = js.undefined
   
-  var autoPlay: js.UndefOr[Boolean] = js.native
+  var autoPlay: js.UndefOr[Boolean] = js.undefined
   
-  var capture: js.UndefOr[Boolean | String] = js.native
+  var capture: js.UndefOr[Boolean | String] = js.undefined
   
-  var cellPadding: js.UndefOr[Double | String] = js.native
+  var cellPadding: js.UndefOr[Double | String] = js.undefined
   
-  var cellSpacing: js.UndefOr[Double | String] = js.native
+  var cellSpacing: js.UndefOr[Double | String] = js.undefined
   
-  var challenge: js.UndefOr[String] = js.native
+  var challenge: js.UndefOr[String] = js.undefined
   
-  var charSet: js.UndefOr[String] = js.native
+  var charSet: js.UndefOr[String] = js.undefined
   
-  var checked: js.UndefOr[Boolean] = js.native
+  var checked: js.UndefOr[Boolean] = js.undefined
   
-  var cite: js.UndefOr[String] = js.native
+  var cite: js.UndefOr[String] = js.undefined
   
-  var classID: js.UndefOr[String] = js.native
+  var classID: js.UndefOr[String] = js.undefined
   
-  var colSpan: js.UndefOr[Double] = js.native
+  var colSpan: js.UndefOr[Double] = js.undefined
   
-  var cols: js.UndefOr[Double] = js.native
+  var cols: js.UndefOr[Double] = js.undefined
   
-  var content: js.UndefOr[String] = js.native
+  var content: js.UndefOr[String] = js.undefined
   
-  var controls: js.UndefOr[Boolean] = js.native
+  var controls: js.UndefOr[Boolean] = js.undefined
   
-  var coords: js.UndefOr[String] = js.native
+  var coords: js.UndefOr[String] = js.undefined
   
-  var crossOrigin: js.UndefOr[String] = js.native
+  var crossOrigin: js.UndefOr[String] = js.undefined
   
-  var data: js.UndefOr[String] = js.native
+  var data: js.UndefOr[String] = js.undefined
   
-  var dateTime: js.UndefOr[String] = js.native
+  var dateTime: js.UndefOr[String] = js.undefined
   
-  var defer: js.UndefOr[Boolean] = js.native
+  var defer: js.UndefOr[Boolean] = js.undefined
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var download: js.UndefOr[js.Any] = js.native
+  var download: js.UndefOr[js.Any] = js.undefined
   
-  var encType: js.UndefOr[String] = js.native
+  var encType: js.UndefOr[String] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var formAction: js.UndefOr[String] = js.native
+  var formAction: js.UndefOr[String] = js.undefined
   
-  var formEncType: js.UndefOr[String] = js.native
+  var formEncType: js.UndefOr[String] = js.undefined
   
-  var formMethod: js.UndefOr[String] = js.native
+  var formMethod: js.UndefOr[String] = js.undefined
   
-  var formNoValidate: js.UndefOr[Boolean] = js.native
+  var formNoValidate: js.UndefOr[Boolean] = js.undefined
   
-  var formTarget: js.UndefOr[String] = js.native
+  var formTarget: js.UndefOr[String] = js.undefined
   
-  var frameBorder: js.UndefOr[Double | String] = js.native
+  var frameBorder: js.UndefOr[Double | String] = js.undefined
   
-  var headers: js.UndefOr[String] = js.native
+  var headers: js.UndefOr[String] = js.undefined
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var high: js.UndefOr[Double] = js.native
+  var high: js.UndefOr[Double] = js.undefined
   
-  var href: js.UndefOr[String] = js.native
+  var href: js.UndefOr[String] = js.undefined
   
-  var hrefLang: js.UndefOr[String] = js.native
+  var hrefLang: js.UndefOr[String] = js.undefined
   
-  var htmlFor: js.UndefOr[String] = js.native
+  var htmlFor: js.UndefOr[String] = js.undefined
   
-  var httpEquiv: js.UndefOr[String] = js.native
+  var httpEquiv: js.UndefOr[String] = js.undefined
   
-  var integrity: js.UndefOr[String] = js.native
+  var integrity: js.UndefOr[String] = js.undefined
   
-  var keyParams: js.UndefOr[String] = js.native
+  var keyParams: js.UndefOr[String] = js.undefined
   
-  var keyType: js.UndefOr[String] = js.native
+  var keyType: js.UndefOr[String] = js.undefined
   
-  var kind: js.UndefOr[String] = js.native
+  var kind: js.UndefOr[String] = js.undefined
   
-  var label: js.UndefOr[String] = js.native
+  var label: js.UndefOr[String] = js.undefined
   
-  var list: js.UndefOr[String] = js.native
+  var list: js.UndefOr[String] = js.undefined
   
-  var loop: js.UndefOr[Boolean] = js.native
+  var loop: js.UndefOr[Boolean] = js.undefined
   
-  var low: js.UndefOr[Double] = js.native
+  var low: js.UndefOr[Double] = js.undefined
   
-  var manifest: js.UndefOr[String] = js.native
+  var manifest: js.UndefOr[String] = js.undefined
   
-  var marginHeight: js.UndefOr[Double] = js.native
+  var marginHeight: js.UndefOr[Double] = js.undefined
   
-  var marginWidth: js.UndefOr[Double] = js.native
+  var marginWidth: js.UndefOr[Double] = js.undefined
   
-  var max: js.UndefOr[Double | String] = js.native
+  var max: js.UndefOr[Double | String] = js.undefined
   
-  var maxLength: js.UndefOr[Double] = js.native
+  var maxLength: js.UndefOr[Double] = js.undefined
   
-  var media: js.UndefOr[String] = js.native
+  var media: js.UndefOr[String] = js.undefined
   
-  var mediaGroup: js.UndefOr[String] = js.native
+  var mediaGroup: js.UndefOr[String] = js.undefined
   
-  var method: js.UndefOr[String] = js.native
+  var method: js.UndefOr[String] = js.undefined
   
-  var min: js.UndefOr[Double | String] = js.native
+  var min: js.UndefOr[Double | String] = js.undefined
   
-  var minLength: js.UndefOr[Double] = js.native
+  var minLength: js.UndefOr[Double] = js.undefined
   
-  var multiple: js.UndefOr[Boolean] = js.native
+  var multiple: js.UndefOr[Boolean] = js.undefined
   
-  var muted: js.UndefOr[Boolean] = js.native
+  var muted: js.UndefOr[Boolean] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
-  var noValidate: js.UndefOr[Boolean] = js.native
+  var noValidate: js.UndefOr[Boolean] = js.undefined
   
-  var nonce: js.UndefOr[String] = js.native
+  var nonce: js.UndefOr[String] = js.undefined
   
-  var open: js.UndefOr[Boolean] = js.native
+  var open: js.UndefOr[Boolean] = js.undefined
   
-  var optimum: js.UndefOr[Double] = js.native
+  var optimum: js.UndefOr[Double] = js.undefined
   
-  var pattern: js.UndefOr[String] = js.native
+  var pattern: js.UndefOr[String] = js.undefined
   
-  var playsInline: js.UndefOr[Boolean] = js.native
+  var playsInline: js.UndefOr[Boolean] = js.undefined
   
-  var poster: js.UndefOr[String] = js.native
+  var poster: js.UndefOr[String] = js.undefined
   
-  var preload: js.UndefOr[String] = js.native
+  var preload: js.UndefOr[String] = js.undefined
   
-  var readOnly: js.UndefOr[Boolean] = js.native
+  var readOnly: js.UndefOr[Boolean] = js.undefined
   
-  var rel: js.UndefOr[String] = js.native
+  var rel: js.UndefOr[String] = js.undefined
   
-  var required: js.UndefOr[Boolean] = js.native
+  var required: js.UndefOr[Boolean] = js.undefined
   
-  var reversed: js.UndefOr[Boolean] = js.native
+  var reversed: js.UndefOr[Boolean] = js.undefined
   
-  var rowSpan: js.UndefOr[Double] = js.native
+  var rowSpan: js.UndefOr[Double] = js.undefined
   
-  var rows: js.UndefOr[Double] = js.native
+  var rows: js.UndefOr[Double] = js.undefined
   
-  var sandbox: js.UndefOr[String] = js.native
+  var sandbox: js.UndefOr[String] = js.undefined
   
-  var scope: js.UndefOr[String] = js.native
+  var scope: js.UndefOr[String] = js.undefined
   
-  var scoped: js.UndefOr[Boolean] = js.native
+  var scoped: js.UndefOr[Boolean] = js.undefined
   
-  var scrolling: js.UndefOr[String] = js.native
+  var scrolling: js.UndefOr[String] = js.undefined
   
-  var seamless: js.UndefOr[Boolean] = js.native
+  var seamless: js.UndefOr[Boolean] = js.undefined
   
-  var selected: js.UndefOr[Boolean] = js.native
+  var selected: js.UndefOr[Boolean] = js.undefined
   
-  var shape: js.UndefOr[String] = js.native
+  var shape: js.UndefOr[String] = js.undefined
   
-  var size: js.UndefOr[Double] = js.native
+  var size: js.UndefOr[Double] = js.undefined
   
-  var sizes: js.UndefOr[String] = js.native
+  var sizes: js.UndefOr[String] = js.undefined
   
-  var span: js.UndefOr[Double] = js.native
+  var span: js.UndefOr[Double] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var srcDoc: js.UndefOr[String] = js.native
+  var srcDoc: js.UndefOr[String] = js.undefined
   
-  var srcLang: js.UndefOr[String] = js.native
+  var srcLang: js.UndefOr[String] = js.undefined
   
-  var srcSet: js.UndefOr[String] = js.native
+  var srcSet: js.UndefOr[String] = js.undefined
   
-  var start: js.UndefOr[Double] = js.native
+  var start: js.UndefOr[Double] = js.undefined
   
-  var step: js.UndefOr[Double | String] = js.native
+  var step: js.UndefOr[Double | String] = js.undefined
   
-  var summary: js.UndefOr[String] = js.native
+  var summary: js.UndefOr[String] = js.undefined
   
-  var target: js.UndefOr[String] = js.native
+  var target: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
   
-  var useMap: js.UndefOr[String] = js.native
+  var useMap: js.UndefOr[String] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
   
-  var wmode: js.UndefOr[String] = js.native
+  var wmode: js.UndefOr[String] = js.undefined
   
-  var wrap: js.UndefOr[String] = js.native
+  var wrap: js.UndefOr[String] = js.undefined
 }
 object AllHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/AnchorHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/AnchorHTMLAttributes.scala
@@ -4,28 +4,27 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait AnchorHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var download: js.UndefOr[js.Any] = js.native
+  var download: js.UndefOr[js.Any] = js.undefined
   
-  var href: js.UndefOr[String] = js.native
+  var href: js.UndefOr[String] = js.undefined
   
-  var hrefLang: js.UndefOr[String] = js.native
+  var hrefLang: js.UndefOr[String] = js.undefined
   
-  var media: js.UndefOr[String] = js.native
+  var media: js.UndefOr[String] = js.undefined
   
-  var ping: js.UndefOr[String] = js.native
+  var ping: js.UndefOr[String] = js.undefined
   
-  var referrerPolicy: js.UndefOr[String] = js.native
+  var referrerPolicy: js.UndefOr[String] = js.undefined
   
-  var rel: js.UndefOr[String] = js.native
+  var rel: js.UndefOr[String] = js.undefined
   
-  var target: js.UndefOr[String] = js.native
+  var target: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
 }
 object AnchorHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/AnimationEvent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/AnimationEvent.scala
@@ -7,16 +7,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait AnimationEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeAnimationEvent, EventTarget & T, EventTarget] {
   
-  var animationName: String = js.native
+  var animationName: String
   
-  var elapsedTime: Double = js.native
+  var elapsedTime: Double
   
-  var pseudoElement: String = js.native
+  var pseudoElement: String
 }
 object AnimationEvent {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/AreaHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/AreaHTMLAttributes.scala
@@ -4,28 +4,27 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait AreaHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var alt: js.UndefOr[String] = js.native
+  var alt: js.UndefOr[String] = js.undefined
   
-  var coords: js.UndefOr[String] = js.native
+  var coords: js.UndefOr[String] = js.undefined
   
-  var download: js.UndefOr[js.Any] = js.native
+  var download: js.UndefOr[js.Any] = js.undefined
   
-  var href: js.UndefOr[String] = js.native
+  var href: js.UndefOr[String] = js.undefined
   
-  var hrefLang: js.UndefOr[String] = js.native
+  var hrefLang: js.UndefOr[String] = js.undefined
   
-  var media: js.UndefOr[String] = js.native
+  var media: js.UndefOr[String] = js.undefined
   
-  var rel: js.UndefOr[String] = js.native
+  var rel: js.UndefOr[String] = js.undefined
   
-  var shape: js.UndefOr[String] = js.native
+  var shape: js.UndefOr[String] = js.undefined
   
-  var target: js.UndefOr[String] = js.native
+  var target: js.UndefOr[String] = js.undefined
 }
 object AreaHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/AriaAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/AriaAttributes.scala
@@ -40,240 +40,239 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
-@js.native
 trait AriaAttributes extends StObject {
   
   /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
-  var `aria-activedescendant`: js.UndefOr[String] = js.native
+  var `aria-activedescendant`: js.UndefOr[String] = js.undefined
   
   /** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */
-  var `aria-atomic`: js.UndefOr[Boolean] = js.native
+  var `aria-atomic`: js.UndefOr[Boolean] = js.undefined
   
   /**
     * Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
     * presented if they are made.
     */
-  var `aria-autocomplete`: js.UndefOr[none | `inline` | list | both] = js.native
+  var `aria-autocomplete`: js.UndefOr[none | `inline` | list | both] = js.undefined
   
   /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
-  var `aria-busy`: js.UndefOr[Boolean] = js.native
+  var `aria-busy`: js.UndefOr[Boolean] = js.undefined
   
   /**
     * Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
     * @see aria-pressed @see aria-selected.
     */
-  var `aria-checked`: js.UndefOr[Boolean | mixed] = js.native
+  var `aria-checked`: js.UndefOr[Boolean | mixed] = js.undefined
   
   /**
     * Defines the total number of columns in a table, grid, or treegrid.
     * @see aria-colindex.
     */
-  var `aria-colcount`: js.UndefOr[Double] = js.native
+  var `aria-colcount`: js.UndefOr[Double] = js.undefined
   
   /**
     * Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
     * @see aria-colcount @see aria-colspan.
     */
-  var `aria-colindex`: js.UndefOr[Double] = js.native
+  var `aria-colindex`: js.UndefOr[Double] = js.undefined
   
   /**
     * Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
     * @see aria-colindex @see aria-rowspan.
     */
-  var `aria-colspan`: js.UndefOr[Double] = js.native
+  var `aria-colspan`: js.UndefOr[Double] = js.undefined
   
   /**
     * Identifies the element (or elements) whose contents or presence are controlled by the current element.
     * @see aria-owns.
     */
-  var `aria-controls`: js.UndefOr[String] = js.native
+  var `aria-controls`: js.UndefOr[String] = js.undefined
   
   /** Indicates the element that represents the current item within a container or set of related elements. */
-  var `aria-current`: js.UndefOr[Boolean | page | step | location | date | time] = js.native
+  var `aria-current`: js.UndefOr[Boolean | page | step | location | date | time] = js.undefined
   
   /**
     * Identifies the element (or elements) that describes the object.
     * @see aria-labelledby
     */
-  var `aria-describedby`: js.UndefOr[String] = js.native
+  var `aria-describedby`: js.UndefOr[String] = js.undefined
   
   /**
     * Identifies the element that provides a detailed, extended description for the object.
     * @see aria-describedby.
     */
-  var `aria-details`: js.UndefOr[String] = js.native
+  var `aria-details`: js.UndefOr[String] = js.undefined
   
   /**
     * Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
     * @see aria-hidden @see aria-readonly.
     */
-  var `aria-disabled`: js.UndefOr[Boolean] = js.native
+  var `aria-disabled`: js.UndefOr[Boolean] = js.undefined
   
   /**
     * Indicates what functions can be performed when a dragged object is released on the drop target.
     * @deprecated in ARIA 1.1
     */
-  var `aria-dropeffect`: js.UndefOr[none | copy | execute | link | move | popup] = js.native
+  var `aria-dropeffect`: js.UndefOr[none | copy | execute | link | move | popup] = js.undefined
   
   /**
     * Identifies the element that provides an error message for the object.
     * @see aria-invalid @see aria-describedby.
     */
-  var `aria-errormessage`: js.UndefOr[String] = js.native
+  var `aria-errormessage`: js.UndefOr[String] = js.undefined
   
   /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
-  var `aria-expanded`: js.UndefOr[Boolean] = js.native
+  var `aria-expanded`: js.UndefOr[Boolean] = js.undefined
   
   /**
     * Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
     * allows assistive technology to override the general default of reading in document source order.
     */
-  var `aria-flowto`: js.UndefOr[String] = js.native
+  var `aria-flowto`: js.UndefOr[String] = js.undefined
   
   /**
     * Indicates an element's "grabbed" state in a drag-and-drop operation.
     * @deprecated in ARIA 1.1
     */
-  var `aria-grabbed`: js.UndefOr[Boolean] = js.native
+  var `aria-grabbed`: js.UndefOr[Boolean] = js.undefined
   
   /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
-  var `aria-haspopup`: js.UndefOr[Boolean | menu | listbox | tree | grid | dialog] = js.native
+  var `aria-haspopup`: js.UndefOr[Boolean | menu | listbox | tree | grid | dialog] = js.undefined
   
   /**
     * Indicates whether the element is exposed to an accessibility API.
     * @see aria-disabled.
     */
-  var `aria-hidden`: js.UndefOr[Boolean] = js.native
+  var `aria-hidden`: js.UndefOr[Boolean] = js.undefined
   
   /**
     * Indicates the entered value does not conform to the format expected by the application.
     * @see aria-errormessage.
     */
-  var `aria-invalid`: js.UndefOr[Boolean | grammar | spelling] = js.native
+  var `aria-invalid`: js.UndefOr[Boolean | grammar | spelling] = js.undefined
   
   /** Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. */
-  var `aria-keyshortcuts`: js.UndefOr[String] = js.native
+  var `aria-keyshortcuts`: js.UndefOr[String] = js.undefined
   
   /**
     * Defines a string value that labels the current element.
     * @see aria-labelledby.
     */
-  var `aria-label`: js.UndefOr[String] = js.native
+  var `aria-label`: js.UndefOr[String] = js.undefined
   
   /**
     * Identifies the element (or elements) that labels the current element.
     * @see aria-describedby.
     */
-  var `aria-labelledby`: js.UndefOr[String] = js.native
+  var `aria-labelledby`: js.UndefOr[String] = js.undefined
   
   /** Defines the hierarchical level of an element within a structure. */
-  var `aria-level`: js.UndefOr[Double] = js.native
+  var `aria-level`: js.UndefOr[Double] = js.undefined
   
   /** Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. */
-  var `aria-live`: js.UndefOr[off | assertive | polite] = js.native
+  var `aria-live`: js.UndefOr[off | assertive | polite] = js.undefined
   
   /** Indicates whether an element is modal when displayed. */
-  var `aria-modal`: js.UndefOr[Boolean] = js.native
+  var `aria-modal`: js.UndefOr[Boolean] = js.undefined
   
   /** Indicates whether a text box accepts multiple lines of input or only a single line. */
-  var `aria-multiline`: js.UndefOr[Boolean] = js.native
+  var `aria-multiline`: js.UndefOr[Boolean] = js.undefined
   
   /** Indicates that the user may select more than one item from the current selectable descendants. */
-  var `aria-multiselectable`: js.UndefOr[Boolean] = js.native
+  var `aria-multiselectable`: js.UndefOr[Boolean] = js.undefined
   
   /** Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. */
-  var `aria-orientation`: js.UndefOr[horizontal | vertical] = js.native
+  var `aria-orientation`: js.UndefOr[horizontal | vertical] = js.undefined
   
   /**
     * Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
     * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
     * @see aria-controls.
     */
-  var `aria-owns`: js.UndefOr[String] = js.native
+  var `aria-owns`: js.UndefOr[String] = js.undefined
   
   /**
     * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
     * A hint could be a sample value or a brief description of the expected format.
     */
-  var `aria-placeholder`: js.UndefOr[String] = js.native
+  var `aria-placeholder`: js.UndefOr[String] = js.undefined
   
   /**
     * Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
     * @see aria-setsize.
     */
-  var `aria-posinset`: js.UndefOr[Double] = js.native
+  var `aria-posinset`: js.UndefOr[Double] = js.undefined
   
   /**
     * Indicates the current "pressed" state of toggle buttons.
     * @see aria-checked @see aria-selected.
     */
-  var `aria-pressed`: js.UndefOr[Boolean | mixed] = js.native
+  var `aria-pressed`: js.UndefOr[Boolean | mixed] = js.undefined
   
   /**
     * Indicates that the element is not editable, but is otherwise operable.
     * @see aria-disabled.
     */
-  var `aria-readonly`: js.UndefOr[Boolean] = js.native
+  var `aria-readonly`: js.UndefOr[Boolean] = js.undefined
   
   /**
     * Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
     * @see aria-atomic.
     */
-  var `aria-relevant`: js.UndefOr[additions | (`additions text`) | all | removals | text] = js.native
+  var `aria-relevant`: js.UndefOr[additions | (`additions text`) | all | removals | text] = js.undefined
   
   /** Indicates that user input is required on the element before a form may be submitted. */
-  var `aria-required`: js.UndefOr[Boolean] = js.native
+  var `aria-required`: js.UndefOr[Boolean] = js.undefined
   
   /** Defines a human-readable, author-localized description for the role of an element. */
-  var `aria-roledescription`: js.UndefOr[String] = js.native
+  var `aria-roledescription`: js.UndefOr[String] = js.undefined
   
   /**
     * Defines the total number of rows in a table, grid, or treegrid.
     * @see aria-rowindex.
     */
-  var `aria-rowcount`: js.UndefOr[Double] = js.native
+  var `aria-rowcount`: js.UndefOr[Double] = js.undefined
   
   /**
     * Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
     * @see aria-rowcount @see aria-rowspan.
     */
-  var `aria-rowindex`: js.UndefOr[Double] = js.native
+  var `aria-rowindex`: js.UndefOr[Double] = js.undefined
   
   /**
     * Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
     * @see aria-rowindex @see aria-colspan.
     */
-  var `aria-rowspan`: js.UndefOr[Double] = js.native
+  var `aria-rowspan`: js.UndefOr[Double] = js.undefined
   
   /**
     * Indicates the current "selected" state of various widgets.
     * @see aria-checked @see aria-pressed.
     */
-  var `aria-selected`: js.UndefOr[Boolean] = js.native
+  var `aria-selected`: js.UndefOr[Boolean] = js.undefined
   
   /**
     * Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
     * @see aria-posinset.
     */
-  var `aria-setsize`: js.UndefOr[Double] = js.native
+  var `aria-setsize`: js.UndefOr[Double] = js.undefined
   
   /** Indicates if items in a table or grid are sorted in ascending or descending order. */
-  var `aria-sort`: js.UndefOr[none | ascending | descending | other] = js.native
+  var `aria-sort`: js.UndefOr[none | ascending | descending | other] = js.undefined
   
   /** Defines the maximum allowed value for a range widget. */
-  var `aria-valuemax`: js.UndefOr[Double] = js.native
+  var `aria-valuemax`: js.UndefOr[Double] = js.undefined
   
   /** Defines the minimum allowed value for a range widget. */
-  var `aria-valuemin`: js.UndefOr[Double] = js.native
+  var `aria-valuemin`: js.UndefOr[Double] = js.undefined
   
   /**
     * Defines the current value for a range widget.
     * @see aria-valuetext.
     */
-  var `aria-valuenow`: js.UndefOr[Double] = js.native
+  var `aria-valuenow`: js.UndefOr[Double] = js.undefined
   
   /** Defines the human readable text alternative of aria-valuenow for a range widget. */
-  var `aria-valuetext`: js.UndefOr[String] = js.native
+  var `aria-valuetext`: js.UndefOr[String] = js.undefined
 }
 object AriaAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/Attributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/Attributes.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Attributes extends StObject {
   
-  var key: js.UndefOr[Key] = js.native
+  var key: js.UndefOr[Key] = js.undefined
 }
 object Attributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/BaseHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/BaseHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait BaseHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var href: js.UndefOr[String] = js.native
+  var href: js.UndefOr[String] = js.undefined
   
-  var target: js.UndefOr[String] = js.native
+  var target: js.UndefOr[String] = js.undefined
 }
 object BaseHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/BaseSyntheticEvent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/BaseSyntheticEvent.scala
@@ -10,38 +10,37 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 // Event System
 // ----------------------------------------------------------------------
 // TODO: change any to unknown when moving to TS v3
-@js.native
 trait BaseSyntheticEvent[E, C, T] extends StObject {
   
-  var bubbles: Boolean = js.native
+  var bubbles: Boolean
   
-  var cancelable: Boolean = js.native
+  var cancelable: Boolean
   
-  var currentTarget: C = js.native
+  var currentTarget: C
   
-  var defaultPrevented: Boolean = js.native
+  var defaultPrevented: Boolean
   
-  var eventPhase: Double = js.native
+  var eventPhase: Double
   
-  def isDefaultPrevented(): Boolean = js.native
+  def isDefaultPrevented(): Boolean
   
-  def isPropagationStopped(): Boolean = js.native
+  def isPropagationStopped(): Boolean
   
-  var isTrusted: Boolean = js.native
+  var isTrusted: Boolean
   
-  var nativeEvent: E = js.native
+  var nativeEvent: E
   
-  def persist(): Unit = js.native
+  def persist(): Unit
   
-  def preventDefault(): Unit = js.native
+  def preventDefault(): Unit
   
-  def stopPropagation(): Unit = js.native
+  def stopPropagation(): Unit
   
-  var target: T = js.native
+  var target: T
   
-  var timeStamp: Double = js.native
+  var timeStamp: Double
   
-  var `type`: String = js.native
+  var `type`: String
 }
 object BaseSyntheticEvent {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/BlockquoteHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/BlockquoteHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait BlockquoteHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var cite: js.UndefOr[String] = js.native
+  var cite: js.UndefOr[String] = js.undefined
 }
 object BlockquoteHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ButtonHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ButtonHTMLAttributes.scala
@@ -7,32 +7,31 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ButtonHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var autoFocus: js.UndefOr[Boolean] = js.native
+  var autoFocus: js.UndefOr[Boolean] = js.undefined
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var formAction: js.UndefOr[String] = js.native
+  var formAction: js.UndefOr[String] = js.undefined
   
-  var formEncType: js.UndefOr[String] = js.native
+  var formEncType: js.UndefOr[String] = js.undefined
   
-  var formMethod: js.UndefOr[String] = js.native
+  var formMethod: js.UndefOr[String] = js.undefined
   
-  var formNoValidate: js.UndefOr[Boolean] = js.native
+  var formNoValidate: js.UndefOr[Boolean] = js.undefined
   
-  var formTarget: js.UndefOr[String] = js.native
+  var formTarget: js.UndefOr[String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[submit | reset | button] = js.native
+  var `type`: js.UndefOr[submit | reset | button] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object ButtonHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/CSSProperties.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/CSSProperties.scala
@@ -5,11 +5,10 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* import warning: RemoveDifficultInheritance.summarizeChanges 
-- Dropped / * import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify CSS.Properties<string | number> * / any */ @js.native
-trait CSSProperties extends StObject {
+- Dropped / * import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify CSS.Properties<string | number> * / any */ trait CSSProperties extends StObject {
   
   /* fake member to keep old syntax */
-  val hack: js.UndefOr[js.Any] = js.native
+  val hack: js.UndefOr[js.Any] = js.undefined
 }
 object CSSProperties {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/CanvasHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/CanvasHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait CanvasHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
 }
 object CanvasHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ChangeEvent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ChangeEvent.scala
@@ -8,13 +8,12 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ChangeEvent[T]
   extends StObject
      with BaseSyntheticEvent[Event, EventTarget & T, EventTarget] {
   
   @JSName("target")
-  var target_ChangeEvent: EventTarget & T = js.native
+  var target_ChangeEvent: EventTarget & T
 }
 object ChangeEvent {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ChildContextProvider.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ChildContextProvider.scala
@@ -5,10 +5,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ChildContextProvider[CC] extends StObject {
   
-  def getChildContext(): CC = js.native
+  def getChildContext(): CC
 }
 object ChildContextProvider {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ClassAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ClassAttributes.scala
@@ -5,12 +5,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ClassAttributes[T]
   extends StObject
      with Attributes {
   
-  var ref: js.UndefOr[LegacyRef[T]] = js.native
+  var ref: js.UndefOr[LegacyRef[T]] = js.undefined
 }
 object ClassAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ClipboardEvent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ClipboardEvent.scala
@@ -8,12 +8,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ClipboardEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeClipboardEvent, EventTarget & T, EventTarget] {
   
-  var clipboardData: DataTransfer = js.native
+  var clipboardData: DataTransfer
 }
 object ClipboardEvent {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ColHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ColHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ColHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var span: js.UndefOr[Double] = js.native
+  var span: js.UndefOr[Double] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
 }
 object ColHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ColgroupHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ColgroupHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ColgroupHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var span: js.UndefOr[Double] = js.native
+  var span: js.UndefOr[Double] = js.undefined
 }
 object ColgroupHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ComponentElement.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ComponentElement.scala
@@ -5,12 +5,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ComponentElement[P, T /* <: japgolly.scalajs.react.raw.React.Component[P & js.Object, js.Object] */]
   extends StObject
      with ReactElement {
   
-  var ref: js.UndefOr[LegacyRef[T]] = js.native
+  var ref: js.UndefOr[LegacyRef[T]] = js.undefined
 }
 object ComponentElement {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ComponentLifecycle.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ComponentLifecycle.scala
@@ -11,7 +11,6 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 // This should actually be something like `Lifecycle<P, S> | DeprecatedLifecycle<P, S>`,
 // as React will _not_ call the deprecated lifecycle methods if any of the new lifecycle
 // methods are present.
-@js.native
 trait ComponentLifecycle[P, S, SS]
   extends StObject
      with NewLifecycle[P, S, SS]
@@ -27,18 +26,18 @@ trait ComponentLifecycle[P, S, SS]
       /* errorInfo */ ErrorInfo, 
       Unit
     ]
-  ] = js.native
+  ] = js.undefined
   
   /**
     * Called immediately after a component is mounted. Setting state here will trigger re-rendering.
     */
-  var componentDidMount: js.UndefOr[js.Function0[Unit]] = js.native
+  var componentDidMount: js.UndefOr[js.Function0[Unit]] = js.undefined
   
   /**
     * Called immediately before a component is destroyed. Perform any necessary cleanup in this method, such as
     * cancelled network requests, or cleaning up any DOM elements created in `componentDidMount`.
     */
-  var componentWillUnmount: js.UndefOr[js.Function0[Unit]] = js.native
+  var componentWillUnmount: js.UndefOr[js.Function0[Unit]] = js.undefined
   
   /**
     * Called to determine whether the change in props and state should trigger a re-render.
@@ -52,7 +51,7 @@ trait ComponentLifecycle[P, S, SS]
     */
   var shouldComponentUpdate: js.UndefOr[
     js.Function3[/* nextProps */ P, /* nextState */ S, /* nextContext */ js.Any, Boolean]
-  ] = js.native
+  ] = js.undefined
 }
 object ComponentLifecycle {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ComponentSpec.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ComponentSpec.scala
@@ -7,13 +7,12 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ComponentSpec[P, S]
   extends StObject
      with Mixin[P, S]
      with /* propertyName */ StringDictionary[js.Any] {
   
-  def render(): Node = js.native
+  def render(): Node
 }
 object ComponentSpec {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/CompositionEvent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/CompositionEvent.scala
@@ -7,12 +7,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait CompositionEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeCompositionEvent, EventTarget & T, EventTarget] {
   
-  var data: String = js.native
+  var data: String
 }
 object CompositionEvent {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ConsumerProps.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ConsumerProps.scala
@@ -5,12 +5,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ConsumerProps[T] extends StObject {
   
-  def children(value: T): Node = js.native
+  def children(value: T): Node
   
-  var unstable_observedBits: js.UndefOr[Double] = js.native
+  var unstable_observedBits: js.UndefOr[Double] = js.undefined
 }
 object ConsumerProps {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/Context.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/Context.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Context[T] extends StObject {
   
-  var Consumer: typingsJapgolly.react.mod.Consumer[T] = js.native
+  var Consumer: typingsJapgolly.react.mod.Consumer[T]
   
-  var Provider: typingsJapgolly.react.mod.Provider[T] = js.native
+  var Provider: typingsJapgolly.react.mod.Provider[T]
   
-  var displayName: js.UndefOr[String] = js.native
+  var displayName: js.UndefOr[String] = js.undefined
 }
 object Context {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DOMAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DOMAttributes.scala
@@ -25,186 +25,185 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DOMAttributes[T] extends StObject {
   
-  var children: js.UndefOr[Node] = js.native
+  var children: js.UndefOr[Node] = js.undefined
   
-  var dangerouslySetInnerHTML: js.UndefOr[Html] = js.native
+  var dangerouslySetInnerHTML: js.UndefOr[Html] = js.undefined
   
   // Media Events
-  var onAbort: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onAbort: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onAnimationEnd: js.UndefOr[AnimationEventHandler[T]] = js.native
+  var onAnimationEnd: js.UndefOr[AnimationEventHandler[T]] = js.undefined
   
-  var onAnimationIteration: js.UndefOr[AnimationEventHandler[T]] = js.native
+  var onAnimationIteration: js.UndefOr[AnimationEventHandler[T]] = js.undefined
   
   // Animation Events
-  var onAnimationStart: js.UndefOr[AnimationEventHandler[T]] = js.native
+  var onAnimationStart: js.UndefOr[AnimationEventHandler[T]] = js.undefined
   
   // MouseEvents
-  var onAuxClick: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onAuxClick: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onBeforeInput: js.UndefOr[FormEventHandler[T]] = js.native
+  var onBeforeInput: js.UndefOr[FormEventHandler[T]] = js.undefined
   
-  var onBlur: js.UndefOr[FocusEventHandler[T]] = js.native
+  var onBlur: js.UndefOr[FocusEventHandler[T]] = js.undefined
   
-  var onCanPlay: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onCanPlay: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onCanPlayThrough: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onCanPlayThrough: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
   // Form Events
-  var onChange: js.UndefOr[FormEventHandler[T]] = js.native
+  var onChange: js.UndefOr[FormEventHandler[T]] = js.undefined
   
-  var onClick: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onClick: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
   // Composition Events
-  var onCompositionEnd: js.UndefOr[CompositionEventHandler[T]] = js.native
+  var onCompositionEnd: js.UndefOr[CompositionEventHandler[T]] = js.undefined
   
-  var onCompositionStart: js.UndefOr[CompositionEventHandler[T]] = js.native
+  var onCompositionStart: js.UndefOr[CompositionEventHandler[T]] = js.undefined
   
-  var onCompositionUpdate: js.UndefOr[CompositionEventHandler[T]] = js.native
+  var onCompositionUpdate: js.UndefOr[CompositionEventHandler[T]] = js.undefined
   
-  var onContextMenu: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onContextMenu: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
   // Clipboard Events
-  var onCopy: js.UndefOr[ClipboardEventHandler[T]] = js.native
+  var onCopy: js.UndefOr[ClipboardEventHandler[T]] = js.undefined
   
-  var onCut: js.UndefOr[ClipboardEventHandler[T]] = js.native
+  var onCut: js.UndefOr[ClipboardEventHandler[T]] = js.undefined
   
-  var onDoubleClick: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onDoubleClick: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onDrag: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDrag: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDragEnd: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDragEnd: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDragEnter: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDragEnter: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDragExit: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDragExit: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDragLeave: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDragLeave: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDragOver: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDragOver: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDragStart: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDragStart: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDrop: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDrop: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDurationChange: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onDurationChange: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onEmptied: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onEmptied: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onEncrypted: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onEncrypted: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onEnded: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onEnded: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onError: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onError: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
   // Focus Events
-  var onFocus: js.UndefOr[FocusEventHandler[T]] = js.native
+  var onFocus: js.UndefOr[FocusEventHandler[T]] = js.undefined
   
-  var onInput: js.UndefOr[FormEventHandler[T]] = js.native
+  var onInput: js.UndefOr[FormEventHandler[T]] = js.undefined
   
-  var onInvalid: js.UndefOr[FormEventHandler[T]] = js.native
+  var onInvalid: js.UndefOr[FormEventHandler[T]] = js.undefined
   
   // also a Media Event
   // Keyboard Events
-  var onKeyDown: js.UndefOr[KeyboardEventHandler[T]] = js.native
+  var onKeyDown: js.UndefOr[KeyboardEventHandler[T]] = js.undefined
   
-  var onKeyPress: js.UndefOr[KeyboardEventHandler[T]] = js.native
+  var onKeyPress: js.UndefOr[KeyboardEventHandler[T]] = js.undefined
   
-  var onKeyUp: js.UndefOr[KeyboardEventHandler[T]] = js.native
+  var onKeyUp: js.UndefOr[KeyboardEventHandler[T]] = js.undefined
   
   // Image Events
-  var onLoad: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onLoad: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onLoadStart: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onLoadStart: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onLoadedData: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onLoadedData: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onLoadedMetadata: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onLoadedMetadata: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onMouseDown: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onMouseDown: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onMouseEnter: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onMouseEnter: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onMouseLeave: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onMouseLeave: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onMouseMove: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onMouseMove: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onMouseOut: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onMouseOut: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onMouseOver: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onMouseOver: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onMouseUp: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onMouseUp: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onPaste: js.UndefOr[ClipboardEventHandler[T]] = js.native
+  var onPaste: js.UndefOr[ClipboardEventHandler[T]] = js.undefined
   
-  var onPause: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onPause: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onPlay: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onPlay: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onPlaying: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onPlaying: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onPointerCancel: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerCancel: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
   // Pointer Events
-  var onPointerDown: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerDown: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
-  var onPointerEnter: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerEnter: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
-  var onPointerLeave: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerLeave: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
-  var onPointerMove: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerMove: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
-  var onPointerOut: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerOut: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
-  var onPointerOver: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerOver: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
-  var onPointerUp: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerUp: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
-  var onProgress: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onProgress: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onRateChange: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onRateChange: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onReset: js.UndefOr[FormEventHandler[T]] = js.native
+  var onReset: js.UndefOr[FormEventHandler[T]] = js.undefined
   
   // UI Events
-  var onScroll: js.UndefOr[UIEventHandler[T]] = js.native
+  var onScroll: js.UndefOr[UIEventHandler[T]] = js.undefined
   
-  var onSeeked: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onSeeked: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onSeeking: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onSeeking: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
   // Selection Events
-  var onSelect: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onSelect: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onStalled: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onStalled: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onSubmit: js.UndefOr[FormEventHandler[T]] = js.native
+  var onSubmit: js.UndefOr[FormEventHandler[T]] = js.undefined
   
-  var onSuspend: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onSuspend: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onTimeUpdate: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onTimeUpdate: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
   // Touch Events
-  var onTouchCancel: js.UndefOr[TouchEventHandler[T]] = js.native
+  var onTouchCancel: js.UndefOr[TouchEventHandler[T]] = js.undefined
   
-  var onTouchEnd: js.UndefOr[TouchEventHandler[T]] = js.native
+  var onTouchEnd: js.UndefOr[TouchEventHandler[T]] = js.undefined
   
-  var onTouchMove: js.UndefOr[TouchEventHandler[T]] = js.native
+  var onTouchMove: js.UndefOr[TouchEventHandler[T]] = js.undefined
   
-  var onTouchStart: js.UndefOr[TouchEventHandler[T]] = js.native
+  var onTouchStart: js.UndefOr[TouchEventHandler[T]] = js.undefined
   
   // Transition Events
-  var onTransitionEnd: js.UndefOr[TransitionEventHandler[T]] = js.native
+  var onTransitionEnd: js.UndefOr[TransitionEventHandler[T]] = js.undefined
   
-  var onVolumeChange: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onVolumeChange: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onWaiting: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onWaiting: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
   // Wheel Events
-  var onWheel: js.UndefOr[WheelEventHandler[T]] = js.native
+  var onWheel: js.UndefOr[WheelEventHandler[T]] = js.undefined
 }
 object DOMAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DOMElement.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DOMElement.scala
@@ -7,12 +7,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 // string fallback for custom web-components
-@js.native
 trait DOMElement[P /* <: HTMLAttributes[T] | SVGAttributes[T] */, T /* <: Element */]
   extends StObject
      with ReactElement {
   
-  var ref: LegacyRef[T] = js.native
+  var ref: LegacyRef[T]
 }
 object DOMElement {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DataHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DataHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DataHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object DataHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DelHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DelHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DelHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var cite: js.UndefOr[String] = js.native
+  var cite: js.UndefOr[String] = js.undefined
   
-  var dateTime: js.UndefOr[String] = js.native
+  var dateTime: js.UndefOr[String] = js.undefined
 }
 object DelHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DeprecatedLifecycle.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DeprecatedLifecycle.scala
@@ -5,7 +5,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DeprecatedLifecycle[P, S] extends StObject {
   
   /**
@@ -21,7 +20,7 @@ trait DeprecatedLifecycle[P, S] extends StObject {
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
     */
-  var UNSAFE_componentWillMount: js.UndefOr[js.Function0[Unit]] = js.native
+  var UNSAFE_componentWillMount: js.UndefOr[js.Function0[Unit]] = js.undefined
   
   /**
     * Called when the component may be receiving new props.
@@ -39,7 +38,7 @@ trait DeprecatedLifecycle[P, S] extends StObject {
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
     */
-  var UNSAFE_componentWillReceiveProps: js.UndefOr[js.Function2[/* nextProps */ P, /* nextContext */ js.Any, Unit]] = js.native
+  var UNSAFE_componentWillReceiveProps: js.UndefOr[js.Function2[/* nextProps */ P, /* nextContext */ js.Any, Unit]] = js.undefined
   
   /**
     * Called immediately before rendering when new props or state is received. Not called for the initial render.
@@ -57,7 +56,7 @@ trait DeprecatedLifecycle[P, S] extends StObject {
     */
   var UNSAFE_componentWillUpdate: js.UndefOr[
     js.Function3[/* nextProps */ P, /* nextState */ S, /* nextContext */ js.Any, Unit]
-  ] = js.native
+  ] = js.undefined
   
   /**
     * Called immediately before mounting occurs, and before `Component#render`.
@@ -70,7 +69,7 @@ trait DeprecatedLifecycle[P, S] extends StObject {
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
     */
-  var componentWillMount: js.UndefOr[js.Function0[Unit]] = js.native
+  var componentWillMount: js.UndefOr[js.Function0[Unit]] = js.undefined
   
   /**
     * Called when the component may be receiving new props.
@@ -86,7 +85,7 @@ trait DeprecatedLifecycle[P, S] extends StObject {
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
     */
-  var componentWillReceiveProps: js.UndefOr[js.Function2[/* nextProps */ P, /* nextContext */ js.Any, Unit]] = js.native
+  var componentWillReceiveProps: js.UndefOr[js.Function2[/* nextProps */ P, /* nextContext */ js.Any, Unit]] = js.undefined
   
   /**
     * Called immediately before rendering when new props or state is received. Not called for the initial render.
@@ -102,7 +101,7 @@ trait DeprecatedLifecycle[P, S] extends StObject {
     */
   var componentWillUpdate: js.UndefOr[
     js.Function3[/* nextProps */ P, /* nextState */ S, /* nextContext */ js.Any, Unit]
-  ] = js.native
+  ] = js.undefined
 }
 object DeprecatedLifecycle {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DetailedReactHTMLElement.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DetailedReactHTMLElement.scala
@@ -5,7 +5,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DetailedReactHTMLElement[P /* <: HTMLAttributes[T] */, T /* <: HTMLElement */]
   extends StObject
      with DOMElement[P, T]

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DetailsHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DetailsHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DetailsHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var open: js.UndefOr[Boolean] = js.native
+  var open: js.UndefOr[Boolean] = js.undefined
 }
 object DetailsHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DialogHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DialogHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DialogHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var open: js.UndefOr[Boolean] = js.native
+  var open: js.UndefOr[Boolean] = js.undefined
 }
 object DialogHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DragEvent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/DragEvent.scala
@@ -8,12 +8,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DragEvent[T]
   extends StObject
      with MouseEvent[T, NativeDragEvent] {
   
-  var dataTransfer: DataTransfer = js.native
+  var dataTransfer: DataTransfer
 }
 object DragEvent {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/EmbedHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/EmbedHTMLAttributes.scala
@@ -4,18 +4,17 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait EmbedHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
 }
 object EmbedHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ErrorInfo.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ErrorInfo.scala
@@ -7,13 +7,12 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 //
 // Error Interfaces
 // ----------------------------------------------------------------------
-@js.native
 trait ErrorInfo extends StObject {
   
   /**
     * Captures which component contained the exception, and its ancestors.
     */
-  var componentStack: String = js.native
+  var componentStack: String
 }
 object ErrorInfo {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/FieldsetHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/FieldsetHTMLAttributes.scala
@@ -4,16 +4,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait FieldsetHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
 }
 object FieldsetHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/FocusEvent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/FocusEvent.scala
@@ -7,15 +7,14 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait FocusEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeFocusEvent, EventTarget & T, EventTarget] {
   
-  var relatedTarget: EventTarget = js.native
+  var relatedTarget: EventTarget
   
   @JSName("target")
-  var target_FocusEvent: EventTarget & T = js.native
+  var target_FocusEvent: EventTarget & T
 }
 object FocusEvent {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/FormHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/FormHTMLAttributes.scala
@@ -4,26 +4,25 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait FormHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var acceptCharset: js.UndefOr[String] = js.native
+  var acceptCharset: js.UndefOr[String] = js.undefined
   
-  var action: js.UndefOr[String] = js.native
+  var action: js.UndefOr[String] = js.undefined
   
-  var autoComplete: js.UndefOr[String] = js.native
+  var autoComplete: js.UndefOr[String] = js.undefined
   
-  var encType: js.UndefOr[String] = js.native
+  var encType: js.UndefOr[String] = js.undefined
   
-  var method: js.UndefOr[String] = js.native
+  var method: js.UndefOr[String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
-  var noValidate: js.UndefOr[Boolean] = js.native
+  var noValidate: js.UndefOr[Boolean] = js.undefined
   
-  var target: js.UndefOr[String] = js.native
+  var target: js.UndefOr[String] = js.undefined
 }
 object FormHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/FunctionComponentElement.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/FunctionComponentElement.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait FunctionComponentElement[P]
   extends StObject
      with ReactElement {
   
-  var ref: js.UndefOr[js.Any] = js.native
+  var ref: js.UndefOr[js.Any] = js.undefined
 }
 object FunctionComponentElement {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/HTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/HTMLAttributes.scala
@@ -6,104 +6,103 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HTMLAttributes[T]
   extends StObject
      with AriaAttributes
      with DOMAttributes[T] {
   
   // RDFa Attributes
-  var about: js.UndefOr[String] = js.native
+  var about: js.UndefOr[String] = js.undefined
   
   // Standard HTML Attributes
-  var accessKey: js.UndefOr[String] = js.native
+  var accessKey: js.UndefOr[String] = js.undefined
   
   // Non-standard Attributes
-  var autoCapitalize: js.UndefOr[String] = js.native
+  var autoCapitalize: js.UndefOr[String] = js.undefined
   
-  var autoCorrect: js.UndefOr[String] = js.native
+  var autoCorrect: js.UndefOr[String] = js.undefined
   
-  var autoSave: js.UndefOr[String] = js.native
+  var autoSave: js.UndefOr[String] = js.undefined
   
-  var className: js.UndefOr[String] = js.native
+  var className: js.UndefOr[String] = js.undefined
   
-  var color: js.UndefOr[String] = js.native
+  var color: js.UndefOr[String] = js.undefined
   
-  var contentEditable: js.UndefOr[Boolean] = js.native
+  var contentEditable: js.UndefOr[Boolean] = js.undefined
   
-  var contextMenu: js.UndefOr[String] = js.native
+  var contextMenu: js.UndefOr[String] = js.undefined
   
-  var datatype: js.UndefOr[String] = js.native
+  var datatype: js.UndefOr[String] = js.undefined
   
   // React-specific Attributes
-  var defaultChecked: js.UndefOr[Boolean] = js.native
+  var defaultChecked: js.UndefOr[Boolean] = js.undefined
   
-  var defaultValue: js.UndefOr[String | js.Array[String]] = js.native
+  var defaultValue: js.UndefOr[String | js.Array[String]] = js.undefined
   
-  var dir: js.UndefOr[String] = js.native
+  var dir: js.UndefOr[String] = js.undefined
   
-  var draggable: js.UndefOr[Boolean] = js.native
+  var draggable: js.UndefOr[Boolean] = js.undefined
   
-  var hidden: js.UndefOr[Boolean] = js.native
+  var hidden: js.UndefOr[Boolean] = js.undefined
   
-  var id: js.UndefOr[String] = js.native
+  var id: js.UndefOr[String] = js.undefined
   
-  var inlist: js.UndefOr[js.Any] = js.native
+  var inlist: js.UndefOr[js.Any] = js.undefined
   
   // Unknown
-  var inputMode: js.UndefOr[String] = js.native
+  var inputMode: js.UndefOr[String] = js.undefined
   
-  var is: js.UndefOr[String] = js.native
+  var is: js.UndefOr[String] = js.undefined
   
-  var itemID: js.UndefOr[String] = js.native
+  var itemID: js.UndefOr[String] = js.undefined
   
-  var itemProp: js.UndefOr[String] = js.native
+  var itemProp: js.UndefOr[String] = js.undefined
   
-  var itemRef: js.UndefOr[String] = js.native
+  var itemRef: js.UndefOr[String] = js.undefined
   
-  var itemScope: js.UndefOr[Boolean] = js.native
+  var itemScope: js.UndefOr[Boolean] = js.undefined
   
-  var itemType: js.UndefOr[String] = js.native
+  var itemType: js.UndefOr[String] = js.undefined
   
-  var lang: js.UndefOr[String] = js.native
+  var lang: js.UndefOr[String] = js.undefined
   
-  var placeholder: js.UndefOr[String] = js.native
+  var placeholder: js.UndefOr[String] = js.undefined
   
-  var prefix: js.UndefOr[String] = js.native
+  var prefix: js.UndefOr[String] = js.undefined
   
-  var property: js.UndefOr[String] = js.native
+  var property: js.UndefOr[String] = js.undefined
   
-  var radioGroup: js.UndefOr[String] = js.native
+  var radioGroup: js.UndefOr[String] = js.undefined
   
-  var resource: js.UndefOr[String] = js.native
+  var resource: js.UndefOr[String] = js.undefined
   
-  var results: js.UndefOr[Double] = js.native
+  var results: js.UndefOr[Double] = js.undefined
   
   // <command>, <menuitem>
   // WAI-ARIA
-  var role: js.UndefOr[String] = js.native
+  var role: js.UndefOr[String] = js.undefined
   
-  var security: js.UndefOr[String] = js.native
+  var security: js.UndefOr[String] = js.undefined
   
-  var slot: js.UndefOr[String] = js.native
+  var slot: js.UndefOr[String] = js.undefined
   
-  var spellCheck: js.UndefOr[Boolean] = js.native
+  var spellCheck: js.UndefOr[Boolean] = js.undefined
   
-  var style: js.UndefOr[CSSProperties] = js.native
+  var style: js.UndefOr[CSSProperties] = js.undefined
   
-  var suppressContentEditableWarning: js.UndefOr[Boolean] = js.native
+  var suppressContentEditableWarning: js.UndefOr[Boolean] = js.undefined
   
-  var suppressHydrationWarning: js.UndefOr[Boolean] = js.native
+  var suppressHydrationWarning: js.UndefOr[Boolean] = js.undefined
   
-  var tabIndex: js.UndefOr[Double] = js.native
+  var tabIndex: js.UndefOr[Double] = js.undefined
   
-  var title: js.UndefOr[String] = js.native
+  var title: js.UndefOr[String] = js.undefined
   
-  var typeof: js.UndefOr[String] = js.native
+  var typeof: js.UndefOr[String] = js.undefined
   
-  var unselectable: js.UndefOr[on | off] = js.native
+  var unselectable: js.UndefOr[on | off] = js.undefined
   
-  var vocab: js.UndefOr[String] = js.native
+  var vocab: js.UndefOr[String] = js.undefined
 }
 object HTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/HTMLProps.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/HTMLProps.scala
@@ -4,7 +4,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HTMLProps[T]
   extends StObject
      with AllHTMLAttributes[T]

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/HtmlHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/HtmlHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HtmlHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var manifest: js.UndefOr[String] = js.native
+  var manifest: js.UndefOr[String] = js.undefined
 }
 object HtmlHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/IframeHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/IframeHTMLAttributes.scala
@@ -4,40 +4,39 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait IframeHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var allow: js.UndefOr[String] = js.native
+  var allow: js.UndefOr[String] = js.undefined
   
-  var allowFullScreen: js.UndefOr[Boolean] = js.native
+  var allowFullScreen: js.UndefOr[Boolean] = js.undefined
   
-  var allowTransparency: js.UndefOr[Boolean] = js.native
+  var allowTransparency: js.UndefOr[Boolean] = js.undefined
   
-  var frameBorder: js.UndefOr[Double | String] = js.native
+  var frameBorder: js.UndefOr[Double | String] = js.undefined
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var marginHeight: js.UndefOr[Double] = js.native
+  var marginHeight: js.UndefOr[Double] = js.undefined
   
-  var marginWidth: js.UndefOr[Double] = js.native
+  var marginWidth: js.UndefOr[Double] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
-  var referrerPolicy: js.UndefOr[String] = js.native
+  var referrerPolicy: js.UndefOr[String] = js.undefined
   
-  var sandbox: js.UndefOr[String] = js.native
+  var sandbox: js.UndefOr[String] = js.undefined
   
-  var scrolling: js.UndefOr[String] = js.native
+  var scrolling: js.UndefOr[String] = js.undefined
   
-  var seamless: js.UndefOr[Boolean] = js.native
+  var seamless: js.UndefOr[Boolean] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var srcDoc: js.UndefOr[String] = js.native
+  var srcDoc: js.UndefOr[String] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
 }
 object IframeHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ImgHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ImgHTMLAttributes.scala
@@ -10,28 +10,27 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ImgHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var alt: js.UndefOr[String] = js.native
+  var alt: js.UndefOr[String] = js.undefined
   
-  var crossOrigin: js.UndefOr[anonymous | `use-credentials` | _empty] = js.native
+  var crossOrigin: js.UndefOr[anonymous | `use-credentials` | _empty] = js.undefined
   
-  var decoding: js.UndefOr[async | auto | sync] = js.native
+  var decoding: js.UndefOr[async | auto | sync] = js.undefined
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var sizes: js.UndefOr[String] = js.native
+  var sizes: js.UndefOr[String] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var srcSet: js.UndefOr[String] = js.native
+  var srcSet: js.UndefOr[String] = js.undefined
   
-  var useMap: js.UndefOr[String] = js.native
+  var useMap: js.UndefOr[String] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
 }
 object ImgHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/InputHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/InputHTMLAttributes.scala
@@ -7,76 +7,75 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait InputHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var accept: js.UndefOr[String] = js.native
+  var accept: js.UndefOr[String] = js.undefined
   
-  var alt: js.UndefOr[String] = js.native
+  var alt: js.UndefOr[String] = js.undefined
   
-  var autoComplete: js.UndefOr[String] = js.native
+  var autoComplete: js.UndefOr[String] = js.undefined
   
-  var autoFocus: js.UndefOr[Boolean] = js.native
+  var autoFocus: js.UndefOr[Boolean] = js.undefined
   
-  var capture: js.UndefOr[Boolean | String] = js.native
+  var capture: js.UndefOr[Boolean | String] = js.undefined
   
   // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
-  var checked: js.UndefOr[Boolean] = js.native
+  var checked: js.UndefOr[Boolean] = js.undefined
   
-  var crossOrigin: js.UndefOr[String] = js.native
+  var crossOrigin: js.UndefOr[String] = js.undefined
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var formAction: js.UndefOr[String] = js.native
+  var formAction: js.UndefOr[String] = js.undefined
   
-  var formEncType: js.UndefOr[String] = js.native
+  var formEncType: js.UndefOr[String] = js.undefined
   
-  var formMethod: js.UndefOr[String] = js.native
+  var formMethod: js.UndefOr[String] = js.undefined
   
-  var formNoValidate: js.UndefOr[Boolean] = js.native
+  var formNoValidate: js.UndefOr[Boolean] = js.undefined
   
-  var formTarget: js.UndefOr[String] = js.native
+  var formTarget: js.UndefOr[String] = js.undefined
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var list: js.UndefOr[String] = js.native
+  var list: js.UndefOr[String] = js.undefined
   
-  var max: js.UndefOr[Double | String] = js.native
+  var max: js.UndefOr[Double | String] = js.undefined
   
-  var maxLength: js.UndefOr[Double] = js.native
+  var maxLength: js.UndefOr[Double] = js.undefined
   
-  var min: js.UndefOr[Double | String] = js.native
+  var min: js.UndefOr[Double | String] = js.undefined
   
-  var minLength: js.UndefOr[Double] = js.native
+  var minLength: js.UndefOr[Double] = js.undefined
   
-  var multiple: js.UndefOr[Boolean] = js.native
+  var multiple: js.UndefOr[Boolean] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
   @JSName("onChange")
-  var onChange_InputHTMLAttributes: js.UndefOr[ChangeEventHandler[T]] = js.native
+  var onChange_InputHTMLAttributes: js.UndefOr[ChangeEventHandler[T]] = js.undefined
   
-  var pattern: js.UndefOr[String] = js.native
+  var pattern: js.UndefOr[String] = js.undefined
   
-  var readOnly: js.UndefOr[Boolean] = js.native
+  var readOnly: js.UndefOr[Boolean] = js.undefined
   
-  var required: js.UndefOr[Boolean] = js.native
+  var required: js.UndefOr[Boolean] = js.undefined
   
-  var size: js.UndefOr[Double] = js.native
+  var size: js.UndefOr[Double] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var step: js.UndefOr[Double | String] = js.native
+  var step: js.UndefOr[Double | String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
 }
 object InputHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/InsHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/InsHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait InsHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var cite: js.UndefOr[String] = js.native
+  var cite: js.UndefOr[String] = js.undefined
   
-  var dateTime: js.UndefOr[String] = js.native
+  var dateTime: js.UndefOr[String] = js.undefined
 }
 object InsHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/InvalidEvent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/InvalidEvent.scala
@@ -8,13 +8,12 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait InvalidEvent[T]
   extends StObject
      with BaseSyntheticEvent[Event, EventTarget & T, EventTarget] {
   
   @JSName("target")
-  var target_InvalidEvent: EventTarget & T = js.native
+  var target_InvalidEvent: EventTarget & T
 }
 object InvalidEvent {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/KeyboardEvent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/KeyboardEvent.scala
@@ -7,40 +7,39 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait KeyboardEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeKeyboardEvent, EventTarget & T, EventTarget] {
   
-  var altKey: Boolean = js.native
+  var altKey: Boolean
   
-  var charCode: Double = js.native
+  var charCode: Double
   
-  var ctrlKey: Boolean = js.native
+  var ctrlKey: Boolean
   
   /**
     * See [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#keys-modifier). for a list of valid (case-sensitive) arguments to this method.
     */
-  def getModifierState(key: String): Boolean = js.native
+  def getModifierState(key: String): Boolean
   
   /**
     * See the [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#named-key-attribute-values). for possible values
     */
-  var key: String = js.native
+  var key: String
   
-  var keyCode: Double = js.native
+  var keyCode: Double
   
-  var locale: String = js.native
+  var locale: String
   
-  var location: Double = js.native
+  var location: Double
   
-  var metaKey: Boolean = js.native
+  var metaKey: Boolean
   
-  var repeat: Boolean = js.native
+  var repeat: Boolean
   
-  var shiftKey: Boolean = js.native
+  var shiftKey: Boolean
   
-  var which: Double = js.native
+  var which: Double
 }
 object KeyboardEvent {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/KeygenHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/KeygenHTMLAttributes.scala
@@ -4,24 +4,23 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait KeygenHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var autoFocus: js.UndefOr[Boolean] = js.native
+  var autoFocus: js.UndefOr[Boolean] = js.undefined
   
-  var challenge: js.UndefOr[String] = js.native
+  var challenge: js.UndefOr[String] = js.undefined
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var keyParams: js.UndefOr[String] = js.native
+  var keyParams: js.UndefOr[String] = js.undefined
   
-  var keyType: js.UndefOr[String] = js.native
+  var keyType: js.UndefOr[String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
 }
 object KeygenHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/LabelHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/LabelHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait LabelHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var htmlFor: js.UndefOr[String] = js.native
+  var htmlFor: js.UndefOr[String] = js.undefined
 }
 object LabelHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/LiHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/LiHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait LiHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object LiHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/LinkHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/LinkHTMLAttributes.scala
@@ -4,28 +4,27 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait LinkHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var as: js.UndefOr[String] = js.native
+  var as: js.UndefOr[String] = js.undefined
   
-  var crossOrigin: js.UndefOr[String] = js.native
+  var crossOrigin: js.UndefOr[String] = js.undefined
   
-  var href: js.UndefOr[String] = js.native
+  var href: js.UndefOr[String] = js.undefined
   
-  var hrefLang: js.UndefOr[String] = js.native
+  var hrefLang: js.UndefOr[String] = js.undefined
   
-  var integrity: js.UndefOr[String] = js.native
+  var integrity: js.UndefOr[String] = js.undefined
   
-  var media: js.UndefOr[String] = js.native
+  var media: js.UndefOr[String] = js.undefined
   
-  var rel: js.UndefOr[String] = js.native
+  var rel: js.UndefOr[String] = js.undefined
   
-  var sizes: js.UndefOr[String] = js.native
+  var sizes: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
 }
 object LinkHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/MapHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/MapHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait MapHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
 }
 object MapHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/MediaHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/MediaHTMLAttributes.scala
@@ -4,30 +4,29 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait MediaHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var autoPlay: js.UndefOr[Boolean] = js.native
+  var autoPlay: js.UndefOr[Boolean] = js.undefined
   
-  var controls: js.UndefOr[Boolean] = js.native
+  var controls: js.UndefOr[Boolean] = js.undefined
   
-  var controlsList: js.UndefOr[String] = js.native
+  var controlsList: js.UndefOr[String] = js.undefined
   
-  var crossOrigin: js.UndefOr[String] = js.native
+  var crossOrigin: js.UndefOr[String] = js.undefined
   
-  var loop: js.UndefOr[Boolean] = js.native
+  var loop: js.UndefOr[Boolean] = js.undefined
   
-  var mediaGroup: js.UndefOr[String] = js.native
+  var mediaGroup: js.UndefOr[String] = js.undefined
   
-  var muted: js.UndefOr[Boolean] = js.native
+  var muted: js.UndefOr[Boolean] = js.undefined
   
-  var playsinline: js.UndefOr[Boolean] = js.native
+  var playsinline: js.UndefOr[Boolean] = js.undefined
   
-  var preload: js.UndefOr[String] = js.native
+  var preload: js.UndefOr[String] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
 }
 object MediaHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/MenuHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/MenuHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait MenuHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
 }
 object MenuHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/MetaHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/MetaHTMLAttributes.scala
@@ -4,18 +4,17 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait MetaHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var charSet: js.UndefOr[String] = js.native
+  var charSet: js.UndefOr[String] = js.undefined
   
-  var content: js.UndefOr[String] = js.native
+  var content: js.UndefOr[String] = js.undefined
   
-  var httpEquiv: js.UndefOr[String] = js.native
+  var httpEquiv: js.UndefOr[String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
 }
 object MetaHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/MeterHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/MeterHTMLAttributes.scala
@@ -4,24 +4,23 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait MeterHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var high: js.UndefOr[Double] = js.native
+  var high: js.UndefOr[Double] = js.undefined
   
-  var low: js.UndefOr[Double] = js.native
+  var low: js.UndefOr[Double] = js.undefined
   
-  var max: js.UndefOr[Double | String] = js.native
+  var max: js.UndefOr[Double | String] = js.undefined
   
-  var min: js.UndefOr[Double | String] = js.native
+  var min: js.UndefOr[Double | String] = js.undefined
   
-  var optimum: js.UndefOr[Double] = js.native
+  var optimum: js.UndefOr[Double] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object MeterHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/Mixin.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/Mixin.scala
@@ -6,26 +6,25 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Mixin[P, S]
   extends StObject
      with ComponentLifecycle[P, S, js.Any] {
   
-  var childContextTypes: js.UndefOr[ValidationMap[js.Any]] = js.native
+  var childContextTypes: js.UndefOr[ValidationMap[js.Any]] = js.undefined
   
-  var contextTypes: js.UndefOr[ValidationMap[js.Any]] = js.native
+  var contextTypes: js.UndefOr[ValidationMap[js.Any]] = js.undefined
   
-  var displayName: js.UndefOr[String] = js.native
+  var displayName: js.UndefOr[String] = js.undefined
   
-  var getDefaultProps: js.UndefOr[js.Function0[P]] = js.native
+  var getDefaultProps: js.UndefOr[js.Function0[P]] = js.undefined
   
-  var getInitialState: js.UndefOr[js.Function0[S]] = js.native
+  var getInitialState: js.UndefOr[js.Function0[S]] = js.undefined
   
-  var mixins: js.UndefOr[js.Array[Mixin[P, S]]] = js.native
+  var mixins: js.UndefOr[js.Array[Mixin[P, S]]] = js.undefined
   
-  var propTypes: js.UndefOr[ValidationMap[js.Any]] = js.native
+  var propTypes: js.UndefOr[ValidationMap[js.Any]] = js.undefined
   
-  var statics: js.UndefOr[StringDictionary[js.Any]] = js.native
+  var statics: js.UndefOr[StringDictionary[js.Any]] = js.undefined
 }
 object Mixin {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/MouseEvent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/MouseEvent.scala
@@ -7,45 +7,44 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait MouseEvent[T, E]
   extends StObject
      with BaseSyntheticEvent[E, EventTarget & T, EventTarget] {
   
-  var altKey: Boolean = js.native
+  var altKey: Boolean
   
-  var button: Double = js.native
+  var button: Double
   
-  var buttons: Double = js.native
+  var buttons: Double
   
-  var clientX: Double = js.native
+  var clientX: Double
   
-  var clientY: Double = js.native
+  var clientY: Double
   
-  var ctrlKey: Boolean = js.native
+  var ctrlKey: Boolean
   
   /**
     * See [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#keys-modifier). for a list of valid (case-sensitive) arguments to this method.
     */
-  def getModifierState(key: String): Boolean = js.native
+  def getModifierState(key: String): Boolean
   
-  var metaKey: Boolean = js.native
+  var metaKey: Boolean
   
-  var movementX: Double = js.native
+  var movementX: Double
   
-  var movementY: Double = js.native
+  var movementY: Double
   
-  var pageX: Double = js.native
+  var pageX: Double
   
-  var pageY: Double = js.native
+  var pageY: Double
   
-  var relatedTarget: EventTarget = js.native
+  var relatedTarget: EventTarget
   
-  var screenX: Double = js.native
+  var screenX: Double
   
-  var screenY: Double = js.native
+  var screenY: Double
   
-  var shiftKey: Boolean = js.native
+  var shiftKey: Boolean
 }
 object MouseEvent {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/MutableRefObject.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/MutableRefObject.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait MutableRefObject[T] extends StObject {
   
-  var current: T = js.native
+  var current: T
 }
 object MutableRefObject {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/NewLifecycle.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/NewLifecycle.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 // This should be "infer SS" but can't use it yet
-@js.native
 trait NewLifecycle[P, S, SS] extends StObject {
   
   /**
@@ -16,7 +15,7 @@ trait NewLifecycle[P, S, SS] extends StObject {
     */
   var componentDidUpdate: js.UndefOr[
     js.Function3[/* prevProps */ P, /* prevState */ S, /* snapshot */ js.UndefOr[SS], Unit]
-  ] = js.native
+  ] = js.undefined
   
   /**
     * Runs before React applies the result of `render` to the document, and
@@ -26,7 +25,7 @@ trait NewLifecycle[P, S, SS] extends StObject {
     * Note: the presence of getSnapshotBeforeUpdate prevents any of the deprecated
     * lifecycle events from running.
     */
-  var getSnapshotBeforeUpdate: js.UndefOr[js.Function2[/* prevProps */ P, /* prevState */ S, SS | Null]] = js.native
+  var getSnapshotBeforeUpdate: js.UndefOr[js.Function2[/* prevProps */ P, /* prevState */ S, SS | Null]] = js.undefined
 }
 object NewLifecycle {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ObjectHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ObjectHTMLAttributes.scala
@@ -4,28 +4,27 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ObjectHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var classID: js.UndefOr[String] = js.native
+  var classID: js.UndefOr[String] = js.undefined
   
-  var data: js.UndefOr[String] = js.native
+  var data: js.UndefOr[String] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
   
-  var useMap: js.UndefOr[String] = js.native
+  var useMap: js.UndefOr[String] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
   
-  var wmode: js.UndefOr[String] = js.native
+  var wmode: js.UndefOr[String] = js.undefined
 }
 object ObjectHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/OlHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/OlHTMLAttributes.scala
@@ -9,16 +9,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait OlHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var reversed: js.UndefOr[Boolean] = js.native
+  var reversed: js.UndefOr[Boolean] = js.undefined
   
-  var start: js.UndefOr[Double] = js.native
+  var start: js.UndefOr[Double] = js.undefined
   
-  var `type`: js.UndefOr[`1` | a_ | A | i_ | I] = js.native
+  var `type`: js.UndefOr[`1` | a_ | A | i_ | I] = js.undefined
 }
 object OlHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/OptgroupHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/OptgroupHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait OptgroupHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var label: js.UndefOr[String] = js.native
+  var label: js.UndefOr[String] = js.undefined
 }
 object OptgroupHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/OptionHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/OptionHTMLAttributes.scala
@@ -4,18 +4,17 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait OptionHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var label: js.UndefOr[String] = js.native
+  var label: js.UndefOr[String] = js.undefined
   
-  var selected: js.UndefOr[Boolean] = js.native
+  var selected: js.UndefOr[Boolean] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object OptionHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/OutputHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/OutputHTMLAttributes.scala
@@ -4,16 +4,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait OutputHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var htmlFor: js.UndefOr[String] = js.native
+  var htmlFor: js.UndefOr[String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
 }
 object OutputHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ParamHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ParamHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ParamHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object ParamHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/PointerEvent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/PointerEvent.scala
@@ -10,26 +10,25 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait PointerEvent[T]
   extends StObject
      with MouseEvent[T, NativePointerEvent] {
   
-  var height: Double = js.native
+  var height: Double
   
-  var isPrimary: Boolean = js.native
+  var isPrimary: Boolean
   
-  var pointerId: Double = js.native
+  var pointerId: Double
   
-  var pointerType: mouse | pen | touch = js.native
+  var pointerType: mouse | pen | touch
   
-  var pressure: Double = js.native
+  var pressure: Double
   
-  var tiltX: Double = js.native
+  var tiltX: Double
   
-  var tiltY: Double = js.native
+  var tiltY: Double
   
-  var width: Double = js.native
+  var width: Double
 }
 object PointerEvent {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ProfilerProps.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ProfilerProps.scala
@@ -13,14 +13,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ProfilerProps extends StObject {
   
-  var children: js.UndefOr[Node] = js.native
+  var children: js.UndefOr[Node] = js.undefined
   
-  var id: String = js.native
+  var id: String
   
-  var onRender: ProfilerOnRenderCallback = js.native
+  var onRender: ProfilerOnRenderCallback
 }
 object ProfilerProps {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ProgressHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ProgressHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ProgressHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var max: js.UndefOr[Double | String] = js.native
+  var max: js.UndefOr[Double | String] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object ProgressHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/Props.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/Props.scala
@@ -28,14 +28,13 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
   * };
   * ```
   */
-@js.native
 trait Props[T] extends StObject {
   
-  var children: js.UndefOr[Node] = js.native
+  var children: js.UndefOr[Node] = js.undefined
   
-  var key: js.UndefOr[Key] = js.native
+  var key: js.UndefOr[Key] = js.undefined
   
-  var ref: js.UndefOr[LegacyRef[T]] = js.native
+  var ref: js.UndefOr[LegacyRef[T]] = js.undefined
 }
 object Props {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ProviderProps.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ProviderProps.scala
@@ -11,12 +11,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 // Context via RenderProps
-@js.native
 trait ProviderProps[T] extends StObject {
   
-  var children: js.UndefOr[Node] = js.native
+  var children: js.UndefOr[Node] = js.undefined
   
-  var value: T = js.native
+  var value: T
 }
 object ProviderProps {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/QuoteHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/QuoteHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait QuoteHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var cite: js.UndefOr[String] = js.native
+  var cite: js.UndefOr[String] = js.undefined
 }
 object QuoteHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactDOM.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactDOM.scala
@@ -62,7 +62,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ReactDOM
   extends StObject
      with ReactHTML

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactElement.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactElement.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ReactElement extends StObject {
   
-  var key: Key | Null = js.native
+  var key: Key | Null
   
-  var props: js.Any = js.native
+  var props: js.Any
   
-  var `type`: js.Any = js.native
+  var `type`: js.Any
 }
 object ReactElement {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactHTML.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactHTML.scala
@@ -65,238 +65,237 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 //
 // React.DOM
 // ----------------------------------------------------------------------
-@js.native
 trait ReactHTML extends StObject {
   
-  var a: DetailedHTMLFactory[AnchorHTMLAttributes[HTMLAnchorElement], HTMLAnchorElement] = js.native
+  var a: DetailedHTMLFactory[AnchorHTMLAttributes[HTMLAnchorElement], HTMLAnchorElement]
   
-  var abbr: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var abbr: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var address: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var address: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var area: DetailedHTMLFactory[AreaHTMLAttributes[HTMLAreaElement], HTMLAreaElement] = js.native
+  var area: DetailedHTMLFactory[AreaHTMLAttributes[HTMLAreaElement], HTMLAreaElement]
   
-  var article: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var article: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var aside: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var aside: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var audio: DetailedHTMLFactory[AudioHTMLAttributes[HTMLAudioElement], HTMLAudioElement] = js.native
+  var audio: DetailedHTMLFactory[AudioHTMLAttributes[HTMLAudioElement], HTMLAudioElement]
   
-  var b: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var b: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var base: DetailedHTMLFactory[BaseHTMLAttributes[HTMLBaseElement], HTMLBaseElement] = js.native
+  var base: DetailedHTMLFactory[BaseHTMLAttributes[HTMLBaseElement], HTMLBaseElement]
   
-  var bdi: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var bdi: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var bdo: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var bdo: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var big: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var big: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var blockquote: DetailedHTMLFactory[BlockquoteHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var blockquote: DetailedHTMLFactory[BlockquoteHTMLAttributes[HTMLElement], HTMLElement]
   
-  var body: DetailedHTMLFactory[HTMLAttributes[HTMLBodyElement], HTMLBodyElement] = js.native
+  var body: DetailedHTMLFactory[HTMLAttributes[HTMLBodyElement], HTMLBodyElement]
   
-  var br: DetailedHTMLFactory[HTMLAttributes[HTMLBRElement], HTMLBRElement] = js.native
+  var br: DetailedHTMLFactory[HTMLAttributes[HTMLBRElement], HTMLBRElement]
   
-  var button: DetailedHTMLFactory[ButtonHTMLAttributes[HTMLButtonElement], HTMLButtonElement] = js.native
+  var button: DetailedHTMLFactory[ButtonHTMLAttributes[HTMLButtonElement], HTMLButtonElement]
   
-  var canvas: DetailedHTMLFactory[CanvasHTMLAttributes[HTMLCanvasElement], HTMLCanvasElement] = js.native
+  var canvas: DetailedHTMLFactory[CanvasHTMLAttributes[HTMLCanvasElement], HTMLCanvasElement]
   
-  var caption: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var caption: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var cite: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var cite: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var code: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var code: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var col: DetailedHTMLFactory[ColHTMLAttributes[HTMLTableColElement], HTMLTableColElement] = js.native
+  var col: DetailedHTMLFactory[ColHTMLAttributes[HTMLTableColElement], HTMLTableColElement]
   
-  var colgroup: DetailedHTMLFactory[ColgroupHTMLAttributes[HTMLTableColElement], HTMLTableColElement] = js.native
+  var colgroup: DetailedHTMLFactory[ColgroupHTMLAttributes[HTMLTableColElement], HTMLTableColElement]
   
-  var data: DetailedHTMLFactory[DataHTMLAttributes[HTMLDataElement], HTMLDataElement] = js.native
+  var data: DetailedHTMLFactory[DataHTMLAttributes[HTMLDataElement], HTMLDataElement]
   
-  var datalist: DetailedHTMLFactory[HTMLAttributes[HTMLDataListElement], HTMLDataListElement] = js.native
+  var datalist: DetailedHTMLFactory[HTMLAttributes[HTMLDataListElement], HTMLDataListElement]
   
-  var dd: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var dd: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var del: DetailedHTMLFactory[DelHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var del: DetailedHTMLFactory[DelHTMLAttributes[HTMLElement], HTMLElement]
   
-  var details: DetailedHTMLFactory[DetailsHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var details: DetailedHTMLFactory[DetailsHTMLAttributes[HTMLElement], HTMLElement]
   
-  var dfn: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var dfn: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var dialog: DetailedHTMLFactory[DialogHTMLAttributes[HTMLDialogElement], HTMLDialogElement] = js.native
+  var dialog: DetailedHTMLFactory[DialogHTMLAttributes[HTMLDialogElement], HTMLDialogElement]
   
-  var div: DetailedHTMLFactory[HTMLAttributes[HTMLDivElement], HTMLDivElement] = js.native
+  var div: DetailedHTMLFactory[HTMLAttributes[HTMLDivElement], HTMLDivElement]
   
-  var dl: DetailedHTMLFactory[HTMLAttributes[HTMLDListElement], HTMLDListElement] = js.native
+  var dl: DetailedHTMLFactory[HTMLAttributes[HTMLDListElement], HTMLDListElement]
   
-  var dt: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var dt: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var em: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var em: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var embed: DetailedHTMLFactory[EmbedHTMLAttributes[HTMLEmbedElement], HTMLEmbedElement] = js.native
+  var embed: DetailedHTMLFactory[EmbedHTMLAttributes[HTMLEmbedElement], HTMLEmbedElement]
   
-  var fieldset: DetailedHTMLFactory[FieldsetHTMLAttributes[HTMLFieldSetElement], HTMLFieldSetElement] = js.native
+  var fieldset: DetailedHTMLFactory[FieldsetHTMLAttributes[HTMLFieldSetElement], HTMLFieldSetElement]
   
-  var figcaption: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var figcaption: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var figure: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var figure: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var footer: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var footer: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var form: DetailedHTMLFactory[FormHTMLAttributes[HTMLFormElement], HTMLFormElement] = js.native
+  var form: DetailedHTMLFactory[FormHTMLAttributes[HTMLFormElement], HTMLFormElement]
   
-  var h1: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement] = js.native
+  var h1: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement]
   
-  var h2: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement] = js.native
+  var h2: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement]
   
-  var h3: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement] = js.native
+  var h3: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement]
   
-  var h4: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement] = js.native
+  var h4: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement]
   
-  var h5: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement] = js.native
+  var h5: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement]
   
-  var h6: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement] = js.native
+  var h6: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement]
   
-  var head: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLHeadElement] = js.native
+  var head: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLHeadElement]
   
-  var header: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var header: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var hgroup: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var hgroup: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var hr: DetailedHTMLFactory[HTMLAttributes[HTMLHRElement], HTMLHRElement] = js.native
+  var hr: DetailedHTMLFactory[HTMLAttributes[HTMLHRElement], HTMLHRElement]
   
-  var html: DetailedHTMLFactory[HtmlHTMLAttributes[HTMLHtmlElement], HTMLHtmlElement] = js.native
+  var html: DetailedHTMLFactory[HtmlHTMLAttributes[HTMLHtmlElement], HTMLHtmlElement]
   
-  var i: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var i: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var iframe: DetailedHTMLFactory[IframeHTMLAttributes[HTMLIFrameElement], HTMLIFrameElement] = js.native
+  var iframe: DetailedHTMLFactory[IframeHTMLAttributes[HTMLIFrameElement], HTMLIFrameElement]
   
-  var img: DetailedHTMLFactory[ImgHTMLAttributes[HTMLImageElement], HTMLImageElement] = js.native
+  var img: DetailedHTMLFactory[ImgHTMLAttributes[HTMLImageElement], HTMLImageElement]
   
-  var input: DetailedHTMLFactory[InputHTMLAttributes[HTMLInputElement], HTMLInputElement] = js.native
+  var input: DetailedHTMLFactory[InputHTMLAttributes[HTMLInputElement], HTMLInputElement]
   
-  var ins: DetailedHTMLFactory[InsHTMLAttributes[HTMLModElement], HTMLModElement] = js.native
+  var ins: DetailedHTMLFactory[InsHTMLAttributes[HTMLModElement], HTMLModElement]
   
-  var kbd: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var kbd: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var keygen: DetailedHTMLFactory[KeygenHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var keygen: DetailedHTMLFactory[KeygenHTMLAttributes[HTMLElement], HTMLElement]
   
-  var label: DetailedHTMLFactory[LabelHTMLAttributes[HTMLLabelElement], HTMLLabelElement] = js.native
+  var label: DetailedHTMLFactory[LabelHTMLAttributes[HTMLLabelElement], HTMLLabelElement]
   
-  var legend: DetailedHTMLFactory[HTMLAttributes[HTMLLegendElement], HTMLLegendElement] = js.native
+  var legend: DetailedHTMLFactory[HTMLAttributes[HTMLLegendElement], HTMLLegendElement]
   
-  var li: DetailedHTMLFactory[LiHTMLAttributes[HTMLLIElement], HTMLLIElement] = js.native
+  var li: DetailedHTMLFactory[LiHTMLAttributes[HTMLLIElement], HTMLLIElement]
   
-  var link: DetailedHTMLFactory[LinkHTMLAttributes[HTMLLinkElement], HTMLLinkElement] = js.native
+  var link: DetailedHTMLFactory[LinkHTMLAttributes[HTMLLinkElement], HTMLLinkElement]
   
-  var main: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var main: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var map: DetailedHTMLFactory[MapHTMLAttributes[HTMLMapElement], HTMLMapElement] = js.native
+  var map: DetailedHTMLFactory[MapHTMLAttributes[HTMLMapElement], HTMLMapElement]
   
-  var mark: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var mark: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var menu: DetailedHTMLFactory[MenuHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var menu: DetailedHTMLFactory[MenuHTMLAttributes[HTMLElement], HTMLElement]
   
-  var menuitem: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var menuitem: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var meta: DetailedHTMLFactory[MetaHTMLAttributes[HTMLMetaElement], HTMLMetaElement] = js.native
+  var meta: DetailedHTMLFactory[MetaHTMLAttributes[HTMLMetaElement], HTMLMetaElement]
   
-  var meter: DetailedHTMLFactory[MeterHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var meter: DetailedHTMLFactory[MeterHTMLAttributes[HTMLElement], HTMLElement]
   
-  var nav: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var nav: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var noscript: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var noscript: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var `object`: DetailedHTMLFactory[ObjectHTMLAttributes[HTMLObjectElement], HTMLObjectElement] = js.native
+  var `object`: DetailedHTMLFactory[ObjectHTMLAttributes[HTMLObjectElement], HTMLObjectElement]
   
-  var ol: DetailedHTMLFactory[OlHTMLAttributes[HTMLOListElement], HTMLOListElement] = js.native
+  var ol: DetailedHTMLFactory[OlHTMLAttributes[HTMLOListElement], HTMLOListElement]
   
-  var optgroup: DetailedHTMLFactory[OptgroupHTMLAttributes[HTMLOptGroupElement], HTMLOptGroupElement] = js.native
+  var optgroup: DetailedHTMLFactory[OptgroupHTMLAttributes[HTMLOptGroupElement], HTMLOptGroupElement]
   
-  var option: DetailedHTMLFactory[OptionHTMLAttributes[HTMLOptionElement], HTMLOptionElement] = js.native
+  var option: DetailedHTMLFactory[OptionHTMLAttributes[HTMLOptionElement], HTMLOptionElement]
   
-  var output: DetailedHTMLFactory[OutputHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var output: DetailedHTMLFactory[OutputHTMLAttributes[HTMLElement], HTMLElement]
   
-  var p: DetailedHTMLFactory[HTMLAttributes[HTMLParagraphElement], HTMLParagraphElement] = js.native
+  var p: DetailedHTMLFactory[HTMLAttributes[HTMLParagraphElement], HTMLParagraphElement]
   
-  var param: DetailedHTMLFactory[ParamHTMLAttributes[HTMLParamElement], HTMLParamElement] = js.native
+  var param: DetailedHTMLFactory[ParamHTMLAttributes[HTMLParamElement], HTMLParamElement]
   
-  var picture: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var picture: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var pre: DetailedHTMLFactory[HTMLAttributes[HTMLPreElement], HTMLPreElement] = js.native
+  var pre: DetailedHTMLFactory[HTMLAttributes[HTMLPreElement], HTMLPreElement]
   
-  var progress: DetailedHTMLFactory[ProgressHTMLAttributes[HTMLProgressElement], HTMLProgressElement] = js.native
+  var progress: DetailedHTMLFactory[ProgressHTMLAttributes[HTMLProgressElement], HTMLProgressElement]
   
-  var q: DetailedHTMLFactory[QuoteHTMLAttributes[HTMLQuoteElement], HTMLQuoteElement] = js.native
+  var q: DetailedHTMLFactory[QuoteHTMLAttributes[HTMLQuoteElement], HTMLQuoteElement]
   
-  var rp: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var rp: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var rt: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var rt: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var ruby: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var ruby: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var s: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var s: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var samp: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var samp: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var script: DetailedHTMLFactory[ScriptHTMLAttributes[HTMLScriptElement], HTMLScriptElement] = js.native
+  var script: DetailedHTMLFactory[ScriptHTMLAttributes[HTMLScriptElement], HTMLScriptElement]
   
-  var section: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var section: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var select: DetailedHTMLFactory[SelectHTMLAttributes[HTMLSelectElement], HTMLSelectElement] = js.native
+  var select: DetailedHTMLFactory[SelectHTMLAttributes[HTMLSelectElement], HTMLSelectElement]
   
-  var small: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var small: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var source: DetailedHTMLFactory[SourceHTMLAttributes[HTMLSourceElement], HTMLSourceElement] = js.native
+  var source: DetailedHTMLFactory[SourceHTMLAttributes[HTMLSourceElement], HTMLSourceElement]
   
-  var span: DetailedHTMLFactory[HTMLAttributes[HTMLSpanElement], HTMLSpanElement] = js.native
+  var span: DetailedHTMLFactory[HTMLAttributes[HTMLSpanElement], HTMLSpanElement]
   
-  var strong: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var strong: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var style: DetailedHTMLFactory[StyleHTMLAttributes[HTMLStyleElement], HTMLStyleElement] = js.native
+  var style: DetailedHTMLFactory[StyleHTMLAttributes[HTMLStyleElement], HTMLStyleElement]
   
-  var sub: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var sub: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var summary: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var summary: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var sup: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var sup: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var table: DetailedHTMLFactory[TableHTMLAttributes[HTMLTableElement], HTMLTableElement] = js.native
+  var table: DetailedHTMLFactory[TableHTMLAttributes[HTMLTableElement], HTMLTableElement]
   
-  var tbody: DetailedHTMLFactory[HTMLAttributes[HTMLTableSectionElement], HTMLTableSectionElement] = js.native
+  var tbody: DetailedHTMLFactory[HTMLAttributes[HTMLTableSectionElement], HTMLTableSectionElement]
   
-  var td: DetailedHTMLFactory[TdHTMLAttributes[HTMLTableDataCellElement], HTMLTableDataCellElement] = js.native
+  var td: DetailedHTMLFactory[TdHTMLAttributes[HTMLTableDataCellElement], HTMLTableDataCellElement]
   
-  var template: DetailedHTMLFactory[HTMLAttributes[HTMLTemplateElement], HTMLTemplateElement] = js.native
+  var template: DetailedHTMLFactory[HTMLAttributes[HTMLTemplateElement], HTMLTemplateElement]
   
-  var textarea: DetailedHTMLFactory[TextareaHTMLAttributes[HTMLTextAreaElement], HTMLTextAreaElement] = js.native
+  var textarea: DetailedHTMLFactory[TextareaHTMLAttributes[HTMLTextAreaElement], HTMLTextAreaElement]
   
-  var tfoot: DetailedHTMLFactory[HTMLAttributes[HTMLTableSectionElement], HTMLTableSectionElement] = js.native
+  var tfoot: DetailedHTMLFactory[HTMLAttributes[HTMLTableSectionElement], HTMLTableSectionElement]
   
-  var th: DetailedHTMLFactory[ThHTMLAttributes[HTMLTableHeaderCellElement], HTMLTableHeaderCellElement] = js.native
+  var th: DetailedHTMLFactory[ThHTMLAttributes[HTMLTableHeaderCellElement], HTMLTableHeaderCellElement]
   
-  var thead: DetailedHTMLFactory[HTMLAttributes[HTMLTableSectionElement], HTMLTableSectionElement] = js.native
+  var thead: DetailedHTMLFactory[HTMLAttributes[HTMLTableSectionElement], HTMLTableSectionElement]
   
-  var time: DetailedHTMLFactory[TimeHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var time: DetailedHTMLFactory[TimeHTMLAttributes[HTMLElement], HTMLElement]
   
-  var title: DetailedHTMLFactory[HTMLAttributes[HTMLTitleElement], HTMLTitleElement] = js.native
+  var title: DetailedHTMLFactory[HTMLAttributes[HTMLTitleElement], HTMLTitleElement]
   
-  var tr: DetailedHTMLFactory[HTMLAttributes[HTMLTableRowElement], HTMLTableRowElement] = js.native
+  var tr: DetailedHTMLFactory[HTMLAttributes[HTMLTableRowElement], HTMLTableRowElement]
   
-  var track: DetailedHTMLFactory[TrackHTMLAttributes[HTMLTrackElement], HTMLTrackElement] = js.native
+  var track: DetailedHTMLFactory[TrackHTMLAttributes[HTMLTrackElement], HTMLTrackElement]
   
-  var u: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var u: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var ul: DetailedHTMLFactory[HTMLAttributes[HTMLUListElement], HTMLUListElement] = js.native
+  var ul: DetailedHTMLFactory[HTMLAttributes[HTMLUListElement], HTMLUListElement]
   
-  var `var`: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var `var`: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var video: DetailedHTMLFactory[VideoHTMLAttributes[HTMLVideoElement], HTMLVideoElement] = js.native
+  var video: DetailedHTMLFactory[VideoHTMLAttributes[HTMLVideoElement], HTMLVideoElement]
   
-  var wbr: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var wbr: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var webview: DetailedHTMLFactory[WebViewHTMLAttributes[HTMLWebViewElement], HTMLWebViewElement] = js.native
+  var webview: DetailedHTMLFactory[WebViewHTMLAttributes[HTMLWebViewElement], HTMLWebViewElement]
 }
 object ReactHTML {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactNodeArray.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactNodeArray.scala
@@ -6,7 +6,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ReactNodeArray
   extends StObject
      with Array[Node]

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactPortal.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactPortal.scala
@@ -10,12 +10,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ReactPortal
   extends StObject
      with ReactElement {
   
-  var children: Node = js.native
+  var children: Node
 }
 object ReactPortal {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactPropTypes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactPropTypes.scala
@@ -4,40 +4,39 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ReactPropTypes extends StObject {
   
-  var any: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.any */ js.Any = js.native
+  var any: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.any */ js.Any
   
-  var array: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.array */ js.Any = js.native
+  var array: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.array */ js.Any
   
-  var arrayOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.arrayOf */ js.Any = js.native
+  var arrayOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.arrayOf */ js.Any
   
-  var bool: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.bool */ js.Any = js.native
+  var bool: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.bool */ js.Any
   
-  var element: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.element */ js.Any = js.native
+  var element: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.element */ js.Any
   
-  var exact: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.exact */ js.Any = js.native
+  var exact: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.exact */ js.Any
   
-  var func: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.func */ js.Any = js.native
+  var func: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.func */ js.Any
   
-  var instanceOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.instanceOf */ js.Any = js.native
+  var instanceOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.instanceOf */ js.Any
   
-  var node: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.node */ js.Any = js.native
+  var node: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.node */ js.Any
   
-  var number: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.number */ js.Any = js.native
+  var number: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.number */ js.Any
   
-  var `object`: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.object */ js.Any = js.native
+  var `object`: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.object */ js.Any
   
-  var objectOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.objectOf */ js.Any = js.native
+  var objectOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.objectOf */ js.Any
   
-  var oneOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.oneOf */ js.Any = js.native
+  var oneOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.oneOf */ js.Any
   
-  var oneOfType: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.oneOfType */ js.Any = js.native
+  var oneOfType: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.oneOfType */ js.Any
   
-  var shape: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.shape */ js.Any = js.native
+  var shape: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.shape */ js.Any
   
-  var string: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.string */ js.Any = js.native
+  var string: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.string */ js.Any
 }
 object ReactPropTypes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactSVG.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactSVG.scala
@@ -4,118 +4,117 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ReactSVG extends StObject {
   
-  var animate: SVGFactory = js.native
+  var animate: SVGFactory
   
-  var circle: SVGFactory = js.native
+  var circle: SVGFactory
   
-  var clipPath: SVGFactory = js.native
+  var clipPath: SVGFactory
   
-  var defs: SVGFactory = js.native
+  var defs: SVGFactory
   
-  var desc: SVGFactory = js.native
+  var desc: SVGFactory
   
-  var ellipse: SVGFactory = js.native
+  var ellipse: SVGFactory
   
-  var feBlend: SVGFactory = js.native
+  var feBlend: SVGFactory
   
-  var feColorMatrix: SVGFactory = js.native
+  var feColorMatrix: SVGFactory
   
-  var feComponentTransfer: SVGFactory = js.native
+  var feComponentTransfer: SVGFactory
   
-  var feComposite: SVGFactory = js.native
+  var feComposite: SVGFactory
   
-  var feConvolveMatrix: SVGFactory = js.native
+  var feConvolveMatrix: SVGFactory
   
-  var feDiffuseLighting: SVGFactory = js.native
+  var feDiffuseLighting: SVGFactory
   
-  var feDisplacementMap: SVGFactory = js.native
+  var feDisplacementMap: SVGFactory
   
-  var feDistantLight: SVGFactory = js.native
+  var feDistantLight: SVGFactory
   
-  var feDropShadow: SVGFactory = js.native
+  var feDropShadow: SVGFactory
   
-  var feFlood: SVGFactory = js.native
+  var feFlood: SVGFactory
   
-  var feFuncA: SVGFactory = js.native
+  var feFuncA: SVGFactory
   
-  var feFuncB: SVGFactory = js.native
+  var feFuncB: SVGFactory
   
-  var feFuncG: SVGFactory = js.native
+  var feFuncG: SVGFactory
   
-  var feFuncR: SVGFactory = js.native
+  var feFuncR: SVGFactory
   
-  var feGaussianBlur: SVGFactory = js.native
+  var feGaussianBlur: SVGFactory
   
-  var feImage: SVGFactory = js.native
+  var feImage: SVGFactory
   
-  var feMerge: SVGFactory = js.native
+  var feMerge: SVGFactory
   
-  var feMergeNode: SVGFactory = js.native
+  var feMergeNode: SVGFactory
   
-  var feMorphology: SVGFactory = js.native
+  var feMorphology: SVGFactory
   
-  var feOffset: SVGFactory = js.native
+  var feOffset: SVGFactory
   
-  var fePointLight: SVGFactory = js.native
+  var fePointLight: SVGFactory
   
-  var feSpecularLighting: SVGFactory = js.native
+  var feSpecularLighting: SVGFactory
   
-  var feSpotLight: SVGFactory = js.native
+  var feSpotLight: SVGFactory
   
-  var feTile: SVGFactory = js.native
+  var feTile: SVGFactory
   
-  var feTurbulence: SVGFactory = js.native
+  var feTurbulence: SVGFactory
   
-  var filter: SVGFactory = js.native
+  var filter: SVGFactory
   
-  var foreignObject: SVGFactory = js.native
+  var foreignObject: SVGFactory
   
-  var g: SVGFactory = js.native
+  var g: SVGFactory
   
-  var image: SVGFactory = js.native
+  var image: SVGFactory
   
-  var line: SVGFactory = js.native
+  var line: SVGFactory
   
-  var linearGradient: SVGFactory = js.native
+  var linearGradient: SVGFactory
   
-  var marker: SVGFactory = js.native
+  var marker: SVGFactory
   
-  var mask: SVGFactory = js.native
+  var mask: SVGFactory
   
-  var metadata: SVGFactory = js.native
+  var metadata: SVGFactory
   
-  var path: SVGFactory = js.native
+  var path: SVGFactory
   
-  var pattern: SVGFactory = js.native
+  var pattern: SVGFactory
   
-  var polygon: SVGFactory = js.native
+  var polygon: SVGFactory
   
-  var polyline: SVGFactory = js.native
+  var polyline: SVGFactory
   
-  var radialGradient: SVGFactory = js.native
+  var radialGradient: SVGFactory
   
-  var rect: SVGFactory = js.native
+  var rect: SVGFactory
   
-  var stop: SVGFactory = js.native
+  var stop: SVGFactory
   
-  var svg: SVGFactory = js.native
+  var svg: SVGFactory
   
-  var switch: SVGFactory = js.native
+  var switch: SVGFactory
   
-  var symbol: SVGFactory = js.native
+  var symbol: SVGFactory
   
-  var text: SVGFactory = js.native
+  var text: SVGFactory
   
-  var textPath: SVGFactory = js.native
+  var textPath: SVGFactory
   
-  var tspan: SVGFactory = js.native
+  var tspan: SVGFactory
   
-  var use: SVGFactory = js.native
+  var use: SVGFactory
   
-  var view: SVGFactory = js.native
+  var view: SVGFactory
 }
 object ReactSVG {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactSVGElement.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ReactSVGElement.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 // ReactSVG for ReactSVGElement
-@js.native
 trait ReactSVGElement
   extends StObject
      with DOMElement[SVGAttributes[SVGElement], SVGElement]

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/RefAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/RefAttributes.scala
@@ -5,12 +5,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait RefAttributes[T]
   extends StObject
      with Attributes {
   
-  var ref: js.UndefOr[Ref[T]] = js.native
+  var ref: js.UndefOr[Ref[T]] = js.undefined
 }
 object RefAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/RefObject.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/RefObject.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait RefObject[T] extends StObject {
   
-  val current: T | Null = js.native
+  val current: T | Null
 }
 object RefObject {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/SVGAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/SVGAttributes.scala
@@ -43,529 +43,528 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 //   - "number | string"
 //   - "string"
 //   - union of string literals
-@js.native
 trait SVGAttributes[T]
   extends StObject
      with AriaAttributes
      with DOMAttributes[T] {
   
   // SVG Specific attributes
-  var accentHeight: js.UndefOr[Double | String] = js.native
+  var accentHeight: js.UndefOr[Double | String] = js.undefined
   
-  var accumulate: js.UndefOr[none | sum] = js.native
+  var accumulate: js.UndefOr[none | sum] = js.undefined
   
-  var additive: js.UndefOr[replace | sum] = js.native
+  var additive: js.UndefOr[replace | sum] = js.undefined
   
   var alignmentBaseline: js.UndefOr[
     auto | baseline | `before-edge` | `text-before-edge` | middle | central | `after-edge` | `text-after-edge` | ideographic | alphabetic | hanging | mathematical | inherit
-  ] = js.native
+  ] = js.undefined
   
-  var allowReorder: js.UndefOr[no | yes] = js.native
+  var allowReorder: js.UndefOr[no | yes] = js.undefined
   
-  var alphabetic: js.UndefOr[Double | String] = js.native
+  var alphabetic: js.UndefOr[Double | String] = js.undefined
   
-  var amplitude: js.UndefOr[Double | String] = js.native
+  var amplitude: js.UndefOr[Double | String] = js.undefined
   
-  var arabicForm: js.UndefOr[initial | medial | terminal | isolated] = js.native
+  var arabicForm: js.UndefOr[initial | medial | terminal | isolated] = js.undefined
   
-  var ascent: js.UndefOr[Double | String] = js.native
+  var ascent: js.UndefOr[Double | String] = js.undefined
   
-  var attributeName: js.UndefOr[String] = js.native
+  var attributeName: js.UndefOr[String] = js.undefined
   
-  var attributeType: js.UndefOr[String] = js.native
+  var attributeType: js.UndefOr[String] = js.undefined
   
-  var autoReverse: js.UndefOr[Double | String] = js.native
+  var autoReverse: js.UndefOr[Double | String] = js.undefined
   
-  var azimuth: js.UndefOr[Double | String] = js.native
+  var azimuth: js.UndefOr[Double | String] = js.undefined
   
-  var baseFrequency: js.UndefOr[Double | String] = js.native
+  var baseFrequency: js.UndefOr[Double | String] = js.undefined
   
-  var baseProfile: js.UndefOr[Double | String] = js.native
+  var baseProfile: js.UndefOr[Double | String] = js.undefined
   
-  var baselineShift: js.UndefOr[Double | String] = js.native
+  var baselineShift: js.UndefOr[Double | String] = js.undefined
   
-  var bbox: js.UndefOr[Double | String] = js.native
+  var bbox: js.UndefOr[Double | String] = js.undefined
   
-  var begin: js.UndefOr[Double | String] = js.native
+  var begin: js.UndefOr[Double | String] = js.undefined
   
-  var bias: js.UndefOr[Double | String] = js.native
+  var bias: js.UndefOr[Double | String] = js.undefined
   
-  var by: js.UndefOr[Double | String] = js.native
+  var by: js.UndefOr[Double | String] = js.undefined
   
-  var calcMode: js.UndefOr[Double | String] = js.native
+  var calcMode: js.UndefOr[Double | String] = js.undefined
   
-  var capHeight: js.UndefOr[Double | String] = js.native
+  var capHeight: js.UndefOr[Double | String] = js.undefined
   
   // Attributes which also defined in HTMLAttributes
   // See comment in SVGDOMPropertyConfig.js
-  var className: js.UndefOr[String] = js.native
+  var className: js.UndefOr[String] = js.undefined
   
-  var clip: js.UndefOr[Double | String] = js.native
+  var clip: js.UndefOr[Double | String] = js.undefined
   
-  var clipPath: js.UndefOr[String] = js.native
+  var clipPath: js.UndefOr[String] = js.undefined
   
-  var clipPathUnits: js.UndefOr[Double | String] = js.native
+  var clipPathUnits: js.UndefOr[Double | String] = js.undefined
   
-  var clipRule: js.UndefOr[Double | String] = js.native
+  var clipRule: js.UndefOr[Double | String] = js.undefined
   
-  var color: js.UndefOr[String] = js.native
+  var color: js.UndefOr[String] = js.undefined
   
-  var colorInterpolation: js.UndefOr[Double | String] = js.native
+  var colorInterpolation: js.UndefOr[Double | String] = js.undefined
   
-  var colorInterpolationFilters: js.UndefOr[auto | sRGB | linearRGB | inherit] = js.native
+  var colorInterpolationFilters: js.UndefOr[auto | sRGB | linearRGB | inherit] = js.undefined
   
-  var colorProfile: js.UndefOr[Double | String] = js.native
+  var colorProfile: js.UndefOr[Double | String] = js.undefined
   
-  var colorRendering: js.UndefOr[Double | String] = js.native
+  var colorRendering: js.UndefOr[Double | String] = js.undefined
   
-  var contentScriptType: js.UndefOr[Double | String] = js.native
+  var contentScriptType: js.UndefOr[Double | String] = js.undefined
   
-  var contentStyleType: js.UndefOr[Double | String] = js.native
+  var contentStyleType: js.UndefOr[Double | String] = js.undefined
   
-  var cursor: js.UndefOr[Double | String] = js.native
+  var cursor: js.UndefOr[Double | String] = js.undefined
   
-  var cx: js.UndefOr[Double | String] = js.native
+  var cx: js.UndefOr[Double | String] = js.undefined
   
-  var cy: js.UndefOr[Double | String] = js.native
+  var cy: js.UndefOr[Double | String] = js.undefined
   
-  var d: js.UndefOr[String] = js.native
+  var d: js.UndefOr[String] = js.undefined
   
-  var decelerate: js.UndefOr[Double | String] = js.native
+  var decelerate: js.UndefOr[Double | String] = js.undefined
   
-  var descent: js.UndefOr[Double | String] = js.native
+  var descent: js.UndefOr[Double | String] = js.undefined
   
-  var diffuseConstant: js.UndefOr[Double | String] = js.native
+  var diffuseConstant: js.UndefOr[Double | String] = js.undefined
   
-  var direction: js.UndefOr[Double | String] = js.native
+  var direction: js.UndefOr[Double | String] = js.undefined
   
-  var display: js.UndefOr[Double | String] = js.native
+  var display: js.UndefOr[Double | String] = js.undefined
   
-  var divisor: js.UndefOr[Double | String] = js.native
+  var divisor: js.UndefOr[Double | String] = js.undefined
   
-  var dominantBaseline: js.UndefOr[Double | String] = js.native
+  var dominantBaseline: js.UndefOr[Double | String] = js.undefined
   
-  var dur: js.UndefOr[Double | String] = js.native
+  var dur: js.UndefOr[Double | String] = js.undefined
   
-  var dx: js.UndefOr[Double | String] = js.native
+  var dx: js.UndefOr[Double | String] = js.undefined
   
-  var dy: js.UndefOr[Double | String] = js.native
+  var dy: js.UndefOr[Double | String] = js.undefined
   
-  var edgeMode: js.UndefOr[Double | String] = js.native
+  var edgeMode: js.UndefOr[Double | String] = js.undefined
   
-  var elevation: js.UndefOr[Double | String] = js.native
+  var elevation: js.UndefOr[Double | String] = js.undefined
   
-  var enableBackground: js.UndefOr[Double | String] = js.native
+  var enableBackground: js.UndefOr[Double | String] = js.undefined
   
-  var end: js.UndefOr[Double | String] = js.native
+  var end: js.UndefOr[Double | String] = js.undefined
   
-  var exponent: js.UndefOr[Double | String] = js.native
+  var exponent: js.UndefOr[Double | String] = js.undefined
   
-  var externalResourcesRequired: js.UndefOr[Double | String] = js.native
+  var externalResourcesRequired: js.UndefOr[Double | String] = js.undefined
   
-  var fill: js.UndefOr[String] = js.native
+  var fill: js.UndefOr[String] = js.undefined
   
-  var fillOpacity: js.UndefOr[Double | String] = js.native
+  var fillOpacity: js.UndefOr[Double | String] = js.undefined
   
-  var fillRule: js.UndefOr[nonzero | evenodd | inherit] = js.native
+  var fillRule: js.UndefOr[nonzero | evenodd | inherit] = js.undefined
   
-  var filter: js.UndefOr[String] = js.native
+  var filter: js.UndefOr[String] = js.undefined
   
-  var filterRes: js.UndefOr[Double | String] = js.native
+  var filterRes: js.UndefOr[Double | String] = js.undefined
   
-  var filterUnits: js.UndefOr[Double | String] = js.native
+  var filterUnits: js.UndefOr[Double | String] = js.undefined
   
-  var floodColor: js.UndefOr[Double | String] = js.native
+  var floodColor: js.UndefOr[Double | String] = js.undefined
   
-  var floodOpacity: js.UndefOr[Double | String] = js.native
+  var floodOpacity: js.UndefOr[Double | String] = js.undefined
   
-  var focusable: js.UndefOr[Double | String] = js.native
+  var focusable: js.UndefOr[Double | String] = js.undefined
   
-  var fontFamily: js.UndefOr[String] = js.native
+  var fontFamily: js.UndefOr[String] = js.undefined
   
-  var fontSize: js.UndefOr[Double | String] = js.native
+  var fontSize: js.UndefOr[Double | String] = js.undefined
   
-  var fontSizeAdjust: js.UndefOr[Double | String] = js.native
+  var fontSizeAdjust: js.UndefOr[Double | String] = js.undefined
   
-  var fontStretch: js.UndefOr[Double | String] = js.native
+  var fontStretch: js.UndefOr[Double | String] = js.undefined
   
-  var fontStyle: js.UndefOr[Double | String] = js.native
+  var fontStyle: js.UndefOr[Double | String] = js.undefined
   
-  var fontVariant: js.UndefOr[Double | String] = js.native
+  var fontVariant: js.UndefOr[Double | String] = js.undefined
   
-  var fontWeight: js.UndefOr[Double | String] = js.native
+  var fontWeight: js.UndefOr[Double | String] = js.undefined
   
-  var format: js.UndefOr[Double | String] = js.native
+  var format: js.UndefOr[Double | String] = js.undefined
   
-  var from: js.UndefOr[Double | String] = js.native
+  var from: js.UndefOr[Double | String] = js.undefined
   
-  var fx: js.UndefOr[Double | String] = js.native
+  var fx: js.UndefOr[Double | String] = js.undefined
   
-  var fy: js.UndefOr[Double | String] = js.native
+  var fy: js.UndefOr[Double | String] = js.undefined
   
-  var g1: js.UndefOr[Double | String] = js.native
+  var g1: js.UndefOr[Double | String] = js.undefined
   
-  var g2: js.UndefOr[Double | String] = js.native
+  var g2: js.UndefOr[Double | String] = js.undefined
   
-  var glyphName: js.UndefOr[Double | String] = js.native
+  var glyphName: js.UndefOr[Double | String] = js.undefined
   
-  var glyphOrientationHorizontal: js.UndefOr[Double | String] = js.native
+  var glyphOrientationHorizontal: js.UndefOr[Double | String] = js.undefined
   
-  var glyphOrientationVertical: js.UndefOr[Double | String] = js.native
+  var glyphOrientationVertical: js.UndefOr[Double | String] = js.undefined
   
-  var glyphRef: js.UndefOr[Double | String] = js.native
+  var glyphRef: js.UndefOr[Double | String] = js.undefined
   
-  var gradientTransform: js.UndefOr[String] = js.native
+  var gradientTransform: js.UndefOr[String] = js.undefined
   
-  var gradientUnits: js.UndefOr[String] = js.native
+  var gradientUnits: js.UndefOr[String] = js.undefined
   
-  var hanging: js.UndefOr[Double | String] = js.native
+  var hanging: js.UndefOr[Double | String] = js.undefined
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var horizAdvX: js.UndefOr[Double | String] = js.native
+  var horizAdvX: js.UndefOr[Double | String] = js.undefined
   
-  var horizOriginX: js.UndefOr[Double | String] = js.native
+  var horizOriginX: js.UndefOr[Double | String] = js.undefined
   
-  var href: js.UndefOr[String] = js.native
+  var href: js.UndefOr[String] = js.undefined
   
-  var id: js.UndefOr[String] = js.native
+  var id: js.UndefOr[String] = js.undefined
   
-  var ideographic: js.UndefOr[Double | String] = js.native
+  var ideographic: js.UndefOr[Double | String] = js.undefined
   
-  var imageRendering: js.UndefOr[Double | String] = js.native
+  var imageRendering: js.UndefOr[Double | String] = js.undefined
   
-  var in: js.UndefOr[String] = js.native
+  var in: js.UndefOr[String] = js.undefined
   
-  var in2: js.UndefOr[Double | String] = js.native
+  var in2: js.UndefOr[Double | String] = js.undefined
   
-  var intercept: js.UndefOr[Double | String] = js.native
+  var intercept: js.UndefOr[Double | String] = js.undefined
   
-  var k: js.UndefOr[Double | String] = js.native
+  var k: js.UndefOr[Double | String] = js.undefined
   
-  var k1: js.UndefOr[Double | String] = js.native
+  var k1: js.UndefOr[Double | String] = js.undefined
   
-  var k2: js.UndefOr[Double | String] = js.native
+  var k2: js.UndefOr[Double | String] = js.undefined
   
-  var k3: js.UndefOr[Double | String] = js.native
+  var k3: js.UndefOr[Double | String] = js.undefined
   
-  var k4: js.UndefOr[Double | String] = js.native
+  var k4: js.UndefOr[Double | String] = js.undefined
   
-  var kernelMatrix: js.UndefOr[Double | String] = js.native
+  var kernelMatrix: js.UndefOr[Double | String] = js.undefined
   
-  var kernelUnitLength: js.UndefOr[Double | String] = js.native
+  var kernelUnitLength: js.UndefOr[Double | String] = js.undefined
   
-  var kerning: js.UndefOr[Double | String] = js.native
+  var kerning: js.UndefOr[Double | String] = js.undefined
   
-  var keyPoints: js.UndefOr[Double | String] = js.native
+  var keyPoints: js.UndefOr[Double | String] = js.undefined
   
-  var keySplines: js.UndefOr[Double | String] = js.native
+  var keySplines: js.UndefOr[Double | String] = js.undefined
   
-  var keyTimes: js.UndefOr[Double | String] = js.native
+  var keyTimes: js.UndefOr[Double | String] = js.undefined
   
-  var lang: js.UndefOr[String] = js.native
+  var lang: js.UndefOr[String] = js.undefined
   
-  var lengthAdjust: js.UndefOr[Double | String] = js.native
+  var lengthAdjust: js.UndefOr[Double | String] = js.undefined
   
-  var letterSpacing: js.UndefOr[Double | String] = js.native
+  var letterSpacing: js.UndefOr[Double | String] = js.undefined
   
-  var lightingColor: js.UndefOr[Double | String] = js.native
+  var lightingColor: js.UndefOr[Double | String] = js.undefined
   
-  var limitingConeAngle: js.UndefOr[Double | String] = js.native
+  var limitingConeAngle: js.UndefOr[Double | String] = js.undefined
   
-  var local: js.UndefOr[Double | String] = js.native
+  var local: js.UndefOr[Double | String] = js.undefined
   
-  var markerEnd: js.UndefOr[String] = js.native
+  var markerEnd: js.UndefOr[String] = js.undefined
   
-  var markerHeight: js.UndefOr[Double | String] = js.native
+  var markerHeight: js.UndefOr[Double | String] = js.undefined
   
-  var markerMid: js.UndefOr[String] = js.native
+  var markerMid: js.UndefOr[String] = js.undefined
   
-  var markerStart: js.UndefOr[String] = js.native
+  var markerStart: js.UndefOr[String] = js.undefined
   
-  var markerUnits: js.UndefOr[Double | String] = js.native
+  var markerUnits: js.UndefOr[Double | String] = js.undefined
   
-  var markerWidth: js.UndefOr[Double | String] = js.native
+  var markerWidth: js.UndefOr[Double | String] = js.undefined
   
-  var mask: js.UndefOr[String] = js.native
+  var mask: js.UndefOr[String] = js.undefined
   
-  var maskContentUnits: js.UndefOr[Double | String] = js.native
+  var maskContentUnits: js.UndefOr[Double | String] = js.undefined
   
-  var maskUnits: js.UndefOr[Double | String] = js.native
+  var maskUnits: js.UndefOr[Double | String] = js.undefined
   
-  var mathematical: js.UndefOr[Double | String] = js.native
+  var mathematical: js.UndefOr[Double | String] = js.undefined
   
-  var max: js.UndefOr[Double | String] = js.native
+  var max: js.UndefOr[Double | String] = js.undefined
   
-  var media: js.UndefOr[String] = js.native
+  var media: js.UndefOr[String] = js.undefined
   
-  var method: js.UndefOr[String] = js.native
+  var method: js.UndefOr[String] = js.undefined
   
-  var min: js.UndefOr[Double | String] = js.native
+  var min: js.UndefOr[Double | String] = js.undefined
   
-  var mode: js.UndefOr[Double | String] = js.native
+  var mode: js.UndefOr[Double | String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
-  var numOctaves: js.UndefOr[Double | String] = js.native
+  var numOctaves: js.UndefOr[Double | String] = js.undefined
   
-  var offset: js.UndefOr[Double | String] = js.native
+  var offset: js.UndefOr[Double | String] = js.undefined
   
-  var opacity: js.UndefOr[Double | String] = js.native
+  var opacity: js.UndefOr[Double | String] = js.undefined
   
-  var operator: js.UndefOr[Double | String] = js.native
+  var operator: js.UndefOr[Double | String] = js.undefined
   
-  var order: js.UndefOr[Double | String] = js.native
+  var order: js.UndefOr[Double | String] = js.undefined
   
-  var orient: js.UndefOr[Double | String] = js.native
+  var orient: js.UndefOr[Double | String] = js.undefined
   
-  var orientation: js.UndefOr[Double | String] = js.native
+  var orientation: js.UndefOr[Double | String] = js.undefined
   
-  var origin: js.UndefOr[Double | String] = js.native
+  var origin: js.UndefOr[Double | String] = js.undefined
   
-  var overflow: js.UndefOr[Double | String] = js.native
+  var overflow: js.UndefOr[Double | String] = js.undefined
   
-  var overlinePosition: js.UndefOr[Double | String] = js.native
+  var overlinePosition: js.UndefOr[Double | String] = js.undefined
   
-  var overlineThickness: js.UndefOr[Double | String] = js.native
+  var overlineThickness: js.UndefOr[Double | String] = js.undefined
   
-  var paintOrder: js.UndefOr[Double | String] = js.native
+  var paintOrder: js.UndefOr[Double | String] = js.undefined
   
-  var panose1: js.UndefOr[Double | String] = js.native
+  var panose1: js.UndefOr[Double | String] = js.undefined
   
-  var pathLength: js.UndefOr[Double | String] = js.native
+  var pathLength: js.UndefOr[Double | String] = js.undefined
   
-  var patternContentUnits: js.UndefOr[String] = js.native
+  var patternContentUnits: js.UndefOr[String] = js.undefined
   
-  var patternTransform: js.UndefOr[Double | String] = js.native
+  var patternTransform: js.UndefOr[Double | String] = js.undefined
   
-  var patternUnits: js.UndefOr[String] = js.native
+  var patternUnits: js.UndefOr[String] = js.undefined
   
-  var pointerEvents: js.UndefOr[Double | String] = js.native
+  var pointerEvents: js.UndefOr[Double | String] = js.undefined
   
-  var points: js.UndefOr[String] = js.native
+  var points: js.UndefOr[String] = js.undefined
   
-  var pointsAtX: js.UndefOr[Double | String] = js.native
+  var pointsAtX: js.UndefOr[Double | String] = js.undefined
   
-  var pointsAtY: js.UndefOr[Double | String] = js.native
+  var pointsAtY: js.UndefOr[Double | String] = js.undefined
   
-  var pointsAtZ: js.UndefOr[Double | String] = js.native
+  var pointsAtZ: js.UndefOr[Double | String] = js.undefined
   
-  var preserveAlpha: js.UndefOr[Double | String] = js.native
+  var preserveAlpha: js.UndefOr[Double | String] = js.undefined
   
-  var preserveAspectRatio: js.UndefOr[String] = js.native
+  var preserveAspectRatio: js.UndefOr[String] = js.undefined
   
-  var primitiveUnits: js.UndefOr[Double | String] = js.native
+  var primitiveUnits: js.UndefOr[Double | String] = js.undefined
   
-  var r: js.UndefOr[Double | String] = js.native
+  var r: js.UndefOr[Double | String] = js.undefined
   
-  var radius: js.UndefOr[Double | String] = js.native
+  var radius: js.UndefOr[Double | String] = js.undefined
   
-  var refX: js.UndefOr[Double | String] = js.native
+  var refX: js.UndefOr[Double | String] = js.undefined
   
-  var refY: js.UndefOr[Double | String] = js.native
+  var refY: js.UndefOr[Double | String] = js.undefined
   
-  var renderingIntent: js.UndefOr[Double | String] = js.native
+  var renderingIntent: js.UndefOr[Double | String] = js.undefined
   
-  var repeatCount: js.UndefOr[Double | String] = js.native
+  var repeatCount: js.UndefOr[Double | String] = js.undefined
   
-  var repeatDur: js.UndefOr[Double | String] = js.native
+  var repeatDur: js.UndefOr[Double | String] = js.undefined
   
-  var requiredExtensions: js.UndefOr[Double | String] = js.native
+  var requiredExtensions: js.UndefOr[Double | String] = js.undefined
   
-  var requiredFeatures: js.UndefOr[Double | String] = js.native
+  var requiredFeatures: js.UndefOr[Double | String] = js.undefined
   
-  var restart: js.UndefOr[Double | String] = js.native
+  var restart: js.UndefOr[Double | String] = js.undefined
   
-  var result: js.UndefOr[String] = js.native
+  var result: js.UndefOr[String] = js.undefined
   
   // Other HTML properties supported by SVG elements in browsers
-  var role: js.UndefOr[String] = js.native
+  var role: js.UndefOr[String] = js.undefined
   
-  var rotate: js.UndefOr[Double | String] = js.native
+  var rotate: js.UndefOr[Double | String] = js.undefined
   
-  var rx: js.UndefOr[Double | String] = js.native
+  var rx: js.UndefOr[Double | String] = js.undefined
   
-  var ry: js.UndefOr[Double | String] = js.native
+  var ry: js.UndefOr[Double | String] = js.undefined
   
-  var scale: js.UndefOr[Double | String] = js.native
+  var scale: js.UndefOr[Double | String] = js.undefined
   
-  var seed: js.UndefOr[Double | String] = js.native
+  var seed: js.UndefOr[Double | String] = js.undefined
   
-  var shapeRendering: js.UndefOr[Double | String] = js.native
+  var shapeRendering: js.UndefOr[Double | String] = js.undefined
   
-  var slope: js.UndefOr[Double | String] = js.native
+  var slope: js.UndefOr[Double | String] = js.undefined
   
-  var spacing: js.UndefOr[Double | String] = js.native
+  var spacing: js.UndefOr[Double | String] = js.undefined
   
-  var specularConstant: js.UndefOr[Double | String] = js.native
+  var specularConstant: js.UndefOr[Double | String] = js.undefined
   
-  var specularExponent: js.UndefOr[Double | String] = js.native
+  var specularExponent: js.UndefOr[Double | String] = js.undefined
   
-  var speed: js.UndefOr[Double | String] = js.native
+  var speed: js.UndefOr[Double | String] = js.undefined
   
-  var spreadMethod: js.UndefOr[String] = js.native
+  var spreadMethod: js.UndefOr[String] = js.undefined
   
-  var startOffset: js.UndefOr[Double | String] = js.native
+  var startOffset: js.UndefOr[Double | String] = js.undefined
   
-  var stdDeviation: js.UndefOr[Double | String] = js.native
+  var stdDeviation: js.UndefOr[Double | String] = js.undefined
   
-  var stemh: js.UndefOr[Double | String] = js.native
+  var stemh: js.UndefOr[Double | String] = js.undefined
   
-  var stemv: js.UndefOr[Double | String] = js.native
+  var stemv: js.UndefOr[Double | String] = js.undefined
   
-  var stitchTiles: js.UndefOr[Double | String] = js.native
+  var stitchTiles: js.UndefOr[Double | String] = js.undefined
   
-  var stopColor: js.UndefOr[String] = js.native
+  var stopColor: js.UndefOr[String] = js.undefined
   
-  var stopOpacity: js.UndefOr[Double | String] = js.native
+  var stopOpacity: js.UndefOr[Double | String] = js.undefined
   
-  var strikethroughPosition: js.UndefOr[Double | String] = js.native
+  var strikethroughPosition: js.UndefOr[Double | String] = js.undefined
   
-  var strikethroughThickness: js.UndefOr[Double | String] = js.native
+  var strikethroughThickness: js.UndefOr[Double | String] = js.undefined
   
-  var string: js.UndefOr[Double | String] = js.native
+  var string: js.UndefOr[Double | String] = js.undefined
   
-  var stroke: js.UndefOr[String] = js.native
+  var stroke: js.UndefOr[String] = js.undefined
   
-  var strokeDasharray: js.UndefOr[String | Double] = js.native
+  var strokeDasharray: js.UndefOr[String | Double] = js.undefined
   
-  var strokeDashoffset: js.UndefOr[String | Double] = js.native
+  var strokeDashoffset: js.UndefOr[String | Double] = js.undefined
   
-  var strokeLinecap: js.UndefOr[butt | round | square | inherit] = js.native
+  var strokeLinecap: js.UndefOr[butt | round | square | inherit] = js.undefined
   
-  var strokeLinejoin: js.UndefOr[miter | round | bevel | inherit] = js.native
+  var strokeLinejoin: js.UndefOr[miter | round | bevel | inherit] = js.undefined
   
-  var strokeMiterlimit: js.UndefOr[Double | String] = js.native
+  var strokeMiterlimit: js.UndefOr[Double | String] = js.undefined
   
-  var strokeOpacity: js.UndefOr[Double | String] = js.native
+  var strokeOpacity: js.UndefOr[Double | String] = js.undefined
   
-  var strokeWidth: js.UndefOr[Double | String] = js.native
+  var strokeWidth: js.UndefOr[Double | String] = js.undefined
   
-  var style: js.UndefOr[CSSProperties] = js.native
+  var style: js.UndefOr[CSSProperties] = js.undefined
   
-  var surfaceScale: js.UndefOr[Double | String] = js.native
+  var surfaceScale: js.UndefOr[Double | String] = js.undefined
   
-  var systemLanguage: js.UndefOr[Double | String] = js.native
+  var systemLanguage: js.UndefOr[Double | String] = js.undefined
   
-  var tabIndex: js.UndefOr[Double] = js.native
+  var tabIndex: js.UndefOr[Double] = js.undefined
   
-  var tableValues: js.UndefOr[Double | String] = js.native
+  var tableValues: js.UndefOr[Double | String] = js.undefined
   
-  var target: js.UndefOr[String] = js.native
+  var target: js.UndefOr[String] = js.undefined
   
-  var targetX: js.UndefOr[Double | String] = js.native
+  var targetX: js.UndefOr[Double | String] = js.undefined
   
-  var targetY: js.UndefOr[Double | String] = js.native
+  var targetY: js.UndefOr[Double | String] = js.undefined
   
-  var textAnchor: js.UndefOr[String] = js.native
+  var textAnchor: js.UndefOr[String] = js.undefined
   
-  var textDecoration: js.UndefOr[Double | String] = js.native
+  var textDecoration: js.UndefOr[Double | String] = js.undefined
   
-  var textLength: js.UndefOr[Double | String] = js.native
+  var textLength: js.UndefOr[Double | String] = js.undefined
   
-  var textRendering: js.UndefOr[Double | String] = js.native
+  var textRendering: js.UndefOr[Double | String] = js.undefined
   
-  var to: js.UndefOr[Double | String] = js.native
+  var to: js.UndefOr[Double | String] = js.undefined
   
-  var transform: js.UndefOr[String] = js.native
+  var transform: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
   
-  var u1: js.UndefOr[Double | String] = js.native
+  var u1: js.UndefOr[Double | String] = js.undefined
   
-  var u2: js.UndefOr[Double | String] = js.native
+  var u2: js.UndefOr[Double | String] = js.undefined
   
-  var underlinePosition: js.UndefOr[Double | String] = js.native
+  var underlinePosition: js.UndefOr[Double | String] = js.undefined
   
-  var underlineThickness: js.UndefOr[Double | String] = js.native
+  var underlineThickness: js.UndefOr[Double | String] = js.undefined
   
-  var unicode: js.UndefOr[Double | String] = js.native
+  var unicode: js.UndefOr[Double | String] = js.undefined
   
-  var unicodeBidi: js.UndefOr[Double | String] = js.native
+  var unicodeBidi: js.UndefOr[Double | String] = js.undefined
   
-  var unicodeRange: js.UndefOr[Double | String] = js.native
+  var unicodeRange: js.UndefOr[Double | String] = js.undefined
   
-  var unitsPerEm: js.UndefOr[Double | String] = js.native
+  var unitsPerEm: js.UndefOr[Double | String] = js.undefined
   
-  var vAlphabetic: js.UndefOr[Double | String] = js.native
+  var vAlphabetic: js.UndefOr[Double | String] = js.undefined
   
-  var vHanging: js.UndefOr[Double | String] = js.native
+  var vHanging: js.UndefOr[Double | String] = js.undefined
   
-  var vIdeographic: js.UndefOr[Double | String] = js.native
+  var vIdeographic: js.UndefOr[Double | String] = js.undefined
   
-  var vMathematical: js.UndefOr[Double | String] = js.native
+  var vMathematical: js.UndefOr[Double | String] = js.undefined
   
-  var values: js.UndefOr[String] = js.native
+  var values: js.UndefOr[String] = js.undefined
   
-  var vectorEffect: js.UndefOr[Double | String] = js.native
+  var vectorEffect: js.UndefOr[Double | String] = js.undefined
   
-  var version: js.UndefOr[String] = js.native
+  var version: js.UndefOr[String] = js.undefined
   
-  var vertAdvY: js.UndefOr[Double | String] = js.native
+  var vertAdvY: js.UndefOr[Double | String] = js.undefined
   
-  var vertOriginX: js.UndefOr[Double | String] = js.native
+  var vertOriginX: js.UndefOr[Double | String] = js.undefined
   
-  var vertOriginY: js.UndefOr[Double | String] = js.native
+  var vertOriginY: js.UndefOr[Double | String] = js.undefined
   
-  var viewBox: js.UndefOr[String] = js.native
+  var viewBox: js.UndefOr[String] = js.undefined
   
-  var viewTarget: js.UndefOr[Double | String] = js.native
+  var viewTarget: js.UndefOr[Double | String] = js.undefined
   
-  var visibility: js.UndefOr[Double | String] = js.native
+  var visibility: js.UndefOr[Double | String] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
   
-  var widths: js.UndefOr[Double | String] = js.native
+  var widths: js.UndefOr[Double | String] = js.undefined
   
-  var wordSpacing: js.UndefOr[Double | String] = js.native
+  var wordSpacing: js.UndefOr[Double | String] = js.undefined
   
-  var writingMode: js.UndefOr[Double | String] = js.native
+  var writingMode: js.UndefOr[Double | String] = js.undefined
   
-  var x: js.UndefOr[Double | String] = js.native
+  var x: js.UndefOr[Double | String] = js.undefined
   
-  var x1: js.UndefOr[Double | String] = js.native
+  var x1: js.UndefOr[Double | String] = js.undefined
   
-  var x2: js.UndefOr[Double | String] = js.native
+  var x2: js.UndefOr[Double | String] = js.undefined
   
-  var xChannelSelector: js.UndefOr[String] = js.native
+  var xChannelSelector: js.UndefOr[String] = js.undefined
   
-  var xHeight: js.UndefOr[Double | String] = js.native
+  var xHeight: js.UndefOr[Double | String] = js.undefined
   
-  var xlinkActuate: js.UndefOr[String] = js.native
+  var xlinkActuate: js.UndefOr[String] = js.undefined
   
-  var xlinkArcrole: js.UndefOr[String] = js.native
+  var xlinkArcrole: js.UndefOr[String] = js.undefined
   
-  var xlinkHref: js.UndefOr[String] = js.native
+  var xlinkHref: js.UndefOr[String] = js.undefined
   
-  var xlinkRole: js.UndefOr[String] = js.native
+  var xlinkRole: js.UndefOr[String] = js.undefined
   
-  var xlinkShow: js.UndefOr[String] = js.native
+  var xlinkShow: js.UndefOr[String] = js.undefined
   
-  var xlinkTitle: js.UndefOr[String] = js.native
+  var xlinkTitle: js.UndefOr[String] = js.undefined
   
-  var xlinkType: js.UndefOr[String] = js.native
+  var xlinkType: js.UndefOr[String] = js.undefined
   
-  var xmlBase: js.UndefOr[String] = js.native
+  var xmlBase: js.UndefOr[String] = js.undefined
   
-  var xmlLang: js.UndefOr[String] = js.native
+  var xmlLang: js.UndefOr[String] = js.undefined
   
-  var xmlSpace: js.UndefOr[String] = js.native
+  var xmlSpace: js.UndefOr[String] = js.undefined
   
-  var xmlns: js.UndefOr[String] = js.native
+  var xmlns: js.UndefOr[String] = js.undefined
   
-  var xmlnsXlink: js.UndefOr[String] = js.native
+  var xmlnsXlink: js.UndefOr[String] = js.undefined
   
-  var y: js.UndefOr[Double | String] = js.native
+  var y: js.UndefOr[Double | String] = js.undefined
   
-  var y1: js.UndefOr[Double | String] = js.native
+  var y1: js.UndefOr[Double | String] = js.undefined
   
-  var y2: js.UndefOr[Double | String] = js.native
+  var y2: js.UndefOr[Double | String] = js.undefined
   
-  var yChannelSelector: js.UndefOr[String] = js.native
+  var yChannelSelector: js.UndefOr[String] = js.undefined
   
-  var z: js.UndefOr[Double | String] = js.native
+  var z: js.UndefOr[Double | String] = js.undefined
   
-  var zoomAndPan: js.UndefOr[String] = js.native
+  var zoomAndPan: js.UndefOr[String] = js.undefined
 }
 object SVGAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/SVGProps.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/SVGProps.scala
@@ -4,7 +4,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SVGProps[T]
   extends StObject
      with SVGAttributes[T]

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/SchedulerInteraction.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/SchedulerInteraction.scala
@@ -7,14 +7,13 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 /**
   * defined in scheduler/tracing
   */
-@js.native
 trait SchedulerInteraction extends StObject {
   
-  var id: Double = js.native
+  var id: Double
   
-  var name: String = js.native
+  var name: String
   
-  var timestamp: Double = js.native
+  var timestamp: Double
 }
 object SchedulerInteraction {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ScriptHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ScriptHTMLAttributes.scala
@@ -4,28 +4,27 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ScriptHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var async: js.UndefOr[Boolean] = js.native
+  var async: js.UndefOr[Boolean] = js.undefined
   
-  var charSet: js.UndefOr[String] = js.native
+  var charSet: js.UndefOr[String] = js.undefined
   
-  var crossOrigin: js.UndefOr[String] = js.native
+  var crossOrigin: js.UndefOr[String] = js.undefined
   
-  var defer: js.UndefOr[Boolean] = js.native
+  var defer: js.UndefOr[Boolean] = js.undefined
   
-  var integrity: js.UndefOr[String] = js.native
+  var integrity: js.UndefOr[String] = js.undefined
   
-  var noModule: js.UndefOr[Boolean] = js.native
+  var noModule: js.UndefOr[Boolean] = js.undefined
   
-  var nonce: js.UndefOr[String] = js.native
+  var nonce: js.UndefOr[String] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
 }
 object ScriptHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/SelectHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/SelectHTMLAttributes.scala
@@ -7,31 +7,30 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SelectHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var autoComplete: js.UndefOr[String] = js.native
+  var autoComplete: js.UndefOr[String] = js.undefined
   
-  var autoFocus: js.UndefOr[Boolean] = js.native
+  var autoFocus: js.UndefOr[Boolean] = js.undefined
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var multiple: js.UndefOr[Boolean] = js.native
+  var multiple: js.UndefOr[Boolean] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
   @JSName("onChange")
-  var onChange_SelectHTMLAttributes: js.UndefOr[ChangeEventHandler[T]] = js.native
+  var onChange_SelectHTMLAttributes: js.UndefOr[ChangeEventHandler[T]] = js.undefined
   
-  var required: js.UndefOr[Boolean] = js.native
+  var required: js.UndefOr[Boolean] = js.undefined
   
-  var size: js.UndefOr[Double] = js.native
+  var size: js.UndefOr[Double] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object SelectHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/SourceHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/SourceHTMLAttributes.scala
@@ -4,20 +4,19 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SourceHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var media: js.UndefOr[String] = js.native
+  var media: js.UndefOr[String] = js.undefined
   
-  var sizes: js.UndefOr[String] = js.native
+  var sizes: js.UndefOr[String] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var srcSet: js.UndefOr[String] = js.native
+  var srcSet: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
 }
 object SourceHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/StaticLifecycle.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/StaticLifecycle.scala
@@ -6,12 +6,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 // Unfortunately, we have no way of declaring that the component constructor must implement this
-@js.native
 trait StaticLifecycle[P, S] extends StObject {
   
-  var getDerivedStateFromError: js.UndefOr[GetDerivedStateFromError[P, S]] = js.native
+  var getDerivedStateFromError: js.UndefOr[GetDerivedStateFromError[P, S]] = js.undefined
   
-  var getDerivedStateFromProps: js.UndefOr[GetDerivedStateFromProps[P, S]] = js.native
+  var getDerivedStateFromProps: js.UndefOr[GetDerivedStateFromProps[P, S]] = js.undefined
 }
 object StaticLifecycle {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/StyleHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/StyleHTMLAttributes.scala
@@ -4,18 +4,17 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait StyleHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var media: js.UndefOr[String] = js.native
+  var media: js.UndefOr[String] = js.undefined
   
-  var nonce: js.UndefOr[String] = js.native
+  var nonce: js.UndefOr[String] = js.undefined
   
-  var scoped: js.UndefOr[Boolean] = js.native
+  var scoped: js.UndefOr[Boolean] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
 }
 object StyleHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/SuspenseProps.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/SuspenseProps.scala
@@ -10,13 +10,12 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SuspenseProps extends StObject {
   
-  var children: js.UndefOr[Node] = js.native
+  var children: js.UndefOr[Node] = js.undefined
   
   /** A fallback react tree to show when a Suspense child (like React.lazy) suspends */
-  var fallback: (/* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify NonNullable<ReactNode> */ js.Any) | Null = js.native
+  var fallback: (/* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify NonNullable<ReactNode> */ js.Any) | Null
 }
 object SuspenseProps {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TableHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TableHTMLAttributes.scala
@@ -4,16 +4,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TableHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var cellPadding: js.UndefOr[Double | String] = js.native
+  var cellPadding: js.UndefOr[Double | String] = js.undefined
   
-  var cellSpacing: js.UndefOr[Double | String] = js.native
+  var cellSpacing: js.UndefOr[Double | String] = js.undefined
   
-  var summary: js.UndefOr[String] = js.native
+  var summary: js.UndefOr[String] = js.undefined
 }
 object TableHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TdHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TdHTMLAttributes.scala
@@ -13,22 +13,21 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TdHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var align: js.UndefOr[left | center | right | justify | char] = js.native
+  var align: js.UndefOr[left | center | right | justify | char] = js.undefined
   
-  var colSpan: js.UndefOr[Double] = js.native
+  var colSpan: js.UndefOr[Double] = js.undefined
   
-  var headers: js.UndefOr[String] = js.native
+  var headers: js.UndefOr[String] = js.undefined
   
-  var rowSpan: js.UndefOr[Double] = js.native
+  var rowSpan: js.UndefOr[Double] = js.undefined
   
-  var scope: js.UndefOr[String] = js.native
+  var scope: js.UndefOr[String] = js.undefined
   
-  var valign: js.UndefOr[top | middle | bottom | baseline] = js.native
+  var valign: js.UndefOr[top | middle | bottom | baseline] = js.undefined
 }
 object TdHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TextareaHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TextareaHTMLAttributes.scala
@@ -7,41 +7,40 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TextareaHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var autoComplete: js.UndefOr[String] = js.native
+  var autoComplete: js.UndefOr[String] = js.undefined
   
-  var autoFocus: js.UndefOr[Boolean] = js.native
+  var autoFocus: js.UndefOr[Boolean] = js.undefined
   
-  var cols: js.UndefOr[Double] = js.native
+  var cols: js.UndefOr[Double] = js.undefined
   
-  var dirName: js.UndefOr[String] = js.native
+  var dirName: js.UndefOr[String] = js.undefined
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var maxLength: js.UndefOr[Double] = js.native
+  var maxLength: js.UndefOr[Double] = js.undefined
   
-  var minLength: js.UndefOr[Double] = js.native
+  var minLength: js.UndefOr[Double] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
   @JSName("onChange")
-  var onChange_TextareaHTMLAttributes: js.UndefOr[ChangeEventHandler[T]] = js.native
+  var onChange_TextareaHTMLAttributes: js.UndefOr[ChangeEventHandler[T]] = js.undefined
   
-  var readOnly: js.UndefOr[Boolean] = js.native
+  var readOnly: js.UndefOr[Boolean] = js.undefined
   
-  var required: js.UndefOr[Boolean] = js.native
+  var required: js.UndefOr[Boolean] = js.undefined
   
-  var rows: js.UndefOr[Double] = js.native
+  var rows: js.UndefOr[Double] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
   
-  var wrap: js.UndefOr[String] = js.native
+  var wrap: js.UndefOr[String] = js.undefined
 }
 object TextareaHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ThHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/ThHTMLAttributes.scala
@@ -9,20 +9,19 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ThHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var align: js.UndefOr[left | center | right | justify | char] = js.native
+  var align: js.UndefOr[left | center | right | justify | char] = js.undefined
   
-  var colSpan: js.UndefOr[Double] = js.native
+  var colSpan: js.UndefOr[Double] = js.undefined
   
-  var headers: js.UndefOr[String] = js.native
+  var headers: js.UndefOr[String] = js.undefined
   
-  var rowSpan: js.UndefOr[Double] = js.native
+  var rowSpan: js.UndefOr[Double] = js.undefined
   
-  var scope: js.UndefOr[String] = js.native
+  var scope: js.UndefOr[String] = js.undefined
 }
 object ThHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TimeHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TimeHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TimeHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var dateTime: js.UndefOr[String] = js.native
+  var dateTime: js.UndefOr[String] = js.undefined
 }
 object TimeHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/Touch.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/Touch.scala
@@ -5,24 +5,23 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Touch extends StObject {
   
-  var clientX: Double = js.native
+  var clientX: Double
   
-  var clientY: Double = js.native
+  var clientY: Double
   
-  var identifier: Double = js.native
+  var identifier: Double
   
-  var pageX: Double = js.native
+  var pageX: Double
   
-  var pageY: Double = js.native
+  var pageY: Double
   
-  var screenX: Double = js.native
+  var screenX: Double
   
-  var screenY: Double = js.native
+  var screenY: Double
   
-  var target: EventTarget = js.native
+  var target: EventTarget
 }
 object Touch {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TouchEvent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TouchEvent.scala
@@ -7,29 +7,28 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TouchEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeTouchEvent, EventTarget & T, EventTarget] {
   
-  var altKey: Boolean = js.native
+  var altKey: Boolean
   
-  var changedTouches: TouchList = js.native
+  var changedTouches: TouchList
   
-  var ctrlKey: Boolean = js.native
+  var ctrlKey: Boolean
   
   /**
     * See [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#keys-modifier). for a list of valid (case-sensitive) arguments to this method.
     */
-  def getModifierState(key: String): Boolean = js.native
+  def getModifierState(key: String): Boolean
   
-  var metaKey: Boolean = js.native
+  var metaKey: Boolean
   
-  var shiftKey: Boolean = js.native
+  var shiftKey: Boolean
   
-  var targetTouches: TouchList = js.native
+  var targetTouches: TouchList
   
-  var touches: TouchList = js.native
+  var touches: TouchList
 }
 object TouchEvent {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TouchList.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TouchList.scala
@@ -5,16 +5,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TouchList
   extends StObject
      with /* index */ NumberDictionary[Touch] {
   
-  def identifiedTouch(identifier: Double): Touch = js.native
+  def identifiedTouch(identifier: Double): Touch
   
-  def item(index: Double): Touch = js.native
+  def item(index: Double): Touch
   
-  var length: Double = js.native
+  var length: Double
 }
 object TouchList {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TrackHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TrackHTMLAttributes.scala
@@ -4,20 +4,19 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TrackHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var default: js.UndefOr[Boolean] = js.native
+  var default: js.UndefOr[Boolean] = js.undefined
   
-  var kind: js.UndefOr[String] = js.native
+  var kind: js.UndefOr[String] = js.undefined
   
-  var label: js.UndefOr[String] = js.native
+  var label: js.UndefOr[String] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var srcLang: js.UndefOr[String] = js.native
+  var srcLang: js.UndefOr[String] = js.undefined
 }
 object TrackHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TransitionEvent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/TransitionEvent.scala
@@ -7,16 +7,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TransitionEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeTransitionEvent, EventTarget & T, EventTarget] {
   
-  var elapsedTime: Double = js.native
+  var elapsedTime: Double
   
-  var propertyName: String = js.native
+  var propertyName: String
   
-  var pseudoElement: String = js.native
+  var pseudoElement: String
 }
 object TransitionEvent {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/UIEvent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/UIEvent.scala
@@ -7,14 +7,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait UIEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeUIEvent, EventTarget & T, EventTarget] {
   
-  var detail: Double = js.native
+  var detail: Double
   
-  var view: AbstractView = js.native
+  var view: AbstractView
 }
 object UIEvent {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/VideoHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/VideoHTMLAttributes.scala
@@ -4,20 +4,19 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait VideoHTMLAttributes[T]
   extends StObject
      with MediaHTMLAttributes[T] {
   
-  var disablePictureInPicture: js.UndefOr[Boolean] = js.native
+  var disablePictureInPicture: js.UndefOr[Boolean] = js.undefined
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var playsInline: js.UndefOr[Boolean] = js.native
+  var playsInline: js.UndefOr[Boolean] = js.undefined
   
-  var poster: js.UndefOr[String] = js.native
+  var poster: js.UndefOr[String] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
 }
 object VideoHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/WebViewHTMLAttributes.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/WebViewHTMLAttributes.scala
@@ -4,44 +4,43 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait WebViewHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var allowFullScreen: js.UndefOr[Boolean] = js.native
+  var allowFullScreen: js.UndefOr[Boolean] = js.undefined
   
-  var allowpopups: js.UndefOr[Boolean] = js.native
+  var allowpopups: js.UndefOr[Boolean] = js.undefined
   
-  var autoFocus: js.UndefOr[Boolean] = js.native
+  var autoFocus: js.UndefOr[Boolean] = js.undefined
   
-  var autosize: js.UndefOr[Boolean] = js.native
+  var autosize: js.UndefOr[Boolean] = js.undefined
   
-  var blinkfeatures: js.UndefOr[String] = js.native
+  var blinkfeatures: js.UndefOr[String] = js.undefined
   
-  var disableblinkfeatures: js.UndefOr[String] = js.native
+  var disableblinkfeatures: js.UndefOr[String] = js.undefined
   
-  var disableguestresize: js.UndefOr[Boolean] = js.native
+  var disableguestresize: js.UndefOr[Boolean] = js.undefined
   
-  var disablewebsecurity: js.UndefOr[Boolean] = js.native
+  var disablewebsecurity: js.UndefOr[Boolean] = js.undefined
   
-  var guestinstance: js.UndefOr[String] = js.native
+  var guestinstance: js.UndefOr[String] = js.undefined
   
-  var httpreferrer: js.UndefOr[String] = js.native
+  var httpreferrer: js.UndefOr[String] = js.undefined
   
-  var nodeintegration: js.UndefOr[Boolean] = js.native
+  var nodeintegration: js.UndefOr[Boolean] = js.undefined
   
-  var partition: js.UndefOr[String] = js.native
+  var partition: js.UndefOr[String] = js.undefined
   
-  var plugins: js.UndefOr[Boolean] = js.native
+  var plugins: js.UndefOr[Boolean] = js.undefined
   
-  var preload: js.UndefOr[String] = js.native
+  var preload: js.UndefOr[String] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var useragent: js.UndefOr[String] = js.native
+  var useragent: js.UndefOr[String] = js.undefined
   
-  var webpreferences: js.UndefOr[String] = js.native
+  var webpreferences: js.UndefOr[String] = js.undefined
 }
 object WebViewHTMLAttributes {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/WheelEvent.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/WheelEvent.scala
@@ -7,18 +7,17 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait WheelEvent[T]
   extends StObject
      with MouseEvent[T, NativeWheelEvent] {
   
-  var deltaMode: Double = js.native
+  var deltaMode: Double
   
-  var deltaX: Double = js.native
+  var deltaX: Double
   
-  var deltaY: Double = js.native
+  var deltaY: Double
   
-  var deltaZ: Double = js.native
+  var deltaZ: Double
 }
 object WheelEvent {
   

--- a/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/global.scala
+++ b/tests/react-integration-test/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod/global.scala
@@ -17,10 +17,8 @@ object global {
     // tslint:disable-next-line:no-empty-interface
     type Element = japgolly.scalajs.react.raw.React.Element
     
-    @js.native
     trait ElementAttributesProperty extends StObject
     
-    @js.native
     trait ElementChildrenAttribute extends StObject
     
     @js.native
@@ -33,35 +31,34 @@ object global {
     // tslint:disable-next-line:no-empty-interface
     type IntrinsicClassAttributes[T] = ClassAttributes[T]
     
-    @js.native
     trait IntrinsicElements extends StObject {
       
       // HTML
-      var a: DetailedHTMLProps[AnchorHTMLAttributes[HTMLAnchorElement], HTMLAnchorElement] = js.native
+      var a: DetailedHTMLProps[AnchorHTMLAttributes[HTMLAnchorElement], HTMLAnchorElement]
       
-      var abbr: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var abbr: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var address: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var address: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var area: DetailedHTMLProps[AreaHTMLAttributes[HTMLAreaElement], HTMLAreaElement] = js.native
+      var area: DetailedHTMLProps[AreaHTMLAttributes[HTMLAreaElement], HTMLAreaElement]
       
-      var article: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var article: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var aside: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var aside: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var audio: DetailedHTMLProps[AudioHTMLAttributes[HTMLAudioElement], HTMLAudioElement] = js.native
+      var audio: DetailedHTMLProps[AudioHTMLAttributes[HTMLAudioElement], HTMLAudioElement]
       
-      var b: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var b: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var base: DetailedHTMLProps[BaseHTMLAttributes[HTMLBaseElement], HTMLBaseElement] = js.native
+      var base: DetailedHTMLProps[BaseHTMLAttributes[HTMLBaseElement], HTMLBaseElement]
       
-      var bdi: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var bdi: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var bdo: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var bdo: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var big: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var big: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var view: SVGProps[SVGViewElement] = js.native
+      var view: SVGProps[SVGViewElement]
     }
     object IntrinsicElements {
       

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-acf900"
+version := "0.0-unknown-8483b9"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d6e1e0",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-46b6e2",
+  "org.scalablytyped" %%% "react" % "16.9.2-242f5f",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7863fe",
   ("com.github.japgolly.scalajs-react" %%% "core" % "1.7.5").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/accordionAccordionAccordionMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/accordionAccordionAccordionMod.scala
@@ -35,7 +35,6 @@ object accordionAccordionAccordionMod extends Shortcut {
   @js.native
   val default: ComponentClassP[AccordionAccordionProps & js.Object] = js.native
   
-  @js.native
   trait AccordionAccordionProps
     extends StObject
        with StrictAccordionAccordionProps
@@ -49,26 +48,25 @@ object accordionAccordionAccordionMod extends Shortcut {
     }
   }
   
-  @js.native
   trait StrictAccordionAccordionProps extends StObject {
     
     /** Index of the currently active panel. */
-    var activeIndex: js.UndefOr[Double | js.Array[Double]] = js.native
+    var activeIndex: js.UndefOr[Double | js.Array[Double]] = js.undefined
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Primary content. */
-    var children: js.UndefOr[Node] = js.native
+    var children: js.UndefOr[Node] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Initial activeIndex value. */
-    var defaultActiveIndex: js.UndefOr[Double | js.Array[Double]] = js.native
+    var defaultActiveIndex: js.UndefOr[Double | js.Array[Double]] = js.undefined
     
     /** Only allow one panel open at a time. */
-    var exclusive: js.UndefOr[Boolean] = js.native
+    var exclusive: js.UndefOr[Boolean] = js.undefined
     
     /**
       * Called when a panel title is clicked.
@@ -82,10 +80,10 @@ object accordionAccordionAccordionMod extends Shortcut {
           /* data */ AccordionTitleProps, 
           Unit
         ]
-      ] = js.native
+      ] = js.undefined
     
     /** Shorthand array of props for Accordion. */
-    var panels: js.UndefOr[SemanticShorthandCollection[AccordionPanelProps]] = js.native
+    var panels: js.UndefOr[SemanticShorthandCollection[AccordionPanelProps]] = js.undefined
   }
   object StrictAccordionAccordionProps {
     

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/accordionAccordionMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/accordionAccordionMod.scala
@@ -66,7 +66,6 @@ object accordionAccordionMod {
     var Title: ComponentClassP[AccordionTitleProps & js.Object] = js.native
   }
   
-  @js.native
   trait AccordionProps
     extends StObject
        with StrictAccordionProps
@@ -80,19 +79,18 @@ object accordionAccordionMod {
     }
   }
   
-  @js.native
   trait StrictAccordionProps
     extends StObject
        with StrictAccordionAccordionProps {
     
     /** Format to take up the width of its container. */
-    var fluid: js.UndefOr[Boolean] = js.native
+    var fluid: js.UndefOr[Boolean] = js.undefined
     
     /** Format for dark backgrounds. */
-    var inverted: js.UndefOr[Boolean] = js.native
+    var inverted: js.UndefOr[Boolean] = js.undefined
     
     /** Adds some basic styling to accordion panels. */
-    var styled: js.UndefOr[Boolean] = js.native
+    var styled: js.UndefOr[Boolean] = js.undefined
   }
   object StrictAccordionProps {
     

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/accordionContentMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/accordionContentMod.scala
@@ -20,7 +20,6 @@ object accordionContentMod extends Shortcut {
   @js.native
   val default: StatelessComponent[AccordionContentProps] = js.native
   
-  @js.native
   trait AccordionContentProps
     extends StObject
        with StrictAccordionContentProps
@@ -34,23 +33,22 @@ object accordionContentMod extends Shortcut {
     }
   }
   
-  @js.native
   trait StrictAccordionContentProps extends StObject {
     
     /** Whether or not the content is visible. */
-    var active: js.UndefOr[Boolean] = js.native
+    var active: js.UndefOr[Boolean] = js.undefined
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Primary content. */
-    var children: js.UndefOr[Node] = js.native
+    var children: js.UndefOr[Node] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Shorthand for primary content. */
-    var content: js.UndefOr[SemanticShorthandContent] = js.native
+    var content: js.UndefOr[SemanticShorthandContent] = js.undefined
   }
   object StrictAccordionContentProps {
     

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/accordionPanelMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/accordionPanelMod.scala
@@ -28,7 +28,6 @@ object accordionPanelMod {
   
   type AccordionPanel = japgolly.scalajs.react.raw.React.Component[AccordionPanelProps & js.Object, js.Object]
   
-  @js.native
   trait AccordionPanelProps
     extends StObject
        with StrictAccordionPanelProps
@@ -42,17 +41,16 @@ object accordionPanelMod {
     }
   }
   
-  @js.native
   trait StrictAccordionPanelProps extends StObject {
     
     /** Whether or not the title is in the open state. */
-    var active: js.UndefOr[Boolean] = js.native
+    var active: js.UndefOr[Boolean] = js.undefined
     
     /** A shorthand for Accordion.Content. */
-    var content: js.UndefOr[SemanticShorthandItem[AccordionContentProps]] = js.native
+    var content: js.UndefOr[SemanticShorthandItem[AccordionContentProps]] = js.undefined
     
     /** A panel index. */
-    var index: js.UndefOr[Double | String] = js.native
+    var index: js.UndefOr[Double | String] = js.undefined
     
     /**
       * Called when a panel title is clicked.
@@ -66,10 +64,10 @@ object accordionPanelMod {
           /* data */ AccordionTitleProps, 
           Unit
         ]
-      ] = js.native
+      ] = js.undefined
     
     /** A shorthand for Accordion.Title. */
-    var title: js.UndefOr[SemanticShorthandItem[AccordionTitleProps]] = js.native
+    var title: js.UndefOr[SemanticShorthandItem[AccordionTitleProps]] = js.undefined
   }
   object StrictAccordionPanelProps {
     

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/accordionTitleMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/accordionTitleMod.scala
@@ -35,7 +35,6 @@ object accordionTitleMod extends Shortcut {
   @js.native
   val default: ComponentClassP[AccordionTitleProps & js.Object] = js.native
   
-  @js.native
   trait AccordionTitleProps
     extends StObject
        with StrictAccordionTitleProps
@@ -49,33 +48,32 @@ object accordionTitleMod extends Shortcut {
     }
   }
   
-  @js.native
   trait StrictAccordionTitleProps extends StObject {
     
     /** Whether or not the title is in the open state. */
-    var active: js.UndefOr[Boolean] = js.native
+    var active: js.UndefOr[Boolean] = js.undefined
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Primary content. */
-    var children: js.UndefOr[Node] = js.native
+    var children: js.UndefOr[Node] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Shorthand for primary content. */
-    var content: js.UndefOr[SemanticShorthandContent] = js.native
+    var content: js.UndefOr[SemanticShorthandContent] = js.undefined
     
     /** Shorthand for Icon. */
     var icon: js.UndefOr[
         SemanticShorthandItem[
           /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify IconProps */ js.Any
         ]
-      ] = js.native
+      ] = js.undefined
     
     /** AccordionTitle index inside Accordion. */
-    var index: js.UndefOr[Double | String] = js.native
+    var index: js.UndefOr[Double | String] = js.undefined
     
     /**
       * Called on click.
@@ -89,7 +87,7 @@ object accordionTitleMod extends Shortcut {
           /* data */ AccordionTitleProps, 
           Unit
         ]
-      ] = js.native
+      ] = js.undefined
   }
   object StrictAccordionTitleProps {
     

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/buttonContentMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/buttonContentMod.scala
@@ -20,7 +20,6 @@ object buttonContentMod extends Shortcut {
   @js.native
   val default: StatelessComponent[ButtonContentProps] = js.native
   
-  @js.native
   trait ButtonContentProps
     extends StObject
        with StrictButtonContentProps
@@ -34,26 +33,25 @@ object buttonContentMod extends Shortcut {
     }
   }
   
-  @js.native
   trait StrictButtonContentProps extends StObject {
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Primary content. */
-    var children: js.UndefOr[Node] = js.native
+    var children: js.UndefOr[Node] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Shorthand for primary content. */
-    var content: js.UndefOr[SemanticShorthandContent] = js.native
+    var content: js.UndefOr[SemanticShorthandContent] = js.undefined
     
     /** Initially hidden, visible on hover. */
-    var hidden: js.UndefOr[Boolean] = js.native
+    var hidden: js.UndefOr[Boolean] = js.undefined
     
     /** Initially visible, hidden on hover. */
-    var visible: js.UndefOr[Boolean] = js.native
+    var visible: js.UndefOr[Boolean] = js.undefined
   }
   object StrictButtonContentProps {
     

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/buttonGroupMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/buttonGroupMod.scala
@@ -31,7 +31,6 @@ object buttonGroupMod extends Shortcut {
   @js.native
   val default: StatelessComponent[ButtonGroupProps] = js.native
   
-  @js.native
   trait ButtonGroupProps
     extends StObject
        with StrictButtonGroupProps
@@ -45,74 +44,73 @@ object buttonGroupMod extends Shortcut {
     }
   }
   
-  @js.native
   trait StrictButtonGroupProps extends StObject {
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Groups can be attached to other content. */
-    var attached: js.UndefOr[Boolean | left | right | top | bottom] = js.native
+    var attached: js.UndefOr[Boolean | left | right | top | bottom] = js.undefined
     
     /** Groups can be less pronounced. */
-    var basic: js.UndefOr[Boolean] = js.native
+    var basic: js.UndefOr[Boolean] = js.undefined
     
     /** Array of shorthand Button values. */
-    var buttons: js.UndefOr[SemanticShorthandCollection[ButtonProps]] = js.native
+    var buttons: js.UndefOr[SemanticShorthandCollection[ButtonProps]] = js.undefined
     
     /** Primary content. */
-    var children: js.UndefOr[Node] = js.native
+    var children: js.UndefOr[Node] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Groups can have a shared color. */
-    var color: js.UndefOr[SemanticCOLORS] = js.native
+    var color: js.UndefOr[SemanticCOLORS] = js.undefined
     
     /** Groups can reduce their padding to fit into tighter spaces. */
-    var compact: js.UndefOr[Boolean] = js.native
+    var compact: js.UndefOr[Boolean] = js.undefined
     
     /** Shorthand for primary content. */
-    var content: js.UndefOr[SemanticShorthandContent] = js.native
+    var content: js.UndefOr[SemanticShorthandContent] = js.undefined
     
     /** Groups can be aligned to the left or right of its container. */
-    var floated: js.UndefOr[SemanticFLOATS] = js.native
+    var floated: js.UndefOr[SemanticFLOATS] = js.undefined
     
     /** Groups can take the width of their container. */
-    var fluid: js.UndefOr[Boolean] = js.native
+    var fluid: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can be formatted as icons. */
-    var icon: js.UndefOr[Boolean] = js.native
+    var icon: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can be formatted to appear on dark backgrounds. */
-    var inverted: js.UndefOr[Boolean] = js.native
+    var inverted: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can be formatted as labeled icon buttons. */
-    var labeled: js.UndefOr[Boolean] = js.native
+    var labeled: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can hint towards a negative consequence. */
-    var negative: js.UndefOr[Boolean] = js.native
+    var negative: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can hint towards a positive consequence. */
-    var positive: js.UndefOr[Boolean] = js.native
+    var positive: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can be formatted to show different levels of emphasis. */
-    var primary: js.UndefOr[Boolean] = js.native
+    var primary: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can be formatted to show different levels of emphasis. */
-    var secondary: js.UndefOr[Boolean] = js.native
+    var secondary: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can have different sizes. */
-    var size: js.UndefOr[SemanticSIZES] = js.native
+    var size: js.UndefOr[SemanticSIZES] = js.undefined
     
     /** Groups can be formatted to toggle on and off. */
-    var toggle: js.UndefOr[Boolean] = js.native
+    var toggle: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can be formatted to appear vertically. */
-    var vertical: js.UndefOr[Boolean] = js.native
+    var vertical: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can have their widths divided evenly. */
-    var widths: js.UndefOr[SemanticWIDTHS] = js.native
+    var widths: js.UndefOr[SemanticWIDTHS] = js.undefined
   }
   object StrictButtonGroupProps {
     

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/buttonMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/buttonMod.scala
@@ -70,72 +70,71 @@ object buttonMod {
   
   type ButtonProps = StrictButtonProps
   
-  @js.native
   trait StrictButtonProps
     extends StObject
        with ButtonHTMLAttributes[HTMLButtonElement] {
     
     /** A button can show it is currently the active user selection. */
-    var active: js.UndefOr[Boolean] = js.native
+    var active: js.UndefOr[Boolean] = js.undefined
     
     /** A button can animate to show hidden content. */
-    var animated: js.UndefOr[Boolean | fade | vertical] = js.native
+    var animated: js.UndefOr[Boolean | fade | vertical] = js.undefined
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** A button can be attached to other content. */
-    var attached: js.UndefOr[Boolean | left | right | top | bottom] = js.native
+    var attached: js.UndefOr[Boolean | left | right | top | bottom] = js.undefined
     
     /** A basic button is less pronounced. */
-    var basic: js.UndefOr[Boolean] = js.native
+    var basic: js.UndefOr[Boolean] = js.undefined
     
     /** A button can be circular. */
-    var circular: js.UndefOr[Boolean] = js.native
+    var circular: js.UndefOr[Boolean] = js.undefined
     
     /** A button can have different colors. */
     @JSName("color")
     var color_StrictButtonProps: js.UndefOr[
         SemanticCOLORS | facebook | (`google plus`) | vk | twitter | linkedin | instagram | youtube
-      ] = js.native
+      ] = js.undefined
     
     /** A button can reduce its padding to fit into tighter spaces. */
-    var compact: js.UndefOr[Boolean] = js.native
+    var compact: js.UndefOr[Boolean] = js.undefined
     
     /** Shorthand for primary content. */
-    var content: js.UndefOr[SemanticShorthandContent] = js.native
+    var content: js.UndefOr[SemanticShorthandContent] = js.undefined
     
     /** A button can be aligned to the left or right of its container. */
-    var floated: js.UndefOr[SemanticFLOATS] = js.native
+    var floated: js.UndefOr[SemanticFLOATS] = js.undefined
     
     /** A button can take the width of its container. */
-    var fluid: js.UndefOr[Boolean] = js.native
+    var fluid: js.UndefOr[Boolean] = js.undefined
     
     /** Add an Icon by name, props object, or pass an <Icon />. */
     var icon: js.UndefOr[
         Boolean | (SemanticShorthandItem[
           /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify IconProps */ js.Any
         ])
-      ] = js.native
+      ] = js.undefined
     
     /** A button can be formatted to appear on dark backgrounds. */
-    var inverted: js.UndefOr[Boolean] = js.native
+    var inverted: js.UndefOr[Boolean] = js.undefined
     
     /** Add a Label by text, props object, or pass a <Label />. */
     var label: js.UndefOr[
         SemanticShorthandItem[
           /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify LabelProps */ js.Any
         ]
-      ] = js.native
+      ] = js.undefined
     
     /** A labeled button can format a Label or Icon to appear on the left or right. */
-    var labelPosition: js.UndefOr[right | left] = js.native
+    var labelPosition: js.UndefOr[right | left] = js.undefined
     
     /** A button can show a loading indicator. */
-    var loading: js.UndefOr[Boolean] = js.native
+    var loading: js.UndefOr[Boolean] = js.undefined
     
     /** A button can hint towards a negative consequence. */
-    var negative: js.UndefOr[Boolean] = js.native
+    var negative: js.UndefOr[Boolean] = js.undefined
     
     /**
       * Called after user's click.
@@ -145,26 +144,26 @@ object buttonMod {
     @JSName("onClick")
     var onClick_StrictButtonProps: js.UndefOr[
         js.Function2[/* event */ ReactMouseEventFrom[HTMLButtonElement], /* data */ ButtonProps, Unit]
-      ] = js.native
+      ] = js.undefined
     
     /** A button can hint towards a positive consequence. */
-    var positive: js.UndefOr[Boolean] = js.native
+    var positive: js.UndefOr[Boolean] = js.undefined
     
     /** A button can be formatted to show different levels of emphasis. */
-    var primary: js.UndefOr[Boolean] = js.native
+    var primary: js.UndefOr[Boolean] = js.undefined
     
     /** A button can be formatted to show different levels of emphasis. */
-    var secondary: js.UndefOr[Boolean] = js.native
+    var secondary: js.UndefOr[Boolean] = js.undefined
     
     /** A button can have different sizes. */
-    var size: js.UndefOr[SemanticSIZES] = js.native
+    var size: js.UndefOr[SemanticSIZES] = js.undefined
     
     /** A button can receive focus. */
     @JSName("tabIndex")
-    var tabIndex_StrictButtonProps: js.UndefOr[Double | String] = js.native
+    var tabIndex_StrictButtonProps: js.UndefOr[Double | String] = js.undefined
     
     /** A button can be formatted to toggle on and off. */
-    var toggle: js.UndefOr[Boolean] = js.native
+    var toggle: js.UndefOr[Boolean] = js.undefined
   }
   object StrictButtonProps {
     

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/buttonOrMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/buttonOrMod.scala
@@ -13,7 +13,6 @@ object buttonOrMod extends Shortcut {
   @js.native
   val default: StatelessComponent[ButtonOrProps] = js.native
   
-  @js.native
   trait ButtonOrProps
     extends StObject
        with StrictButtonOrProps
@@ -27,17 +26,16 @@ object buttonOrMod extends Shortcut {
     }
   }
   
-  @js.native
   trait StrictButtonOrProps extends StObject {
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Or buttons can have their text localized, or adjusted by using the text prop. */
-    var text: js.UndefOr[Double | String] = js.native
+    var text: js.UndefOr[Double | String] = js.undefined
   }
   object StrictButtonOrProps {
     

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/containerContainerMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/containerContainerMod.scala
@@ -21,7 +21,6 @@ object containerContainerMod extends Shortcut {
   @js.native
   val default: StatelessComponent[ContainerProps] = js.native
   
-  @js.native
   trait ContainerProps
     extends StObject
        with StrictContainerProps
@@ -35,29 +34,28 @@ object containerContainerMod extends Shortcut {
     }
   }
   
-  @js.native
   trait StrictContainerProps extends StObject {
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Primary content. */
-    var children: js.UndefOr[Node] = js.native
+    var children: js.UndefOr[Node] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Shorthand for primary content. */
-    var content: js.UndefOr[SemanticShorthandContent] = js.native
+    var content: js.UndefOr[SemanticShorthandContent] = js.undefined
     
     /** Container has no maximum width. */
-    var fluid: js.UndefOr[Boolean] = js.native
+    var fluid: js.UndefOr[Boolean] = js.undefined
     
     /** Reduce maximum width to more naturally accommodate text. */
-    var text: js.UndefOr[Boolean] = js.native
+    var text: js.UndefOr[Boolean] = js.undefined
     
     /** Describes how the text inside this component should be aligned. */
-    var textAlign: js.UndefOr[SemanticTEXTALIGNMENTS] = js.native
+    var textAlign: js.UndefOr[SemanticTEXTALIGNMENTS] = js.undefined
   }
   object StrictContainerProps {
     

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/HtmlIframeProps.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/HtmlIframeProps.scala
@@ -5,7 +5,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HtmlIframeProps
   extends StObject
      with StrictHtmlIframeProps

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/HtmlImageProps.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/HtmlImageProps.scala
@@ -5,7 +5,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HtmlImageProps
   extends StObject
      with StrictHtmlImageProps

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/HtmlInputrops.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/HtmlInputrops.scala
@@ -5,7 +5,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HtmlInputrops
   extends StObject
      with StrictHtmlInputrops

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/HtmlLabelProps.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/HtmlLabelProps.scala
@@ -5,7 +5,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HtmlLabelProps
   extends StObject
      with StrictHtmlLabelProps

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/HtmlSpanProps.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/HtmlSpanProps.scala
@@ -5,7 +5,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HtmlSpanProps
   extends StObject
      with StrictHtmlSpanProps

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/StrictHtmlIframeProps.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/StrictHtmlIframeProps.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait StrictHtmlIframeProps extends StObject {
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
 }
 object StrictHtmlIframeProps {
   

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/StrictHtmlImageProps.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/StrictHtmlImageProps.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait StrictHtmlImageProps extends StObject {
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
 }
 object StrictHtmlImageProps {
   

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/StrictHtmlInputrops.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/StrictHtmlInputrops.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait StrictHtmlInputrops extends StObject {
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
 }
 object StrictHtmlInputrops {
   

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/StrictHtmlLabelProps.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/StrictHtmlLabelProps.scala
@@ -10,10 +10,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait StrictHtmlLabelProps extends StObject {
   
-  var children: js.UndefOr[Node] = js.native
+  var children: js.UndefOr[Node] = js.undefined
 }
 object StrictHtmlLabelProps {
   

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/StrictHtmlSpanProps.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/genericMod/StrictHtmlSpanProps.scala
@@ -10,10 +10,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait StrictHtmlSpanProps extends StObject {
   
-  var children: js.UndefOr[Node] = js.native
+  var children: js.UndefOr[Node] = js.undefined
 }
 object StrictHtmlSpanProps {
   

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/inputInputMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/inputInputMod.scala
@@ -43,13 +43,12 @@ object inputInputMod {
     def select(): Unit = js.native
   }
   
-  @js.native
   trait InputOnChangeData
     extends StObject
        with StrictInputProps {
     
     @JSName("value")
-    var value_InputOnChangeData: String = js.native
+    var value_InputOnChangeData: String
   }
   object InputOnChangeData {
     
@@ -69,53 +68,52 @@ object inputInputMod {
   
   type InputProps = StrictInputProps
   
-  @js.native
   trait StrictInputProps
     extends StObject
        with InputHTMLAttributes[HTMLInputElement] {
     
     /** An Input can be formatted to alert the user to an action they may perform. */
-    var action: js.UndefOr[js.Any | Boolean] = js.native
+    var action: js.UndefOr[js.Any | Boolean] = js.undefined
     
     /** An action can appear along side an Input on the left or right. */
-    var actionPosition: js.UndefOr[left] = js.native
+    var actionPosition: js.UndefOr[left] = js.undefined
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** An Input field can show the data contains errors. */
-    var error: js.UndefOr[Boolean] = js.native
+    var error: js.UndefOr[Boolean] = js.undefined
     
     /** Take on the size of its container. */
-    var fluid: js.UndefOr[Boolean] = js.native
+    var fluid: js.UndefOr[Boolean] = js.undefined
     
     /** An Input field can show a user is currently interacting with it. */
-    var focus: js.UndefOr[Boolean] = js.native
+    var focus: js.UndefOr[Boolean] = js.undefined
     
     /** Optional Icon to display inside the Input. */
-    var icon: js.UndefOr[js.Any | SemanticShorthandItem[InputProps]] = js.native
+    var icon: js.UndefOr[js.Any | SemanticShorthandItem[InputProps]] = js.undefined
     
     /** An Icon can appear inside an Input on the left. */
-    var iconPosition: js.UndefOr[left] = js.native
+    var iconPosition: js.UndefOr[left] = js.undefined
     
     /** Shorthand for creating the HTML Input. */
-    var input: js.UndefOr[SemanticShorthandItem[HtmlInputrops]] = js.native
+    var input: js.UndefOr[SemanticShorthandItem[HtmlInputrops]] = js.undefined
     
     /** Format to appear on dark backgrounds. */
-    var inverted: js.UndefOr[Boolean] = js.native
+    var inverted: js.UndefOr[Boolean] = js.undefined
     
     /** Optional Label to display along side the Input. */
     var label: js.UndefOr[
         SemanticShorthandItem[
           /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify LabelProps */ js.Any
         ]
-      ] = js.native
+      ] = js.undefined
     
     /** A Label can appear outside an Input on the left or right. */
-    var labelPosition: js.UndefOr[left | right | (`left corner`) | (`right corner`)] = js.native
+    var labelPosition: js.UndefOr[left | right | (`left corner`) | (`right corner`)] = js.undefined
     
     /** An Icon Input field can show that it is currently loading data. */
-    var loading: js.UndefOr[Boolean] = js.native
+    var loading: js.UndefOr[Boolean] = js.undefined
     
     /**
       * Called on change.
@@ -126,18 +124,18 @@ object inputInputMod {
     @JSName("onChange")
     var onChange_StrictInputProps: js.UndefOr[
         js.Function2[/* event */ ReactEventFrom[HTMLInputElement], /* data */ InputOnChangeData, Unit]
-      ] = js.native
+      ] = js.undefined
     
     /** An Input can vary in size. */
     @JSName("size")
-    var size_StrictInputProps: js.UndefOr[mini | small | large | big | huge | massive] = js.native
+    var size_StrictInputProps: js.UndefOr[mini | small | large | big | huge | massive] = js.undefined
     
     /** An Input can receive focus. */
     @JSName("tabIndex")
-    var tabIndex_StrictInputProps: js.UndefOr[Double | String] = js.native
+    var tabIndex_StrictInputProps: js.UndefOr[Double | String] = js.undefined
     
     /** Transparent Input has no background. */
-    var transparent: js.UndefOr[Boolean] = js.native
+    var transparent: js.UndefOr[Boolean] = js.undefined
   }
   object StrictInputProps {
     

--- a/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/testContainerTestContainerMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/semantic-ui-react/src/main/scala/typingsJapgolly/semanticUiReact/testContainerTestContainerMod.scala
@@ -23,53 +23,52 @@ object testContainerTestContainerMod extends Shortcut {
   @js.native
   val default: StatelessComponent[TestContainerProps] = js.native
   
-  @js.native
   trait StrictTestContainerProps extends StObject {
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Primary content. */
-    var children: js.UndefOr[Node] = js.native
+    var children: js.UndefOr[Node] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Shorthand for primary content. */
-    var content: js.UndefOr[SemanticShorthandContent] = js.native
+    var content: js.UndefOr[SemanticShorthandContent] = js.undefined
     
     /** TestContainer has no maximum width. */
-    var fluid: js.UndefOr[Boolean] = js.native
+    var fluid: js.UndefOr[Boolean] = js.undefined
     
     /**Should be CallbackTo[Number]*/
-    var optFn0Number: js.UndefOr[js.Function0[Double]] = js.native
+    var optFn0Number: js.UndefOr[js.Function0[Double]] = js.undefined
     
     /**Should be Callback*/
-    var optFn0Void: js.UndefOr[js.Function0[Unit]] = js.native
+    var optFn0Void: js.UndefOr[js.Function0[Unit]] = js.undefined
     
     /**Should be (x:Number) => CallbackTo[Number]*/
-    var optFn1Number: js.UndefOr[js.Function1[/* x */ Double, Double]] = js.native
+    var optFn1Number: js.UndefOr[js.Function1[/* x */ Double, Double]] = js.undefined
     
     /**Should be (x:Number) => Callback*/
-    var optFn1Void: js.UndefOr[js.Function1[/* x */ Double, Unit]] = js.native
+    var optFn1Void: js.UndefOr[js.Function1[/* x */ Double, Unit]] = js.undefined
     
     /**Should be CallbackTo[Number]*/
-    def requiredFn0Number(): Double = js.native
+    def requiredFn0Number(): Double
     
     /**Should be Callback*/
-    def requiredFn0Void(): Unit = js.native
+    def requiredFn0Void(): Unit
     
     /**Should be (x:Number) => CallbackTo[Number]*/
-    def requiredFn1Number(x: Double): Double = js.native
+    def requiredFn1Number(x: Double): Double
     
     /**Should be (x:Number) => Callback*/
-    def requiredFn1Void(x: Double): Unit = js.native
+    def requiredFn1Void(x: Double): Unit
     
     /** Reduce maximum width to more naturally accommodate text. */
-    var text: js.UndefOr[Boolean] = js.native
+    var text: js.UndefOr[Boolean] = js.undefined
     
     /** Describes how the text inside this component should be aligned. */
-    var textAlign: js.UndefOr[SemanticTEXTALIGNMENTS] = js.native
+    var textAlign: js.UndefOr[SemanticTEXTALIGNMENTS] = js.undefined
   }
   object StrictTestContainerProps {
     
@@ -185,7 +184,6 @@ object testContainerTestContainerMod extends Shortcut {
     }
   }
   
-  @js.native
   trait TestContainerProps
     extends StObject
        with StrictTestContainerProps

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-976310"
+version := "0.38.0-023e82"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d6e1e0",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-46b6e2",
+  "org.scalablytyped" %%% "react" % "16.9.2-242f5f",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7863fe",
   ("com.github.japgolly.scalajs-react" %%% "core" % "1.7.5").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/src/main/scala/typingsJapgolly/stardustUiReactComponentEventListener/anon.scala
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/src/main/scala/typingsJapgolly/stardustUiReactComponentEventListener/anon.scala
@@ -6,16 +6,15 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Capture extends StObject {
     
-    var capture: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Requireable<boolean> */ js.Any = js.native
+    var capture: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Requireable<boolean> */ js.Any
     
-    var listener: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<(args : ...any): any> */ js.Any = js.native
+    var listener: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<(args : ...any): any> */ js.Any
     
-    var targetRef: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<imported_react.RefObject<Node | Window>> */ js.Any = js.native
+    var targetRef: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<imported_react.RefObject<Node | Window>> */ js.Any
     
-    var `type`: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<'waiting' | 'error' | 'abort' | 'cancel' | 'progress' | 'ended' | 'change' | 'input' | 'select' | 'fullscreenchange' | 'fullscreenerror' | 'readystatechange' | 'visibilitychange' | 'animationcancel' | 'animationend' | 'animationiteration' | 'animationstart' | 'auxclick' | 'blur' | 'canplay' | 'canplaythrough' | 'click' | 'close' | 'contextmenu' | 'cuechange' | 'dblclick' | 'drag' | 'dragend' | 'dragenter' | 'dragexit' | 'dragleave' | 'dragover' | 'dragstart' | 'drop' | 'durationchange' | 'emptied' | 'focus' | 'gotpointercapture' | 'invalid' | 'keydown' | 'keypress' | 'keyup' | 'load' | 'loadeddata' | 'loadedmetadata' | 'loadend' | 'loadstart' | 'lostpointercapture' | 'mousedown' | 'mouseenter' | 'mouseleave' | 'mousemove' | 'mouseout' | 'mouseover' | 'mouseup' | 'pause' | 'play' | 'playing' | 'pointercancel' | 'pointerdown' | 'pointerenter' | 'pointerleave' | 'pointermove' | 'pointerout' | 'pointerover' | 'pointerup' | 'ratechange' | 'reset' | 'resize' | 'scroll' | 'securitypolicyviolation' | 'seeked' | 'seeking' | 'stalled' | 'submit' | 'suspend' | 'timeupdate' | 'toggle' | 'touchcancel' | 'touchend' | 'touchmove' | 'touchstart' | 'transitioncancel' | 'transitionend' | 'transitionrun' | 'transitionstart' | 'volumechange' | 'wheel' | 'copy' | 'cut' | 'paste'> */ js.Any = js.native
+    var `type`: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<'waiting' | 'error' | 'abort' | 'cancel' | 'progress' | 'ended' | 'change' | 'input' | 'select' | 'fullscreenchange' | 'fullscreenerror' | 'readystatechange' | 'visibilitychange' | 'animationcancel' | 'animationend' | 'animationiteration' | 'animationstart' | 'auxclick' | 'blur' | 'canplay' | 'canplaythrough' | 'click' | 'close' | 'contextmenu' | 'cuechange' | 'dblclick' | 'drag' | 'dragend' | 'dragenter' | 'dragexit' | 'dragleave' | 'dragover' | 'dragstart' | 'drop' | 'durationchange' | 'emptied' | 'focus' | 'gotpointercapture' | 'invalid' | 'keydown' | 'keypress' | 'keyup' | 'load' | 'loadeddata' | 'loadedmetadata' | 'loadend' | 'loadstart' | 'lostpointercapture' | 'mousedown' | 'mouseenter' | 'mouseleave' | 'mousemove' | 'mouseout' | 'mouseover' | 'mouseup' | 'pause' | 'play' | 'playing' | 'pointercancel' | 'pointerdown' | 'pointerenter' | 'pointerleave' | 'pointermove' | 'pointerout' | 'pointerover' | 'pointerup' | 'ratechange' | 'reset' | 'resize' | 'scroll' | 'securitypolicyviolation' | 'seeked' | 'seeking' | 'stalled' | 'submit' | 'suspend' | 'timeupdate' | 'toggle' | 'touchcancel' | 'touchend' | 'touchmove' | 'touchstart' | 'transitioncancel' | 'transitionend' | 'transitionrun' | 'transitionstart' | 'volumechange' | 'wheel' | 'copy' | 'cut' | 'paste'> */ js.Any
   }
   object Capture {
     
@@ -56,16 +55,15 @@ object anon {
     }
   }
   
-  @js.native
   trait Listener extends StObject {
     
-    var capture: Unit = js.native
+    var capture: Unit
     
-    var listener: Unit = js.native
+    var listener: Unit
     
-    var targetRef: Unit = js.native
+    var targetRef: Unit
     
-    var `type`: Unit = js.native
+    var `type`: Unit
   }
   object Listener {
     

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/src/main/scala/typingsJapgolly/stardustUiReactComponentEventListener/typesMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-event-listener/src/main/scala/typingsJapgolly/stardustUiReactComponentEventListener/typesMod.scala
@@ -13,22 +13,21 @@ object typesMod {
     Unit
   ]
   
-  @js.native
   trait EventListenerOptions[T /* <: EventTypes */] extends StObject {
     
     /** Indicating that events of this type will be dispatched to the registered listener before being dispatched to any EventTarget beneath it in the DOM tree. */
-    var capture: js.UndefOr[Boolean] = js.native
+    var capture: js.UndefOr[Boolean] = js.undefined
     
     /** A function which receives a notification when an event of the specified type occurs. */
-    var listener: EventHandler[T] = js.native
+    var listener: EventHandler[T]
     
     /** A ref object with a target node. */
     var targetRef: RefHandle[
         /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Node */ js.Any
-      ] = js.native
+      ]
     
     /** A case-sensitive string representing the event type to listen for. */
-    var `type`: T = js.native
+    var `type`: T
   }
   object EventListenerOptions {
     

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-a1fa79"
+version := "0.38.0-f0ff32"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d6e1e0",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-46b6e2",
+  "org.scalablytyped" %%% "react" % "16.9.2-242f5f",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7863fe",
   ("com.github.japgolly.scalajs-react" %%% "core" % "1.7.5").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/src/main/scala/typingsJapgolly/stardustUiReactComponentRef/anon.scala
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/src/main/scala/typingsJapgolly/stardustUiReactComponentRef/anon.scala
@@ -6,12 +6,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Children extends StObject {
     
-    var children: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<PropTypes.ReactElementLike> */ js.Any = js.native
+    var children: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<PropTypes.ReactElementLike> */ js.Any
     
-    var innerRef: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<React.Ref<any>> */ js.Any = js.native
+    var innerRef: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<React.Ref<any>> */ js.Any
   }
   object Children {
     
@@ -39,12 +38,11 @@ object anon {
     }
   }
   
-  @js.native
   trait InnerRef extends StObject {
     
-    var children: Unit = js.native
+    var children: Unit
     
-    var innerRef: Unit = js.native
+    var innerRef: Unit
   }
   object InnerRef {
     

--- a/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/src/main/scala/typingsJapgolly/stardustUiReactComponentRef/typesMod.scala
+++ b/tests/react-integration-test/check-japgolly/s/stardust-ui__react-component-ref/src/main/scala/typingsJapgolly/stardustUiReactComponentRef/typesMod.scala
@@ -14,17 +14,16 @@ object typesMod {
   @js.native
   val refPropType: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Requireable<React.Ref<any>> */ js.Any = js.native
   
-  @js.native
   trait RefProps extends StObject {
     
-    var children: Element = js.native
+    var children: Element
     
     /**
       * Called when a child component will be mounted or updated.
       *
       * @param {HTMLElement} node - Referred node.
       */
-    var innerRef: Ref[js.Any] = js.native
+    var innerRef: Ref[js.Any]
   }
   object RefProps {
     

--- a/tests/react-integration-test/check-japgolly/s/std/build.sbt
+++ b/tests/react-integration-test/check-japgolly/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-46b6e2"
+version := "0.0-unknown-7863fe"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Array.scala
+++ b/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/DataTransfer.scala
+++ b/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/DataTransfer.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DataTransfer extends StObject

--- a/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Document.scala
+++ b/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Document.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Document extends StObject

--- a/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Element.scala
+++ b/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Element.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Element extends StObject

--- a/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Event.scala
+++ b/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Event.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Event extends StObject

--- a/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/EventTarget.scala
+++ b/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/EventTarget.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait EventTarget extends StObject

--- a/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/HTMLElementTagNameMap.scala
+++ b/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/HTMLElementTagNameMap.scala
@@ -4,216 +4,215 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HTMLElementTagNameMap extends StObject {
   
-  var a: org.scalajs.dom.raw.HTMLAnchorElement = js.native
+  var a: org.scalajs.dom.raw.HTMLAnchorElement
   
-  var abbr: org.scalajs.dom.raw.HTMLElement = js.native
+  var abbr: org.scalajs.dom.raw.HTMLElement
   
-  var address: org.scalajs.dom.raw.HTMLElement = js.native
+  var address: org.scalajs.dom.raw.HTMLElement
   
-  var area: org.scalajs.dom.raw.HTMLAreaElement = js.native
+  var area: org.scalajs.dom.raw.HTMLAreaElement
   
-  var article: org.scalajs.dom.raw.HTMLElement = js.native
+  var article: org.scalajs.dom.raw.HTMLElement
   
-  var aside: org.scalajs.dom.raw.HTMLElement = js.native
+  var aside: org.scalajs.dom.raw.HTMLElement
   
-  var audio: org.scalajs.dom.raw.HTMLAudioElement = js.native
+  var audio: org.scalajs.dom.raw.HTMLAudioElement
   
-  var b: org.scalajs.dom.raw.HTMLElement = js.native
+  var b: org.scalajs.dom.raw.HTMLElement
   
-  var base: org.scalajs.dom.raw.HTMLBaseElement = js.native
+  var base: org.scalajs.dom.raw.HTMLBaseElement
   
-  var bdi: org.scalajs.dom.raw.HTMLElement = js.native
+  var bdi: org.scalajs.dom.raw.HTMLElement
   
-  var bdo: org.scalajs.dom.raw.HTMLElement = js.native
+  var bdo: org.scalajs.dom.raw.HTMLElement
   
-  var blockquote: org.scalajs.dom.raw.HTMLQuoteElement = js.native
+  var blockquote: org.scalajs.dom.raw.HTMLQuoteElement
   
-  var body: org.scalajs.dom.raw.HTMLBodyElement = js.native
+  var body: org.scalajs.dom.raw.HTMLBodyElement
   
-  var br: org.scalajs.dom.raw.HTMLBRElement = js.native
+  var br: org.scalajs.dom.raw.HTMLBRElement
   
-  var button: org.scalajs.dom.raw.HTMLButtonElement = js.native
+  var button: org.scalajs.dom.raw.HTMLButtonElement
   
-  var canvas: org.scalajs.dom.raw.HTMLCanvasElement = js.native
+  var canvas: org.scalajs.dom.raw.HTMLCanvasElement
   
-  var cite: org.scalajs.dom.raw.HTMLElement = js.native
+  var cite: org.scalajs.dom.raw.HTMLElement
   
-  var code: org.scalajs.dom.raw.HTMLElement = js.native
+  var code: org.scalajs.dom.raw.HTMLElement
   
-  var col: org.scalajs.dom.raw.HTMLTableColElement = js.native
+  var col: org.scalajs.dom.raw.HTMLTableColElement
   
-  var colgroup: org.scalajs.dom.raw.HTMLTableColElement = js.native
+  var colgroup: org.scalajs.dom.raw.HTMLTableColElement
   
-  var data: org.scalajs.dom.raw.Element = js.native
+  var data: org.scalajs.dom.raw.Element
   
-  var datalist: org.scalajs.dom.raw.HTMLDataListElement = js.native
+  var datalist: org.scalajs.dom.raw.HTMLDataListElement
   
-  var dd: org.scalajs.dom.raw.HTMLElement = js.native
+  var dd: org.scalajs.dom.raw.HTMLElement
   
-  var del: org.scalajs.dom.raw.HTMLModElement = js.native
+  var del: org.scalajs.dom.raw.HTMLModElement
   
-  var dfn: org.scalajs.dom.raw.HTMLElement = js.native
+  var dfn: org.scalajs.dom.raw.HTMLElement
   
-  var dialog: org.scalajs.dom.raw.Element = js.native
+  var dialog: org.scalajs.dom.raw.Element
   
-  var div: org.scalajs.dom.raw.HTMLDivElement = js.native
+  var div: org.scalajs.dom.raw.HTMLDivElement
   
-  var dl: org.scalajs.dom.raw.HTMLDListElement = js.native
+  var dl: org.scalajs.dom.raw.HTMLDListElement
   
-  var dt: org.scalajs.dom.raw.HTMLElement = js.native
+  var dt: org.scalajs.dom.raw.HTMLElement
   
-  var em: org.scalajs.dom.raw.HTMLElement = js.native
+  var em: org.scalajs.dom.raw.HTMLElement
   
-  var embed: org.scalajs.dom.raw.HTMLEmbedElement = js.native
+  var embed: org.scalajs.dom.raw.HTMLEmbedElement
   
-  var fieldset: org.scalajs.dom.raw.HTMLFieldSetElement = js.native
+  var fieldset: org.scalajs.dom.raw.HTMLFieldSetElement
   
-  var figcaption: org.scalajs.dom.raw.HTMLElement = js.native
+  var figcaption: org.scalajs.dom.raw.HTMLElement
   
-  var figure: org.scalajs.dom.raw.HTMLElement = js.native
+  var figure: org.scalajs.dom.raw.HTMLElement
   
-  var footer: org.scalajs.dom.raw.HTMLElement = js.native
+  var footer: org.scalajs.dom.raw.HTMLElement
   
-  var form: org.scalajs.dom.raw.HTMLFormElement = js.native
+  var form: org.scalajs.dom.raw.HTMLFormElement
   
-  var h1: org.scalajs.dom.raw.HTMLHeadingElement = js.native
+  var h1: org.scalajs.dom.raw.HTMLHeadingElement
   
-  var h2: org.scalajs.dom.raw.HTMLHeadingElement = js.native
+  var h2: org.scalajs.dom.raw.HTMLHeadingElement
   
-  var h3: org.scalajs.dom.raw.HTMLHeadingElement = js.native
+  var h3: org.scalajs.dom.raw.HTMLHeadingElement
   
-  var h4: org.scalajs.dom.raw.HTMLHeadingElement = js.native
+  var h4: org.scalajs.dom.raw.HTMLHeadingElement
   
-  var h5: org.scalajs.dom.raw.HTMLHeadingElement = js.native
+  var h5: org.scalajs.dom.raw.HTMLHeadingElement
   
-  var h6: org.scalajs.dom.raw.HTMLHeadingElement = js.native
+  var h6: org.scalajs.dom.raw.HTMLHeadingElement
   
-  var head: org.scalajs.dom.raw.HTMLHeadElement = js.native
+  var head: org.scalajs.dom.raw.HTMLHeadElement
   
-  var header: org.scalajs.dom.raw.HTMLElement = js.native
+  var header: org.scalajs.dom.raw.HTMLElement
   
-  var hgroup: org.scalajs.dom.raw.HTMLElement = js.native
+  var hgroup: org.scalajs.dom.raw.HTMLElement
   
-  var hr: org.scalajs.dom.raw.HTMLHRElement = js.native
+  var hr: org.scalajs.dom.raw.HTMLHRElement
   
-  var html: org.scalajs.dom.raw.HTMLHtmlElement = js.native
+  var html: org.scalajs.dom.raw.HTMLHtmlElement
   
-  var i: org.scalajs.dom.raw.HTMLElement = js.native
+  var i: org.scalajs.dom.raw.HTMLElement
   
-  var iframe: org.scalajs.dom.raw.HTMLIFrameElement = js.native
+  var iframe: org.scalajs.dom.raw.HTMLIFrameElement
   
-  var img: org.scalajs.dom.raw.HTMLImageElement = js.native
+  var img: org.scalajs.dom.raw.HTMLImageElement
   
-  var input: org.scalajs.dom.raw.HTMLInputElement = js.native
+  var input: org.scalajs.dom.raw.HTMLInputElement
   
-  var ins: org.scalajs.dom.raw.HTMLModElement = js.native
+  var ins: org.scalajs.dom.raw.HTMLModElement
   
-  var kbd: org.scalajs.dom.raw.HTMLElement = js.native
+  var kbd: org.scalajs.dom.raw.HTMLElement
   
-  var label: org.scalajs.dom.raw.HTMLLabelElement = js.native
+  var label: org.scalajs.dom.raw.HTMLLabelElement
   
-  var legend: org.scalajs.dom.raw.HTMLLegendElement = js.native
+  var legend: org.scalajs.dom.raw.HTMLLegendElement
   
-  var li: org.scalajs.dom.raw.HTMLLIElement = js.native
+  var li: org.scalajs.dom.raw.HTMLLIElement
   
-  var link: org.scalajs.dom.raw.HTMLLinkElement = js.native
+  var link: org.scalajs.dom.raw.HTMLLinkElement
   
-  var main: org.scalajs.dom.raw.HTMLElement = js.native
+  var main: org.scalajs.dom.raw.HTMLElement
   
-  var map: org.scalajs.dom.raw.HTMLMapElement = js.native
+  var map: org.scalajs.dom.raw.HTMLMapElement
   
-  var mark: org.scalajs.dom.raw.HTMLElement = js.native
+  var mark: org.scalajs.dom.raw.HTMLElement
   
-  var meta: org.scalajs.dom.raw.HTMLMetaElement = js.native
+  var meta: org.scalajs.dom.raw.HTMLMetaElement
   
-  var nav: org.scalajs.dom.raw.HTMLElement = js.native
+  var nav: org.scalajs.dom.raw.HTMLElement
   
-  var noscript: org.scalajs.dom.raw.HTMLElement = js.native
+  var noscript: org.scalajs.dom.raw.HTMLElement
   
-  var `object`: org.scalajs.dom.raw.HTMLObjectElement = js.native
+  var `object`: org.scalajs.dom.raw.HTMLObjectElement
   
-  var ol: org.scalajs.dom.raw.HTMLOListElement = js.native
+  var ol: org.scalajs.dom.raw.HTMLOListElement
   
-  var optgroup: org.scalajs.dom.raw.HTMLOptGroupElement = js.native
+  var optgroup: org.scalajs.dom.raw.HTMLOptGroupElement
   
-  var option: org.scalajs.dom.raw.HTMLOptionElement = js.native
+  var option: org.scalajs.dom.raw.HTMLOptionElement
   
-  var p: org.scalajs.dom.raw.HTMLParagraphElement = js.native
+  var p: org.scalajs.dom.raw.HTMLParagraphElement
   
-  var param: org.scalajs.dom.raw.HTMLParamElement = js.native
+  var param: org.scalajs.dom.raw.HTMLParamElement
   
-  var pre: org.scalajs.dom.raw.HTMLPreElement = js.native
+  var pre: org.scalajs.dom.raw.HTMLPreElement
   
-  var progress: org.scalajs.dom.raw.HTMLProgressElement = js.native
+  var progress: org.scalajs.dom.raw.HTMLProgressElement
   
-  var q: org.scalajs.dom.raw.HTMLQuoteElement = js.native
+  var q: org.scalajs.dom.raw.HTMLQuoteElement
   
-  var rp: org.scalajs.dom.raw.HTMLElement = js.native
+  var rp: org.scalajs.dom.raw.HTMLElement
   
-  var rt: org.scalajs.dom.raw.HTMLElement = js.native
+  var rt: org.scalajs.dom.raw.HTMLElement
   
-  var ruby: org.scalajs.dom.raw.HTMLElement = js.native
+  var ruby: org.scalajs.dom.raw.HTMLElement
   
-  var s: org.scalajs.dom.raw.HTMLElement = js.native
+  var s: org.scalajs.dom.raw.HTMLElement
   
-  var samp: org.scalajs.dom.raw.HTMLElement = js.native
+  var samp: org.scalajs.dom.raw.HTMLElement
   
-  var script: org.scalajs.dom.raw.HTMLScriptElement = js.native
+  var script: org.scalajs.dom.raw.HTMLScriptElement
   
-  var section: org.scalajs.dom.raw.HTMLElement = js.native
+  var section: org.scalajs.dom.raw.HTMLElement
   
-  var select: org.scalajs.dom.raw.HTMLSelectElement = js.native
+  var select: org.scalajs.dom.raw.HTMLSelectElement
   
-  var small: org.scalajs.dom.raw.HTMLElement = js.native
+  var small: org.scalajs.dom.raw.HTMLElement
   
-  var source: org.scalajs.dom.raw.HTMLSourceElement = js.native
+  var source: org.scalajs.dom.raw.HTMLSourceElement
   
-  var span: org.scalajs.dom.raw.HTMLSpanElement = js.native
+  var span: org.scalajs.dom.raw.HTMLSpanElement
   
-  var strong: org.scalajs.dom.raw.HTMLElement = js.native
+  var strong: org.scalajs.dom.raw.HTMLElement
   
-  var style: org.scalajs.dom.raw.HTMLStyleElement = js.native
+  var style: org.scalajs.dom.raw.HTMLStyleElement
   
-  var sub: org.scalajs.dom.raw.HTMLElement = js.native
+  var sub: org.scalajs.dom.raw.HTMLElement
   
-  var summary: org.scalajs.dom.raw.HTMLElement = js.native
+  var summary: org.scalajs.dom.raw.HTMLElement
   
-  var sup: org.scalajs.dom.raw.HTMLElement = js.native
+  var sup: org.scalajs.dom.raw.HTMLElement
   
-  var table: org.scalajs.dom.raw.HTMLTableElement = js.native
+  var table: org.scalajs.dom.raw.HTMLTableElement
   
-  var tbody: org.scalajs.dom.raw.HTMLTableSectionElement = js.native
+  var tbody: org.scalajs.dom.raw.HTMLTableSectionElement
   
-  var td: org.scalajs.dom.raw.Element = js.native
+  var td: org.scalajs.dom.raw.Element
   
-  var template: org.scalajs.dom.raw.Element = js.native
+  var template: org.scalajs.dom.raw.Element
   
-  var textarea: org.scalajs.dom.raw.HTMLTextAreaElement = js.native
+  var textarea: org.scalajs.dom.raw.HTMLTextAreaElement
   
-  var tfoot: org.scalajs.dom.raw.HTMLTableSectionElement = js.native
+  var tfoot: org.scalajs.dom.raw.HTMLTableSectionElement
   
-  var th: org.scalajs.dom.raw.Element = js.native
+  var th: org.scalajs.dom.raw.Element
   
-  var thead: org.scalajs.dom.raw.HTMLTableSectionElement = js.native
+  var thead: org.scalajs.dom.raw.HTMLTableSectionElement
   
-  var title: org.scalajs.dom.raw.HTMLTitleElement = js.native
+  var title: org.scalajs.dom.raw.HTMLTitleElement
   
-  var tr: org.scalajs.dom.raw.HTMLTableRowElement = js.native
+  var tr: org.scalajs.dom.raw.HTMLTableRowElement
   
-  var track: org.scalajs.dom.raw.HTMLTrackElement = js.native
+  var track: org.scalajs.dom.raw.HTMLTrackElement
   
-  var u: org.scalajs.dom.raw.HTMLElement = js.native
+  var u: org.scalajs.dom.raw.HTMLElement
   
-  var ul: org.scalajs.dom.raw.HTMLUListElement = js.native
+  var ul: org.scalajs.dom.raw.HTMLUListElement
   
-  var `var`: org.scalajs.dom.raw.HTMLElement = js.native
+  var `var`: org.scalajs.dom.raw.HTMLElement
   
-  var video: org.scalajs.dom.raw.HTMLVideoElement = js.native
+  var video: org.scalajs.dom.raw.HTMLVideoElement
   
-  var wbr: org.scalajs.dom.raw.HTMLElement = js.native
+  var wbr: org.scalajs.dom.raw.HTMLElement
 }
 object HTMLElementTagNameMap {
   

--- a/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/SVGElementTagNameMap.scala
+++ b/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/SVGElementTagNameMap.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SVGElementTagNameMap extends StObject {
   
-  var circle: org.scalajs.dom.raw.SVGCircleElement = js.native
+  var circle: org.scalajs.dom.raw.SVGCircleElement
   
-  var clipPath: org.scalajs.dom.raw.SVGClipPathElement = js.native
+  var clipPath: org.scalajs.dom.raw.SVGClipPathElement
   
-  var defs: org.scalajs.dom.raw.SVGDefsElement = js.native
+  var defs: org.scalajs.dom.raw.SVGDefsElement
 }
 object SVGElementTagNameMap {
   

--- a/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/StyleMedia.scala
+++ b/tests/react-integration-test/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/StyleMedia.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait StyleMedia extends StObject

--- a/tests/react-integration-test/check-slinky/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-slinky/c/componentstest/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-e58d31"
+version := "0.0-unknown-35b663"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-93664c",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ee2ca2",
+  "org.scalablytyped" %%% "react" % "16.9.2-7784a5",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-66db32",
   ("me.shadaj" %%% "slinky-web" % "0.6.7").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-slinky/c/componentstest/src/main/scala/typingsSlinky/componentstest/anon.scala
+++ b/tests/react-integration-test/check-slinky/c/componentstest/src/main/scala/typingsSlinky/componentstest/anon.scala
@@ -6,16 +6,15 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Equals extends StObject {
     
     @JSName("equals")
-    var equals_FEquals: js.UndefOr[Boolean] = js.native
+    var equals_FEquals: js.UndefOr[Boolean] = js.undefined
     
-    def finalize(other: js.Object): Boolean = js.native
+    def finalize(other: js.Object): Boolean
     
     @JSName("ne")
-    var ne_FEquals: js.UndefOr[js.Function1[/* other */ js.Object, Boolean]] = js.native
+    var ne_FEquals: js.UndefOr[js.Function1[/* other */ js.Object, Boolean]] = js.undefined
   }
   object Equals {
     

--- a/tests/react-integration-test/check-slinky/c/componentstest/src/main/scala/typingsSlinky/componentstest/mod.scala
+++ b/tests/react-integration-test/check-slinky/c/componentstest/src/main/scala/typingsSlinky/componentstest/mod.scala
@@ -29,14 +29,13 @@ object mod {
   @js.native
   val ObjectNames: ReactComponentClass[Equals] = js.native
   
-  @js.native
   trait A
     extends StObject
        with Props {
     
-    def aCallback(): Double = js.native
+    def aCallback(): Double
     
-    var aMember: Double = js.native
+    var aMember: Double
   }
   object A {
     
@@ -57,14 +56,13 @@ object mod {
     }
   }
   
-  @js.native
   trait B
     extends StObject
        with Props {
     
-    var bCallback: js.UndefOr[js.Function0[String]] = js.native
+    var bCallback: js.UndefOr[js.Function0[String]] = js.undefined
     
-    var bMember: String = js.native
+    var bMember: String
   }
   object B {
     
@@ -88,16 +86,15 @@ object mod {
     }
   }
   
-  @js.native
   trait CardGridProps extends StObject {
     
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
-    var hoverable: js.UndefOr[Boolean] = js.native
+    var hoverable: js.UndefOr[Boolean] = js.undefined
     
-    var prefixCls: js.UndefOr[String] = js.native
+    var prefixCls: js.UndefOr[String] = js.undefined
     
-    var style: js.UndefOr[CSSProperties] = js.native
+    var style: js.UndefOr[CSSProperties] = js.undefined
   }
   object CardGridProps {
     
@@ -145,12 +142,11 @@ object mod {
   }
   
   /* Inlined parent std.Omit<std.Pick<react.react.HTMLAttributes<std.HTMLDivElement>, 'title' | 'onClick'>, 'title'> */
-  @js.native
   trait CardProps extends StObject {
     
-    var onClick: js.UndefOr[MouseEventHandler[HTMLDivElement]] = js.native
+    var onClick: js.UndefOr[MouseEventHandler[HTMLDivElement]] = js.undefined
     
-    var prefixCls: js.UndefOr[String] = js.native
+    var prefixCls: js.UndefOr[String] = js.undefined
   }
   object CardProps {
     

--- a/tests/react-integration-test/check-slinky/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-bootstrap/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-40b6a4"
+version := "0.32-df8bab"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-93664c",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ee2ca2",
+  "org.scalablytyped" %%% "react" % "16.9.2-7784a5",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-66db32",
   ("me.shadaj" %%% "slinky-web" % "0.6.7").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/bootstrapUtilsMod.scala
+++ b/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/bootstrapUtilsMod.scala
@@ -13,10 +13,9 @@ object bootstrapUtilsMod {
   @scala.inline
   def getBsProps(props: js.Any): BSProps = ^.asInstanceOf[js.Dynamic].applyDynamic("getBsProps")(props.asInstanceOf[js.Any]).asInstanceOf[BSProps]
   
-  @js.native
   trait BSProps extends StObject {
     
-    var bsClass: js.Any = js.native
+    var bsClass: js.Any
   }
   object BSProps {
     

--- a/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/buttonGroupMod.scala
+++ b/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/buttonGroupMod.scala
@@ -18,20 +18,19 @@ object buttonGroupMod {
   trait ButtonGroup
     extends Component[ButtonGroupProps, js.Object, js.Any]
   
-  @js.native
   trait ButtonGroupProps
     extends StObject
        with HTMLProps[ButtonGroup] {
     
-    var block: js.UndefOr[Boolean] = js.native
+    var block: js.UndefOr[Boolean] = js.undefined
     
-    var bsSize: js.UndefOr[Sizes] = js.native
+    var bsSize: js.UndefOr[Sizes] = js.undefined
     
-    var bsStyle: js.UndefOr[String] = js.native
+    var bsStyle: js.UndefOr[String] = js.undefined
     
-    var justified: js.UndefOr[Boolean] = js.native
+    var justified: js.UndefOr[Boolean] = js.undefined
     
-    var vertical: js.UndefOr[Boolean] = js.native
+    var vertical: js.UndefOr[Boolean] = js.undefined
   }
   object ButtonGroupProps {
     

--- a/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/toggleButtonGroupMod.scala
+++ b/tests/react-integration-test/check-slinky/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/toggleButtonGroupMod.scala
@@ -21,20 +21,19 @@ object toggleButtonGroupMod {
   class ^ ()
     extends Component[ToggleButtonGroupProps, js.Object, js.Any]
   
-  @js.native
   trait BaseProps extends StObject {
     
     /**
       * You'll usually want to use string|number|string[]|number[] here,
       * but you can technically use any|any[].
       */
-    var defaultValue: js.UndefOr[js.Any] = js.native
+    var defaultValue: js.UndefOr[js.Any] = js.undefined
     
     /**
       * You'll usually want to use string|number|string[]|number[] here,
       * but you can technically use any|any[].
       */
-    var value: js.UndefOr[js.Any] = js.native
+    var value: js.UndefOr[js.Any] = js.undefined
   }
   object BaseProps {
     
@@ -61,14 +60,13 @@ object toggleButtonGroupMod {
     }
   }
   
-  @js.native
   trait CheckboxProps extends StObject {
     
-    var name: js.UndefOr[String] = js.native
+    var name: js.UndefOr[String] = js.undefined
     
-    var onChange: js.UndefOr[js.Function1[/* values */ js.Array[js.Any], Unit]] = js.native
+    var onChange: js.UndefOr[js.Function1[/* values */ js.Array[js.Any], Unit]] = js.undefined
     
-    var `type`: checkbox = js.native
+    var `type`: checkbox
   }
   object CheckboxProps {
     
@@ -99,15 +97,14 @@ object toggleButtonGroupMod {
     }
   }
   
-  @js.native
   trait RadioProps extends StObject {
     
     /** Required if `type` is set to "radio" */
-    var name: String = js.native
+    var name: String
     
-    var onChange: js.UndefOr[js.Function1[/* value */ js.Any, Unit]] = js.native
+    var onChange: js.UndefOr[js.Function1[/* value */ js.Any, Unit]] = js.undefined
     
-    var `type`: radio = js.native
+    var `type`: radio
   }
   object RadioProps {
     

--- a/tests/react-integration-test/check-slinky/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-contextmenu/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-feb4ca"
+version := "2.13.0-74de67"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-93664c",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ee2ca2",
+  "org.scalablytyped" %%% "react" % "16.9.2-7784a5",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-66db32",
   ("me.shadaj" %%% "slinky-web" % "0.6.7").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-slinky/r/react-contextmenu/src/main/scala/typingsSlinky/reactContextmenu/mod.scala
+++ b/tests/react-integration-test/check-slinky/r/react-contextmenu/src/main/scala/typingsSlinky/reactContextmenu/mod.scala
@@ -89,18 +89,17 @@ object mod {
   @scala.inline
   def showMenu(opts: Unit, target: HTMLElement): Unit = (^.asInstanceOf[js.Dynamic].applyDynamic("showMenu")(opts.asInstanceOf[js.Any], target.asInstanceOf[js.Any])).asInstanceOf[Unit]
   
-  @js.native
   trait ContextMenuProps extends StObject {
     
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
-    var data: js.UndefOr[js.Any] = js.native
+    var data: js.UndefOr[js.Any] = js.undefined
     
-    var hideOnLeave: js.UndefOr[Boolean] = js.native
+    var hideOnLeave: js.UndefOr[Boolean] = js.undefined
     
-    var id: String = js.native
+    var id: String
     
-    var onHide: js.UndefOr[js.Function1[/* event */ js.Any, Unit]] = js.native
+    var onHide: js.UndefOr[js.Function1[/* event */ js.Any, Unit]] = js.undefined
     
     var onMouseLeave: js.UndefOr[
         (js.Function3[
@@ -109,11 +108,11 @@ object mod {
           /* target */ HTMLElement, 
           Unit
         ]) | js.Function
-      ] = js.native
+      ] = js.undefined
     
-    var onShow: js.UndefOr[js.Function1[/* event */ js.Any, Unit]] = js.native
+    var onShow: js.UndefOr[js.Function1[/* event */ js.Any, Unit]] = js.undefined
     
-    var rtl: js.UndefOr[Boolean] = js.native
+    var rtl: js.UndefOr[Boolean] = js.undefined
   }
   object ContextMenuProps {
     
@@ -185,20 +184,19 @@ object mod {
     }
   }
   
-  @js.native
   trait ContextMenuTriggerProps extends StObject {
     
-    var attributes: js.UndefOr[HTMLAttributes[js.Any]] = js.native
+    var attributes: js.UndefOr[HTMLAttributes[js.Any]] = js.undefined
     
-    var collect: js.UndefOr[js.Function1[/* data */ js.Any, js.Any]] = js.native
+    var collect: js.UndefOr[js.Function1[/* data */ js.Any, js.Any]] = js.undefined
     
-    var disable: js.UndefOr[Boolean] = js.native
+    var disable: js.UndefOr[Boolean] = js.undefined
     
-    var holdToDisplay: js.UndefOr[Double] = js.native
+    var holdToDisplay: js.UndefOr[Double] = js.undefined
     
-    var id: String = js.native
+    var id: String
     
-    var renderTag: js.UndefOr[ReactType[js.Any]] = js.native
+    var renderTag: js.UndefOr[ReactType[js.Any]] = js.undefined
   }
   object ContextMenuTriggerProps {
     
@@ -246,20 +244,19 @@ object mod {
     }
   }
   
-  @js.native
   trait MenuItemProps extends StObject {
     
-    var attributes: js.UndefOr[HTMLAttributes[HTMLDivElement]] = js.native
+    var attributes: js.UndefOr[HTMLAttributes[HTMLDivElement]] = js.undefined
     
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     var data: js.UndefOr[
         /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Object */ js.Any
-      ] = js.native
+      ] = js.undefined
     
-    var disabled: js.UndefOr[Boolean] = js.native
+    var disabled: js.UndefOr[Boolean] = js.undefined
     
-    var divider: js.UndefOr[Boolean] = js.native
+    var divider: js.UndefOr[Boolean] = js.undefined
     
     var onClick: js.UndefOr[
         (js.Function3[
@@ -268,9 +265,9 @@ object mod {
           /* target */ HTMLElement, 
           Unit
         ]) | js.Function
-      ] = js.native
+      ] = js.undefined
     
-    var preventClose: js.UndefOr[Boolean] = js.native
+    var preventClose: js.UndefOr[Boolean] = js.undefined
   }
   object MenuItemProps {
     
@@ -341,14 +338,13 @@ object mod {
     }
   }
   
-  @js.native
   trait SubMenuProps extends StObject {
     
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
-    var disabled: js.UndefOr[Boolean] = js.native
+    var disabled: js.UndefOr[Boolean] = js.undefined
     
-    var hoverDelay: js.UndefOr[Double] = js.native
+    var hoverDelay: js.UndefOr[Double] = js.undefined
     
     var onClick: js.UndefOr[
         (js.Function3[
@@ -357,13 +353,13 @@ object mod {
           /* target */ HTMLElement, 
           Unit
         ]) | js.Function
-      ] = js.native
+      ] = js.undefined
     
-    var preventCloseOnClick: js.UndefOr[Boolean] = js.native
+    var preventCloseOnClick: js.UndefOr[Boolean] = js.undefined
     
-    var rtl: js.UndefOr[Boolean] = js.native
+    var rtl: js.UndefOr[Boolean] = js.undefined
     
-    var title: ReactElement | ReactText = js.native
+    var title: ReactElement | ReactText
   }
   object SubMenuProps {
     

--- a/tests/react-integration-test/check-slinky/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-dropzone/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-ff93e9"
+version := "10.1.10-13a1c2"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-93664c",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ee2ca2",
+  "org.scalablytyped" %%% "react" % "16.9.2-7784a5",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-66db32",
   ("me.shadaj" %%% "slinky-web" % "0.6.7").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-slinky/r/react-dropzone/src/main/scala/typingsSlinky/reactDropzone/mod.scala
+++ b/tests/react-integration-test/check-slinky/r/react-dropzone/src/main/scala/typingsSlinky/reactDropzone/mod.scala
@@ -32,12 +32,11 @@ object mod {
   
   type DropEvent = DragEvent[HTMLElement] | ChangeEvent[HTMLInputElement] | org.scalajs.dom.raw.DragEvent | Event
   
-  @js.native
   trait DropzoneInputProps
     extends StObject
        with InputHTMLAttributes[HTMLInputElement] {
     
-    var refKey: js.UndefOr[String] = js.native
+    var refKey: js.UndefOr[String] = js.undefined
   }
   object DropzoneInputProps {
     
@@ -59,39 +58,38 @@ object mod {
   }
   
   /* Inlined std.Pick<react.react.HTMLProps<std.HTMLElement>, react-dropzone.react-dropzone.PropTypes> & {  accept :string | std.Array<string> | undefined,   minSize :number | undefined,   maxSize :number | undefined,   preventDropOnDocument :boolean | undefined,   noClick :boolean | undefined,   noKeyboard :boolean | undefined,   noDrag :boolean | undefined,   noDragEventsBubbling :boolean | undefined,   disabled :boolean | undefined,   onDrop :<T extends / * import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify File * / any>(acceptedFiles : std.Array<T>, rejectedFiles : std.Array<T>, event : react-dropzone.react-dropzone.DropEvent): void | undefined,   onDropAccepted :<T extends / * import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify File * / any>(files : std.Array<T>, event : react-dropzone.react-dropzone.DropEvent): void | undefined,   onDropRejected :<T extends / * import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify File * / any>(files : std.Array<T>, event : react-dropzone.react-dropzone.DropEvent): void | undefined,   getFilesFromEvent :(event : react-dropzone.react-dropzone.DropEvent): / * import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Promise<Array<File | DataTransferItem>> * / any | undefined,   onFileDialogCancel :(): void | undefined} */
-  @js.native
   trait DropzoneOptions extends StObject {
     
-    var accept: js.UndefOr[String | js.Array[String]] = js.native
+    var accept: js.UndefOr[String | js.Array[String]] = js.undefined
     
-    var disabled: js.UndefOr[Boolean] = js.native
+    var disabled: js.UndefOr[Boolean] = js.undefined
     
     var getFilesFromEvent: js.UndefOr[
         js.Function1[
           /* event */ DropEvent, 
           /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Promise<Array<File | DataTransferItem>> */ js.Any
         ]
-      ] = js.native
+      ] = js.undefined
     
-    var maxSize: js.UndefOr[Double] = js.native
+    var maxSize: js.UndefOr[Double] = js.undefined
     
-    var minSize: js.UndefOr[Double] = js.native
+    var minSize: js.UndefOr[Double] = js.undefined
     
-    var multiple: js.UndefOr[Boolean] = js.native
+    var multiple: js.UndefOr[Boolean] = js.undefined
     
-    var noClick: js.UndefOr[Boolean] = js.native
+    var noClick: js.UndefOr[Boolean] = js.undefined
     
-    var noDrag: js.UndefOr[Boolean] = js.native
+    var noDrag: js.UndefOr[Boolean] = js.undefined
     
-    var noDragEventsBubbling: js.UndefOr[Boolean] = js.native
+    var noDragEventsBubbling: js.UndefOr[Boolean] = js.undefined
     
-    var noKeyboard: js.UndefOr[Boolean] = js.native
+    var noKeyboard: js.UndefOr[Boolean] = js.undefined
     
-    var onDragEnter: js.UndefOr[DragEventHandler[HTMLElement]] = js.native
+    var onDragEnter: js.UndefOr[DragEventHandler[HTMLElement]] = js.undefined
     
-    var onDragLeave: js.UndefOr[DragEventHandler[HTMLElement]] = js.native
+    var onDragLeave: js.UndefOr[DragEventHandler[HTMLElement]] = js.undefined
     
-    var onDragOver: js.UndefOr[DragEventHandler[HTMLElement]] = js.native
+    var onDragOver: js.UndefOr[DragEventHandler[HTMLElement]] = js.undefined
     
     var onDrop: js.UndefOr[
         js.Function3[
@@ -104,7 +102,7 @@ object mod {
           /* event */ DropEvent, 
           Unit
         ]
-      ] = js.native
+      ] = js.undefined
     
     var onDropAccepted: js.UndefOr[
         js.Function2[
@@ -114,7 +112,7 @@ object mod {
           /* event */ DropEvent, 
           Unit
         ]
-      ] = js.native
+      ] = js.undefined
     
     var onDropRejected: js.UndefOr[
         js.Function2[
@@ -124,11 +122,11 @@ object mod {
           /* event */ DropEvent, 
           Unit
         ]
-      ] = js.native
+      ] = js.undefined
     
-    var onFileDialogCancel: js.UndefOr[js.Function0[Unit]] = js.native
+    var onFileDialogCancel: js.UndefOr[js.Function0[Unit]] = js.undefined
     
-    var preventDropOnDocument: js.UndefOr[Boolean] = js.native
+    var preventDropOnDocument: js.UndefOr[Boolean] = js.undefined
   }
   object DropzoneOptions {
     
@@ -270,12 +268,11 @@ object mod {
     }
   }
   
-  @js.native
   trait DropzoneProps
     extends StObject
        with DropzoneOptions {
     
-    var children: js.UndefOr[js.Function1[/* state */ DropzoneState, Element]] = js.native
+    var children: js.UndefOr[js.Function1[/* state */ DropzoneState, Element]] = js.undefined
   }
   object DropzoneProps {
     
@@ -296,10 +293,9 @@ object mod {
     }
   }
   
-  @js.native
   trait DropzoneRef extends StObject {
     
-    def open(): Unit = js.native
+    def open(): Unit
   }
   object DropzoneRef {
     
@@ -317,13 +313,12 @@ object mod {
     }
   }
   
-  @js.native
   trait DropzoneRootProps
     extends StObject
        with HTMLAttributes[HTMLElement]
        with /* key */ StringDictionary[js.Any] {
     
-    var refKey: js.UndefOr[String] = js.native
+    var refKey: js.UndefOr[String] = js.undefined
   }
   object DropzoneRootProps {
     

--- a/tests/react-integration-test/check-slinky/r/react-markdown/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-markdown/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-markdown"
-version := "0.0-unknown-d00c1b"
+version := "0.0-unknown-95ab69"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-93664c",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ee2ca2",
+  "org.scalablytyped" %%% "react" % "16.9.2-7784a5",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-66db32",
   ("me.shadaj" %%% "slinky-web" % "0.6.7").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-slinky/r/react-markdown/src/main/scala/typingsSlinky/reactMarkdown/mod.scala
+++ b/tests/react-integration-test/check-slinky/r/react-markdown/src/main/scala/typingsSlinky/reactMarkdown/mod.scala
@@ -23,10 +23,9 @@ object mod {
   @scala.inline
   def uriTransformer(uri: String): String = ^.asInstanceOf[js.Dynamic].applyDynamic("uriTransformer")(uri.asInstanceOf[js.Any]).asInstanceOf[String]
   
-  @js.native
   trait ChildrenProp extends StObject {
     
-    val children: String = js.native
+    val children: String
   }
   object ChildrenProp {
     
@@ -54,14 +53,13 @@ object mod {
   
   type ReactMarkdownProps = ReactMarkdownPropsBase & (MutuallyExclusive[ChildrenProp, SourceProp])
   
-  @js.native
   trait ReactMarkdownPropsBase extends StObject {
     
-    val allowNode: js.UndefOr[js.Function1[/* index */ Double, Boolean]] = js.native
+    val allowNode: js.UndefOr[js.Function1[/* index */ Double, Boolean]] = js.undefined
     
-    val className: js.UndefOr[String] = js.native
+    val className: js.UndefOr[String] = js.undefined
     
-    val linkTarget: js.UndefOr[String | LinkTargetResolver] = js.native
+    val linkTarget: js.UndefOr[String | LinkTargetResolver] = js.undefined
     
     val transformLinkUri: js.UndefOr[
         (js.Function3[
@@ -70,7 +68,7 @@ object mod {
           /* title */ js.UndefOr[String], 
           String
         ]) | Null
-      ] = js.native
+      ] = js.undefined
   }
   object ReactMarkdownPropsBase {
     
@@ -121,11 +119,10 @@ object mod {
   
   type Renderers_ = StringDictionary[String | Renderer[js.Any]]
   
-  @js.native
   trait SourceProp extends StObject {
     
     /** @deprecated use children */
-    val source: String = js.native
+    val source: String
   }
   object SourceProp {
     

--- a/tests/react-integration-test/check-slinky/r/react-native/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-native/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "react-native"
-version := "0.0-unknown-42ec2c"
+version := "0.0-unknown-9ff0e7"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ee2ca2",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-66db32",
   ("me.shadaj" %%% "slinky-web" % "0.6.7").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-slinky/r/react-native/src/main/scala/typingsSlinky/reactNative/ViewToken.scala
+++ b/tests/react-integration-test/check-slinky/r/react-native/src/main/scala/typingsSlinky/reactNative/ViewToken.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ViewToken extends StObject

--- a/tests/react-integration-test/check-slinky/r/react-native/src/main/scala/typingsSlinky/reactNative/ViewabilityConfig.scala
+++ b/tests/react-integration-test/check-slinky/r/react-native/src/main/scala/typingsSlinky/reactNative/ViewabilityConfig.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ViewabilityConfig extends StObject

--- a/tests/react-integration-test/check-slinky/r/react-native/src/main/scala/typingsSlinky/reactNative/ViewabilityConfigCallbackPair.scala
+++ b/tests/react-integration-test/check-slinky/r/react-native/src/main/scala/typingsSlinky/reactNative/ViewabilityConfigCallbackPair.scala
@@ -5,12 +5,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ViewabilityConfigCallbackPair extends StObject {
   
-  var onViewableItemsChanged: (js.Function1[/* info */ Changed, Unit]) | Null = js.native
+  var onViewableItemsChanged: (js.Function1[/* info */ Changed, Unit]) | Null
   
-  var viewabilityConfig: ViewabilityConfig = js.native
+  var viewabilityConfig: ViewabilityConfig
 }
 object ViewabilityConfigCallbackPair {
   

--- a/tests/react-integration-test/check-slinky/r/react-native/src/main/scala/typingsSlinky/reactNative/anon.scala
+++ b/tests/react-integration-test/check-slinky/r/react-native/src/main/scala/typingsSlinky/reactNative/anon.scala
@@ -6,12 +6,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Changed extends StObject {
     
-    var changed: js.Array[ViewToken] = js.native
+    var changed: js.Array[ViewToken]
     
-    var viewableItems: js.Array[ViewToken] = js.native
+    var viewableItems: js.Array[ViewToken]
   }
   object Changed {
     

--- a/tests/react-integration-test/check-slinky/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react-select/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-6d035d"
+version := "0.0-unknown-626157"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-93664c",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ee2ca2",
+  "org.scalablytyped" %%% "react" % "16.9.2-7784a5",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-66db32",
   ("me.shadaj" %%% "slinky-web" % "0.6.7").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-slinky/r/react-select/src/main/scala/typingsSlinky/reactSelect/mod.scala
+++ b/tests/react-integration-test/check-slinky/r/react-select/src/main/scala/typingsSlinky/reactSelect/mod.scala
@@ -13,7 +13,6 @@ object mod {
   @js.native
   class default[TValue] () extends ReactSelectClass[TValue]
   
-  @js.native
   trait Option[TValue]
     extends StObject
        with /**
@@ -23,7 +22,7 @@ object mod {
   /* property */ StringDictionary[js.Any] {
     
     /** Value for searching */
-    var value: js.UndefOr[TValue] = js.native
+    var value: js.UndefOr[TValue] = js.undefined
   }
   object Option {
     
@@ -55,7 +54,6 @@ object mod {
     def setValue(value: Option[TValue]): Unit = js.native
   }
   
-  @js.native
   trait ReactSelectProps[TValue]
     extends StObject
        with Props[ReactSelectClass[TValue]] {
@@ -64,7 +62,7 @@ object mod {
       * text to display when `allowCreate` is true.
       * @default 'Add "{label}"?'
       */
-    var addLabelText: js.UndefOr[String] = js.native
+    var addLabelText: js.UndefOr[String] = js.undefined
   }
   object ReactSelectProps {
     

--- a/tests/react-integration-test/check-slinky/r/react/build.sbt
+++ b/tests/react-integration-test/check-slinky/r/react/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-93664c"
+version := "16.9.2-7784a5"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ee2ca2",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-66db32",
   ("me.shadaj" %%% "slinky-web" % "0.6.7").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/anon.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/anon.scala
@@ -8,10 +8,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait `0` extends StObject {
     
-    var defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any = js.native
+    var defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any
   }
   object `0` {
     
@@ -31,10 +30,9 @@ object anon {
     }
   }
   
-  @js.native
   trait `1` extends StObject {
     
-    var ref: js.UndefOr[Exclude[js.Any, String]] = js.native
+    var ref: js.UndefOr[Exclude[js.Any, String]] = js.undefined
   }
   object `1` {
     
@@ -55,10 +53,9 @@ object anon {
     }
   }
   
-  @js.native
   trait Children extends StObject {
     
-    var children: js.UndefOr[ReactElement] = js.native
+    var children: js.UndefOr[ReactElement] = js.undefined
   }
   object Children {
     
@@ -79,12 +76,11 @@ object anon {
     }
   }
   
-  @js.native
   trait DefaultProps extends StObject {
     
-    var defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any = js.native
+    var defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any
     
-    var propTypes: /* import warning: importer.ImportType#apply Failed type conversion: infer T */ js.Any = js.native
+    var propTypes: /* import warning: importer.ImportType#apply Failed type conversion: infer T */ js.Any
   }
   object DefaultProps {
     
@@ -108,10 +104,9 @@ object anon {
     }
   }
   
-  @js.native
   trait Html extends StObject {
     
-    var __html: String = js.native
+    var __html: String
   }
   object Html {
     
@@ -129,10 +124,9 @@ object anon {
     }
   }
   
-  @js.native
   trait PropTypes extends StObject {
     
-    var propTypes: /* import warning: importer.ImportType#apply Failed type conversion: infer T */ js.Any = js.native
+    var propTypes: /* import warning: importer.ImportType#apply Failed type conversion: infer T */ js.Any
   }
   object PropTypes {
     
@@ -150,12 +144,11 @@ object anon {
     }
   }
   
-  @js.native
   trait Ref extends StObject {
     
     var ref: js.UndefOr[
         /* import warning: importer.ImportType#apply Failed type conversion: infer R */ js.Any
-      ] = js.native
+      ] = js.undefined
   }
   object Ref {
     

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/AbstractView.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/AbstractView.scala
@@ -10,12 +10,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 // Browser Interfaces
 // https://github.com/nikeee/2048-typescript/blob/master/2048/js/touch.d.ts
 // ----------------------------------------------------------------------
-@js.native
 trait AbstractView extends StObject {
   
-  var document: Document = js.native
+  var document: Document
   
-  var styleMedia: StyleMedia = js.native
+  var styleMedia: StyleMedia
 }
 object AbstractView {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/AllHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/AllHTMLAttributes.scala
@@ -4,221 +4,220 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait AllHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var default: js.UndefOr[Boolean] = js.native
+  var default: js.UndefOr[Boolean] = js.undefined
   
   // Standard HTML Attributes
-  var accept: js.UndefOr[String] = js.native
+  var accept: js.UndefOr[String] = js.undefined
   
-  var acceptCharset: js.UndefOr[String] = js.native
+  var acceptCharset: js.UndefOr[String] = js.undefined
   
-  var action: js.UndefOr[String] = js.native
+  var action: js.UndefOr[String] = js.undefined
   
-  var allowFullScreen: js.UndefOr[Boolean] = js.native
+  var allowFullScreen: js.UndefOr[Boolean] = js.undefined
   
-  var allowTransparency: js.UndefOr[Boolean] = js.native
+  var allowTransparency: js.UndefOr[Boolean] = js.undefined
   
-  var alt: js.UndefOr[String] = js.native
+  var alt: js.UndefOr[String] = js.undefined
   
-  var as: js.UndefOr[String] = js.native
+  var as: js.UndefOr[String] = js.undefined
   
-  var async: js.UndefOr[Boolean] = js.native
+  var async: js.UndefOr[Boolean] = js.undefined
   
-  var autoComplete: js.UndefOr[String] = js.native
+  var autoComplete: js.UndefOr[String] = js.undefined
   
-  var autoFocus: js.UndefOr[Boolean] = js.native
+  var autoFocus: js.UndefOr[Boolean] = js.undefined
   
-  var autoPlay: js.UndefOr[Boolean] = js.native
+  var autoPlay: js.UndefOr[Boolean] = js.undefined
   
-  var capture: js.UndefOr[Boolean | String] = js.native
+  var capture: js.UndefOr[Boolean | String] = js.undefined
   
-  var cellPadding: js.UndefOr[Double | String] = js.native
+  var cellPadding: js.UndefOr[Double | String] = js.undefined
   
-  var cellSpacing: js.UndefOr[Double | String] = js.native
+  var cellSpacing: js.UndefOr[Double | String] = js.undefined
   
-  var challenge: js.UndefOr[String] = js.native
+  var challenge: js.UndefOr[String] = js.undefined
   
-  var charSet: js.UndefOr[String] = js.native
+  var charSet: js.UndefOr[String] = js.undefined
   
-  var checked: js.UndefOr[Boolean] = js.native
+  var checked: js.UndefOr[Boolean] = js.undefined
   
-  var cite: js.UndefOr[String] = js.native
+  var cite: js.UndefOr[String] = js.undefined
   
-  var classID: js.UndefOr[String] = js.native
+  var classID: js.UndefOr[String] = js.undefined
   
-  var colSpan: js.UndefOr[Double] = js.native
+  var colSpan: js.UndefOr[Double] = js.undefined
   
-  var cols: js.UndefOr[Double] = js.native
+  var cols: js.UndefOr[Double] = js.undefined
   
-  var content: js.UndefOr[String] = js.native
+  var content: js.UndefOr[String] = js.undefined
   
-  var controls: js.UndefOr[Boolean] = js.native
+  var controls: js.UndefOr[Boolean] = js.undefined
   
-  var coords: js.UndefOr[String] = js.native
+  var coords: js.UndefOr[String] = js.undefined
   
-  var crossOrigin: js.UndefOr[String] = js.native
+  var crossOrigin: js.UndefOr[String] = js.undefined
   
-  var data: js.UndefOr[String] = js.native
+  var data: js.UndefOr[String] = js.undefined
   
-  var dateTime: js.UndefOr[String] = js.native
+  var dateTime: js.UndefOr[String] = js.undefined
   
-  var defer: js.UndefOr[Boolean] = js.native
+  var defer: js.UndefOr[Boolean] = js.undefined
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var download: js.UndefOr[js.Any] = js.native
+  var download: js.UndefOr[js.Any] = js.undefined
   
-  var encType: js.UndefOr[String] = js.native
+  var encType: js.UndefOr[String] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var formAction: js.UndefOr[String] = js.native
+  var formAction: js.UndefOr[String] = js.undefined
   
-  var formEncType: js.UndefOr[String] = js.native
+  var formEncType: js.UndefOr[String] = js.undefined
   
-  var formMethod: js.UndefOr[String] = js.native
+  var formMethod: js.UndefOr[String] = js.undefined
   
-  var formNoValidate: js.UndefOr[Boolean] = js.native
+  var formNoValidate: js.UndefOr[Boolean] = js.undefined
   
-  var formTarget: js.UndefOr[String] = js.native
+  var formTarget: js.UndefOr[String] = js.undefined
   
-  var frameBorder: js.UndefOr[Double | String] = js.native
+  var frameBorder: js.UndefOr[Double | String] = js.undefined
   
-  var headers: js.UndefOr[String] = js.native
+  var headers: js.UndefOr[String] = js.undefined
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var high: js.UndefOr[Double] = js.native
+  var high: js.UndefOr[Double] = js.undefined
   
-  var href: js.UndefOr[String] = js.native
+  var href: js.UndefOr[String] = js.undefined
   
-  var hrefLang: js.UndefOr[String] = js.native
+  var hrefLang: js.UndefOr[String] = js.undefined
   
-  var htmlFor: js.UndefOr[String] = js.native
+  var htmlFor: js.UndefOr[String] = js.undefined
   
-  var httpEquiv: js.UndefOr[String] = js.native
+  var httpEquiv: js.UndefOr[String] = js.undefined
   
-  var integrity: js.UndefOr[String] = js.native
+  var integrity: js.UndefOr[String] = js.undefined
   
-  var keyParams: js.UndefOr[String] = js.native
+  var keyParams: js.UndefOr[String] = js.undefined
   
-  var keyType: js.UndefOr[String] = js.native
+  var keyType: js.UndefOr[String] = js.undefined
   
-  var kind: js.UndefOr[String] = js.native
+  var kind: js.UndefOr[String] = js.undefined
   
-  var label: js.UndefOr[String] = js.native
+  var label: js.UndefOr[String] = js.undefined
   
-  var list: js.UndefOr[String] = js.native
+  var list: js.UndefOr[String] = js.undefined
   
-  var loop: js.UndefOr[Boolean] = js.native
+  var loop: js.UndefOr[Boolean] = js.undefined
   
-  var low: js.UndefOr[Double] = js.native
+  var low: js.UndefOr[Double] = js.undefined
   
-  var manifest: js.UndefOr[String] = js.native
+  var manifest: js.UndefOr[String] = js.undefined
   
-  var marginHeight: js.UndefOr[Double] = js.native
+  var marginHeight: js.UndefOr[Double] = js.undefined
   
-  var marginWidth: js.UndefOr[Double] = js.native
+  var marginWidth: js.UndefOr[Double] = js.undefined
   
-  var max: js.UndefOr[Double | String] = js.native
+  var max: js.UndefOr[Double | String] = js.undefined
   
-  var maxLength: js.UndefOr[Double] = js.native
+  var maxLength: js.UndefOr[Double] = js.undefined
   
-  var media: js.UndefOr[String] = js.native
+  var media: js.UndefOr[String] = js.undefined
   
-  var mediaGroup: js.UndefOr[String] = js.native
+  var mediaGroup: js.UndefOr[String] = js.undefined
   
-  var method: js.UndefOr[String] = js.native
+  var method: js.UndefOr[String] = js.undefined
   
-  var min: js.UndefOr[Double | String] = js.native
+  var min: js.UndefOr[Double | String] = js.undefined
   
-  var minLength: js.UndefOr[Double] = js.native
+  var minLength: js.UndefOr[Double] = js.undefined
   
-  var multiple: js.UndefOr[Boolean] = js.native
+  var multiple: js.UndefOr[Boolean] = js.undefined
   
-  var muted: js.UndefOr[Boolean] = js.native
+  var muted: js.UndefOr[Boolean] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
-  var noValidate: js.UndefOr[Boolean] = js.native
+  var noValidate: js.UndefOr[Boolean] = js.undefined
   
-  var nonce: js.UndefOr[String] = js.native
+  var nonce: js.UndefOr[String] = js.undefined
   
-  var open: js.UndefOr[Boolean] = js.native
+  var open: js.UndefOr[Boolean] = js.undefined
   
-  var optimum: js.UndefOr[Double] = js.native
+  var optimum: js.UndefOr[Double] = js.undefined
   
-  var pattern: js.UndefOr[String] = js.native
+  var pattern: js.UndefOr[String] = js.undefined
   
-  var playsInline: js.UndefOr[Boolean] = js.native
+  var playsInline: js.UndefOr[Boolean] = js.undefined
   
-  var poster: js.UndefOr[String] = js.native
+  var poster: js.UndefOr[String] = js.undefined
   
-  var preload: js.UndefOr[String] = js.native
+  var preload: js.UndefOr[String] = js.undefined
   
-  var readOnly: js.UndefOr[Boolean] = js.native
+  var readOnly: js.UndefOr[Boolean] = js.undefined
   
-  var rel: js.UndefOr[String] = js.native
+  var rel: js.UndefOr[String] = js.undefined
   
-  var required: js.UndefOr[Boolean] = js.native
+  var required: js.UndefOr[Boolean] = js.undefined
   
-  var reversed: js.UndefOr[Boolean] = js.native
+  var reversed: js.UndefOr[Boolean] = js.undefined
   
-  var rowSpan: js.UndefOr[Double] = js.native
+  var rowSpan: js.UndefOr[Double] = js.undefined
   
-  var rows: js.UndefOr[Double] = js.native
+  var rows: js.UndefOr[Double] = js.undefined
   
-  var sandbox: js.UndefOr[String] = js.native
+  var sandbox: js.UndefOr[String] = js.undefined
   
-  var scope: js.UndefOr[String] = js.native
+  var scope: js.UndefOr[String] = js.undefined
   
-  var scoped: js.UndefOr[Boolean] = js.native
+  var scoped: js.UndefOr[Boolean] = js.undefined
   
-  var scrolling: js.UndefOr[String] = js.native
+  var scrolling: js.UndefOr[String] = js.undefined
   
-  var seamless: js.UndefOr[Boolean] = js.native
+  var seamless: js.UndefOr[Boolean] = js.undefined
   
-  var selected: js.UndefOr[Boolean] = js.native
+  var selected: js.UndefOr[Boolean] = js.undefined
   
-  var shape: js.UndefOr[String] = js.native
+  var shape: js.UndefOr[String] = js.undefined
   
-  var size: js.UndefOr[Double] = js.native
+  var size: js.UndefOr[Double] = js.undefined
   
-  var sizes: js.UndefOr[String] = js.native
+  var sizes: js.UndefOr[String] = js.undefined
   
-  var span: js.UndefOr[Double] = js.native
+  var span: js.UndefOr[Double] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var srcDoc: js.UndefOr[String] = js.native
+  var srcDoc: js.UndefOr[String] = js.undefined
   
-  var srcLang: js.UndefOr[String] = js.native
+  var srcLang: js.UndefOr[String] = js.undefined
   
-  var srcSet: js.UndefOr[String] = js.native
+  var srcSet: js.UndefOr[String] = js.undefined
   
-  var start: js.UndefOr[Double] = js.native
+  var start: js.UndefOr[Double] = js.undefined
   
-  var step: js.UndefOr[Double | String] = js.native
+  var step: js.UndefOr[Double | String] = js.undefined
   
-  var summary: js.UndefOr[String] = js.native
+  var summary: js.UndefOr[String] = js.undefined
   
-  var target: js.UndefOr[String] = js.native
+  var target: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
   
-  var useMap: js.UndefOr[String] = js.native
+  var useMap: js.UndefOr[String] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
   
-  var wmode: js.UndefOr[String] = js.native
+  var wmode: js.UndefOr[String] = js.undefined
   
-  var wrap: js.UndefOr[String] = js.native
+  var wrap: js.UndefOr[String] = js.undefined
 }
 object AllHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/AnchorHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/AnchorHTMLAttributes.scala
@@ -4,28 +4,27 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait AnchorHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var download: js.UndefOr[js.Any] = js.native
+  var download: js.UndefOr[js.Any] = js.undefined
   
-  var href: js.UndefOr[String] = js.native
+  var href: js.UndefOr[String] = js.undefined
   
-  var hrefLang: js.UndefOr[String] = js.native
+  var hrefLang: js.UndefOr[String] = js.undefined
   
-  var media: js.UndefOr[String] = js.native
+  var media: js.UndefOr[String] = js.undefined
   
-  var ping: js.UndefOr[String] = js.native
+  var ping: js.UndefOr[String] = js.undefined
   
-  var referrerPolicy: js.UndefOr[String] = js.native
+  var referrerPolicy: js.UndefOr[String] = js.undefined
   
-  var rel: js.UndefOr[String] = js.native
+  var rel: js.UndefOr[String] = js.undefined
   
-  var target: js.UndefOr[String] = js.native
+  var target: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
 }
 object AnchorHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/AnimationEvent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/AnimationEvent.scala
@@ -5,16 +5,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait AnimationEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeAnimationEvent, EventTarget & T, EventTarget] {
   
-  var animationName: String = js.native
+  var animationName: String
   
-  var elapsedTime: Double = js.native
+  var elapsedTime: Double
   
-  var pseudoElement: String = js.native
+  var pseudoElement: String
 }
 object AnimationEvent {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/AreaHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/AreaHTMLAttributes.scala
@@ -4,28 +4,27 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait AreaHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var alt: js.UndefOr[String] = js.native
+  var alt: js.UndefOr[String] = js.undefined
   
-  var coords: js.UndefOr[String] = js.native
+  var coords: js.UndefOr[String] = js.undefined
   
-  var download: js.UndefOr[js.Any] = js.native
+  var download: js.UndefOr[js.Any] = js.undefined
   
-  var href: js.UndefOr[String] = js.native
+  var href: js.UndefOr[String] = js.undefined
   
-  var hrefLang: js.UndefOr[String] = js.native
+  var hrefLang: js.UndefOr[String] = js.undefined
   
-  var media: js.UndefOr[String] = js.native
+  var media: js.UndefOr[String] = js.undefined
   
-  var rel: js.UndefOr[String] = js.native
+  var rel: js.UndefOr[String] = js.undefined
   
-  var shape: js.UndefOr[String] = js.native
+  var shape: js.UndefOr[String] = js.undefined
   
-  var target: js.UndefOr[String] = js.native
+  var target: js.UndefOr[String] = js.undefined
 }
 object AreaHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/AriaAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/AriaAttributes.scala
@@ -40,240 +40,239 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
-@js.native
 trait AriaAttributes extends StObject {
   
   /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
-  var `aria-activedescendant`: js.UndefOr[String] = js.native
+  var `aria-activedescendant`: js.UndefOr[String] = js.undefined
   
   /** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */
-  var `aria-atomic`: js.UndefOr[Boolean] = js.native
+  var `aria-atomic`: js.UndefOr[Boolean] = js.undefined
   
   /**
     * Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
     * presented if they are made.
     */
-  var `aria-autocomplete`: js.UndefOr[none | `inline` | list | both] = js.native
+  var `aria-autocomplete`: js.UndefOr[none | `inline` | list | both] = js.undefined
   
   /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
-  var `aria-busy`: js.UndefOr[Boolean] = js.native
+  var `aria-busy`: js.UndefOr[Boolean] = js.undefined
   
   /**
     * Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
     * @see aria-pressed @see aria-selected.
     */
-  var `aria-checked`: js.UndefOr[Boolean | mixed] = js.native
+  var `aria-checked`: js.UndefOr[Boolean | mixed] = js.undefined
   
   /**
     * Defines the total number of columns in a table, grid, or treegrid.
     * @see aria-colindex.
     */
-  var `aria-colcount`: js.UndefOr[Double] = js.native
+  var `aria-colcount`: js.UndefOr[Double] = js.undefined
   
   /**
     * Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
     * @see aria-colcount @see aria-colspan.
     */
-  var `aria-colindex`: js.UndefOr[Double] = js.native
+  var `aria-colindex`: js.UndefOr[Double] = js.undefined
   
   /**
     * Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
     * @see aria-colindex @see aria-rowspan.
     */
-  var `aria-colspan`: js.UndefOr[Double] = js.native
+  var `aria-colspan`: js.UndefOr[Double] = js.undefined
   
   /**
     * Identifies the element (or elements) whose contents or presence are controlled by the current element.
     * @see aria-owns.
     */
-  var `aria-controls`: js.UndefOr[String] = js.native
+  var `aria-controls`: js.UndefOr[String] = js.undefined
   
   /** Indicates the element that represents the current item within a container or set of related elements. */
-  var `aria-current`: js.UndefOr[Boolean | page | step | location | date | time] = js.native
+  var `aria-current`: js.UndefOr[Boolean | page | step | location | date | time] = js.undefined
   
   /**
     * Identifies the element (or elements) that describes the object.
     * @see aria-labelledby
     */
-  var `aria-describedby`: js.UndefOr[String] = js.native
+  var `aria-describedby`: js.UndefOr[String] = js.undefined
   
   /**
     * Identifies the element that provides a detailed, extended description for the object.
     * @see aria-describedby.
     */
-  var `aria-details`: js.UndefOr[String] = js.native
+  var `aria-details`: js.UndefOr[String] = js.undefined
   
   /**
     * Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
     * @see aria-hidden @see aria-readonly.
     */
-  var `aria-disabled`: js.UndefOr[Boolean] = js.native
+  var `aria-disabled`: js.UndefOr[Boolean] = js.undefined
   
   /**
     * Indicates what functions can be performed when a dragged object is released on the drop target.
     * @deprecated in ARIA 1.1
     */
-  var `aria-dropeffect`: js.UndefOr[none | copy | execute | link | move | popup] = js.native
+  var `aria-dropeffect`: js.UndefOr[none | copy | execute | link | move | popup] = js.undefined
   
   /**
     * Identifies the element that provides an error message for the object.
     * @see aria-invalid @see aria-describedby.
     */
-  var `aria-errormessage`: js.UndefOr[String] = js.native
+  var `aria-errormessage`: js.UndefOr[String] = js.undefined
   
   /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
-  var `aria-expanded`: js.UndefOr[Boolean] = js.native
+  var `aria-expanded`: js.UndefOr[Boolean] = js.undefined
   
   /**
     * Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
     * allows assistive technology to override the general default of reading in document source order.
     */
-  var `aria-flowto`: js.UndefOr[String] = js.native
+  var `aria-flowto`: js.UndefOr[String] = js.undefined
   
   /**
     * Indicates an element's "grabbed" state in a drag-and-drop operation.
     * @deprecated in ARIA 1.1
     */
-  var `aria-grabbed`: js.UndefOr[Boolean] = js.native
+  var `aria-grabbed`: js.UndefOr[Boolean] = js.undefined
   
   /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
-  var `aria-haspopup`: js.UndefOr[Boolean | menu | listbox | tree | grid | dialog] = js.native
+  var `aria-haspopup`: js.UndefOr[Boolean | menu | listbox | tree | grid | dialog] = js.undefined
   
   /**
     * Indicates whether the element is exposed to an accessibility API.
     * @see aria-disabled.
     */
-  var `aria-hidden`: js.UndefOr[Boolean] = js.native
+  var `aria-hidden`: js.UndefOr[Boolean] = js.undefined
   
   /**
     * Indicates the entered value does not conform to the format expected by the application.
     * @see aria-errormessage.
     */
-  var `aria-invalid`: js.UndefOr[Boolean | grammar | spelling] = js.native
+  var `aria-invalid`: js.UndefOr[Boolean | grammar | spelling] = js.undefined
   
   /** Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. */
-  var `aria-keyshortcuts`: js.UndefOr[String] = js.native
+  var `aria-keyshortcuts`: js.UndefOr[String] = js.undefined
   
   /**
     * Defines a string value that labels the current element.
     * @see aria-labelledby.
     */
-  var `aria-label`: js.UndefOr[String] = js.native
+  var `aria-label`: js.UndefOr[String] = js.undefined
   
   /**
     * Identifies the element (or elements) that labels the current element.
     * @see aria-describedby.
     */
-  var `aria-labelledby`: js.UndefOr[String] = js.native
+  var `aria-labelledby`: js.UndefOr[String] = js.undefined
   
   /** Defines the hierarchical level of an element within a structure. */
-  var `aria-level`: js.UndefOr[Double] = js.native
+  var `aria-level`: js.UndefOr[Double] = js.undefined
   
   /** Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. */
-  var `aria-live`: js.UndefOr[off | assertive | polite] = js.native
+  var `aria-live`: js.UndefOr[off | assertive | polite] = js.undefined
   
   /** Indicates whether an element is modal when displayed. */
-  var `aria-modal`: js.UndefOr[Boolean] = js.native
+  var `aria-modal`: js.UndefOr[Boolean] = js.undefined
   
   /** Indicates whether a text box accepts multiple lines of input or only a single line. */
-  var `aria-multiline`: js.UndefOr[Boolean] = js.native
+  var `aria-multiline`: js.UndefOr[Boolean] = js.undefined
   
   /** Indicates that the user may select more than one item from the current selectable descendants. */
-  var `aria-multiselectable`: js.UndefOr[Boolean] = js.native
+  var `aria-multiselectable`: js.UndefOr[Boolean] = js.undefined
   
   /** Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. */
-  var `aria-orientation`: js.UndefOr[horizontal | vertical] = js.native
+  var `aria-orientation`: js.UndefOr[horizontal | vertical] = js.undefined
   
   /**
     * Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
     * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
     * @see aria-controls.
     */
-  var `aria-owns`: js.UndefOr[String] = js.native
+  var `aria-owns`: js.UndefOr[String] = js.undefined
   
   /**
     * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
     * A hint could be a sample value or a brief description of the expected format.
     */
-  var `aria-placeholder`: js.UndefOr[String] = js.native
+  var `aria-placeholder`: js.UndefOr[String] = js.undefined
   
   /**
     * Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
     * @see aria-setsize.
     */
-  var `aria-posinset`: js.UndefOr[Double] = js.native
+  var `aria-posinset`: js.UndefOr[Double] = js.undefined
   
   /**
     * Indicates the current "pressed" state of toggle buttons.
     * @see aria-checked @see aria-selected.
     */
-  var `aria-pressed`: js.UndefOr[Boolean | mixed] = js.native
+  var `aria-pressed`: js.UndefOr[Boolean | mixed] = js.undefined
   
   /**
     * Indicates that the element is not editable, but is otherwise operable.
     * @see aria-disabled.
     */
-  var `aria-readonly`: js.UndefOr[Boolean] = js.native
+  var `aria-readonly`: js.UndefOr[Boolean] = js.undefined
   
   /**
     * Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
     * @see aria-atomic.
     */
-  var `aria-relevant`: js.UndefOr[additions | (`additions text`) | all | removals | text] = js.native
+  var `aria-relevant`: js.UndefOr[additions | (`additions text`) | all | removals | text] = js.undefined
   
   /** Indicates that user input is required on the element before a form may be submitted. */
-  var `aria-required`: js.UndefOr[Boolean] = js.native
+  var `aria-required`: js.UndefOr[Boolean] = js.undefined
   
   /** Defines a human-readable, author-localized description for the role of an element. */
-  var `aria-roledescription`: js.UndefOr[String] = js.native
+  var `aria-roledescription`: js.UndefOr[String] = js.undefined
   
   /**
     * Defines the total number of rows in a table, grid, or treegrid.
     * @see aria-rowindex.
     */
-  var `aria-rowcount`: js.UndefOr[Double] = js.native
+  var `aria-rowcount`: js.UndefOr[Double] = js.undefined
   
   /**
     * Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
     * @see aria-rowcount @see aria-rowspan.
     */
-  var `aria-rowindex`: js.UndefOr[Double] = js.native
+  var `aria-rowindex`: js.UndefOr[Double] = js.undefined
   
   /**
     * Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
     * @see aria-rowindex @see aria-colspan.
     */
-  var `aria-rowspan`: js.UndefOr[Double] = js.native
+  var `aria-rowspan`: js.UndefOr[Double] = js.undefined
   
   /**
     * Indicates the current "selected" state of various widgets.
     * @see aria-checked @see aria-pressed.
     */
-  var `aria-selected`: js.UndefOr[Boolean] = js.native
+  var `aria-selected`: js.UndefOr[Boolean] = js.undefined
   
   /**
     * Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
     * @see aria-posinset.
     */
-  var `aria-setsize`: js.UndefOr[Double] = js.native
+  var `aria-setsize`: js.UndefOr[Double] = js.undefined
   
   /** Indicates if items in a table or grid are sorted in ascending or descending order. */
-  var `aria-sort`: js.UndefOr[none | ascending | descending | other] = js.native
+  var `aria-sort`: js.UndefOr[none | ascending | descending | other] = js.undefined
   
   /** Defines the maximum allowed value for a range widget. */
-  var `aria-valuemax`: js.UndefOr[Double] = js.native
+  var `aria-valuemax`: js.UndefOr[Double] = js.undefined
   
   /** Defines the minimum allowed value for a range widget. */
-  var `aria-valuemin`: js.UndefOr[Double] = js.native
+  var `aria-valuemin`: js.UndefOr[Double] = js.undefined
   
   /**
     * Defines the current value for a range widget.
     * @see aria-valuetext.
     */
-  var `aria-valuenow`: js.UndefOr[Double] = js.native
+  var `aria-valuenow`: js.UndefOr[Double] = js.undefined
   
   /** Defines the human readable text alternative of aria-valuenow for a range widget. */
-  var `aria-valuetext`: js.UndefOr[String] = js.native
+  var `aria-valuetext`: js.UndefOr[String] = js.undefined
 }
 object AriaAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/Attributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/Attributes.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Attributes extends StObject {
   
-  var key: js.UndefOr[Key] = js.native
+  var key: js.UndefOr[Key] = js.undefined
 }
 object Attributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/BaseHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/BaseHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait BaseHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var href: js.UndefOr[String] = js.native
+  var href: js.UndefOr[String] = js.undefined
   
-  var target: js.UndefOr[String] = js.native
+  var target: js.UndefOr[String] = js.undefined
 }
 object BaseHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/BaseSyntheticEvent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/BaseSyntheticEvent.scala
@@ -8,38 +8,37 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 // Event System
 // ----------------------------------------------------------------------
 // TODO: change any to unknown when moving to TS v3
-@js.native
 trait BaseSyntheticEvent[E, C, T] extends StObject {
   
-  var bubbles: Boolean = js.native
+  var bubbles: Boolean
   
-  var cancelable: Boolean = js.native
+  var cancelable: Boolean
   
-  var currentTarget: C = js.native
+  var currentTarget: C
   
-  var defaultPrevented: Boolean = js.native
+  var defaultPrevented: Boolean
   
-  var eventPhase: Double = js.native
+  var eventPhase: Double
   
-  def isDefaultPrevented(): Boolean = js.native
+  def isDefaultPrevented(): Boolean
   
-  def isPropagationStopped(): Boolean = js.native
+  def isPropagationStopped(): Boolean
   
-  var isTrusted: Boolean = js.native
+  var isTrusted: Boolean
   
-  var nativeEvent: E = js.native
+  var nativeEvent: E
   
-  def persist(): Unit = js.native
+  def persist(): Unit
   
-  def preventDefault(): Unit = js.native
+  def preventDefault(): Unit
   
-  def stopPropagation(): Unit = js.native
+  def stopPropagation(): Unit
   
-  var target: T = js.native
+  var target: T
   
-  var timeStamp: Double = js.native
+  var timeStamp: Double
   
-  var `type`: String = js.native
+  var `type`: String
 }
 object BaseSyntheticEvent {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/BlockquoteHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/BlockquoteHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait BlockquoteHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var cite: js.UndefOr[String] = js.native
+  var cite: js.UndefOr[String] = js.undefined
 }
 object BlockquoteHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ButtonHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ButtonHTMLAttributes.scala
@@ -7,32 +7,31 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ButtonHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var autoFocus: js.UndefOr[Boolean] = js.native
+  var autoFocus: js.UndefOr[Boolean] = js.undefined
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var formAction: js.UndefOr[String] = js.native
+  var formAction: js.UndefOr[String] = js.undefined
   
-  var formEncType: js.UndefOr[String] = js.native
+  var formEncType: js.UndefOr[String] = js.undefined
   
-  var formMethod: js.UndefOr[String] = js.native
+  var formMethod: js.UndefOr[String] = js.undefined
   
-  var formNoValidate: js.UndefOr[Boolean] = js.native
+  var formNoValidate: js.UndefOr[Boolean] = js.undefined
   
-  var formTarget: js.UndefOr[String] = js.native
+  var formTarget: js.UndefOr[String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[submit | reset | button] = js.native
+  var `type`: js.UndefOr[submit | reset | button] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object ButtonHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/CSSProperties.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/CSSProperties.scala
@@ -5,11 +5,10 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* import warning: RemoveDifficultInheritance.summarizeChanges 
-- Dropped / * import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify CSS.Properties<string | number> * / any */ @js.native
-trait CSSProperties extends StObject {
+- Dropped / * import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify CSS.Properties<string | number> * / any */ trait CSSProperties extends StObject {
   
   /* fake member to keep old syntax */
-  val hack: js.UndefOr[js.Any] = js.native
+  val hack: js.UndefOr[js.Any] = js.undefined
 }
 object CSSProperties {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/CanvasHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/CanvasHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait CanvasHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
 }
 object CanvasHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ChangeEvent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ChangeEvent.scala
@@ -6,13 +6,12 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ChangeEvent[T]
   extends StObject
      with BaseSyntheticEvent[Event, EventTarget & T, EventTarget] {
   
   @JSName("target")
-  var target_ChangeEvent: EventTarget & T = js.native
+  var target_ChangeEvent: EventTarget & T
 }
 object ChangeEvent {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ChildContextProvider.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ChildContextProvider.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ChildContextProvider[CC] extends StObject {
   
-  def getChildContext(): CC = js.native
+  def getChildContext(): CC
 }
 object ChildContextProvider {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ClassAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ClassAttributes.scala
@@ -5,12 +5,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ClassAttributes[T]
   extends StObject
      with Attributes {
   
-  var ref: js.UndefOr[LegacyRef[T]] = js.native
+  var ref: js.UndefOr[LegacyRef[T]] = js.undefined
 }
 object ClassAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ClipboardEvent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ClipboardEvent.scala
@@ -6,12 +6,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ClipboardEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeClipboardEvent, EventTarget & T, EventTarget] {
   
-  var clipboardData: DataTransfer = js.native
+  var clipboardData: DataTransfer
 }
 object ClipboardEvent {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ColHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ColHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ColHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var span: js.UndefOr[Double] = js.native
+  var span: js.UndefOr[Double] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
 }
 object ColHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ColgroupHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ColgroupHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ColgroupHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var span: js.UndefOr[Double] = js.native
+  var span: js.UndefOr[Double] = js.undefined
 }
 object ColgroupHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ComponentElement.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ComponentElement.scala
@@ -6,12 +6,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ComponentElement[P, T /* <: ReactComponentClass[P] */]
   extends StObject
      with ReactElement {
   
-  var ref: js.UndefOr[LegacyRef[T]] = js.native
+  var ref: js.UndefOr[LegacyRef[T]] = js.undefined
 }
 object ComponentElement {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ComponentLifecycle.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ComponentLifecycle.scala
@@ -10,7 +10,6 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 // This should actually be something like `Lifecycle<P, S> | DeprecatedLifecycle<P, S>`,
 // as React will _not_ call the deprecated lifecycle methods if any of the new lifecycle
 // methods are present.
-@js.native
 trait ComponentLifecycle[P, S, SS]
   extends StObject
      with NewLifecycle[P, S, SS]
@@ -26,18 +25,18 @@ trait ComponentLifecycle[P, S, SS]
       /* errorInfo */ ErrorInfo, 
       Unit
     ]
-  ] = js.native
+  ] = js.undefined
   
   /**
     * Called immediately after a component is mounted. Setting state here will trigger re-rendering.
     */
-  var componentDidMount: js.UndefOr[js.Function0[Unit]] = js.native
+  var componentDidMount: js.UndefOr[js.Function0[Unit]] = js.undefined
   
   /**
     * Called immediately before a component is destroyed. Perform any necessary cleanup in this method, such as
     * cancelled network requests, or cleaning up any DOM elements created in `componentDidMount`.
     */
-  var componentWillUnmount: js.UndefOr[js.Function0[Unit]] = js.native
+  var componentWillUnmount: js.UndefOr[js.Function0[Unit]] = js.undefined
   
   /**
     * Called to determine whether the change in props and state should trigger a re-render.
@@ -51,7 +50,7 @@ trait ComponentLifecycle[P, S, SS]
     */
   var shouldComponentUpdate: js.UndefOr[
     js.Function3[/* nextProps */ P, /* nextState */ S, /* nextContext */ js.Any, Boolean]
-  ] = js.native
+  ] = js.undefined
 }
 object ComponentLifecycle {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ComponentSpec.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ComponentSpec.scala
@@ -5,13 +5,12 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ComponentSpec[P, S]
   extends StObject
      with Mixin[P, S]
      with /* propertyName */ StringDictionary[js.Any] {
   
-  def render(): slinky.core.facade.ReactElement = js.native
+  def render(): slinky.core.facade.ReactElement
 }
 object ComponentSpec {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/CompositionEvent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/CompositionEvent.scala
@@ -5,12 +5,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait CompositionEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeCompositionEvent, EventTarget & T, EventTarget] {
   
-  var data: String = js.native
+  var data: String
 }
 object CompositionEvent {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ConsumerProps.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ConsumerProps.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ConsumerProps[T] extends StObject {
   
-  def children(value: T): slinky.core.facade.ReactElement = js.native
+  def children(value: T): slinky.core.facade.ReactElement
   
-  var unstable_observedBits: js.UndefOr[Double] = js.native
+  var unstable_observedBits: js.UndefOr[Double] = js.undefined
 }
 object ConsumerProps {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/Context.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/Context.scala
@@ -5,14 +5,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Context[T] extends StObject {
   
-  var Consumer: ReactComponentClass[ConsumerProps[T]] = js.native
+  var Consumer: ReactComponentClass[ConsumerProps[T]]
   
-  var Provider: ReactComponentClass[ProviderProps[T]] = js.native
+  var Provider: ReactComponentClass[ProviderProps[T]]
   
-  var displayName: js.UndefOr[String] = js.native
+  var displayName: js.UndefOr[String] = js.undefined
 }
 object Context {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DOMAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DOMAttributes.scala
@@ -18,186 +18,185 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DOMAttributes[T] extends StObject {
   
-  var children: js.UndefOr[slinky.core.facade.ReactElement] = js.native
+  var children: js.UndefOr[slinky.core.facade.ReactElement] = js.undefined
   
-  var dangerouslySetInnerHTML: js.UndefOr[Html] = js.native
+  var dangerouslySetInnerHTML: js.UndefOr[Html] = js.undefined
   
   // Media Events
-  var onAbort: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onAbort: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onAnimationEnd: js.UndefOr[AnimationEventHandler[T]] = js.native
+  var onAnimationEnd: js.UndefOr[AnimationEventHandler[T]] = js.undefined
   
-  var onAnimationIteration: js.UndefOr[AnimationEventHandler[T]] = js.native
+  var onAnimationIteration: js.UndefOr[AnimationEventHandler[T]] = js.undefined
   
   // Animation Events
-  var onAnimationStart: js.UndefOr[AnimationEventHandler[T]] = js.native
+  var onAnimationStart: js.UndefOr[AnimationEventHandler[T]] = js.undefined
   
   // MouseEvents
-  var onAuxClick: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onAuxClick: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onBeforeInput: js.UndefOr[FormEventHandler[T]] = js.native
+  var onBeforeInput: js.UndefOr[FormEventHandler[T]] = js.undefined
   
-  var onBlur: js.UndefOr[FocusEventHandler[T]] = js.native
+  var onBlur: js.UndefOr[FocusEventHandler[T]] = js.undefined
   
-  var onCanPlay: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onCanPlay: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onCanPlayThrough: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onCanPlayThrough: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
   // Form Events
-  var onChange: js.UndefOr[FormEventHandler[T]] = js.native
+  var onChange: js.UndefOr[FormEventHandler[T]] = js.undefined
   
-  var onClick: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onClick: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
   // Composition Events
-  var onCompositionEnd: js.UndefOr[CompositionEventHandler[T]] = js.native
+  var onCompositionEnd: js.UndefOr[CompositionEventHandler[T]] = js.undefined
   
-  var onCompositionStart: js.UndefOr[CompositionEventHandler[T]] = js.native
+  var onCompositionStart: js.UndefOr[CompositionEventHandler[T]] = js.undefined
   
-  var onCompositionUpdate: js.UndefOr[CompositionEventHandler[T]] = js.native
+  var onCompositionUpdate: js.UndefOr[CompositionEventHandler[T]] = js.undefined
   
-  var onContextMenu: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onContextMenu: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
   // Clipboard Events
-  var onCopy: js.UndefOr[ClipboardEventHandler[T]] = js.native
+  var onCopy: js.UndefOr[ClipboardEventHandler[T]] = js.undefined
   
-  var onCut: js.UndefOr[ClipboardEventHandler[T]] = js.native
+  var onCut: js.UndefOr[ClipboardEventHandler[T]] = js.undefined
   
-  var onDoubleClick: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onDoubleClick: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onDrag: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDrag: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDragEnd: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDragEnd: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDragEnter: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDragEnter: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDragExit: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDragExit: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDragLeave: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDragLeave: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDragOver: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDragOver: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDragStart: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDragStart: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDrop: js.UndefOr[DragEventHandler[T]] = js.native
+  var onDrop: js.UndefOr[DragEventHandler[T]] = js.undefined
   
-  var onDurationChange: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onDurationChange: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onEmptied: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onEmptied: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onEncrypted: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onEncrypted: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onEnded: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onEnded: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onError: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onError: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
   // Focus Events
-  var onFocus: js.UndefOr[FocusEventHandler[T]] = js.native
+  var onFocus: js.UndefOr[FocusEventHandler[T]] = js.undefined
   
-  var onInput: js.UndefOr[FormEventHandler[T]] = js.native
+  var onInput: js.UndefOr[FormEventHandler[T]] = js.undefined
   
-  var onInvalid: js.UndefOr[FormEventHandler[T]] = js.native
+  var onInvalid: js.UndefOr[FormEventHandler[T]] = js.undefined
   
   // also a Media Event
   // Keyboard Events
-  var onKeyDown: js.UndefOr[KeyboardEventHandler[T]] = js.native
+  var onKeyDown: js.UndefOr[KeyboardEventHandler[T]] = js.undefined
   
-  var onKeyPress: js.UndefOr[KeyboardEventHandler[T]] = js.native
+  var onKeyPress: js.UndefOr[KeyboardEventHandler[T]] = js.undefined
   
-  var onKeyUp: js.UndefOr[KeyboardEventHandler[T]] = js.native
+  var onKeyUp: js.UndefOr[KeyboardEventHandler[T]] = js.undefined
   
   // Image Events
-  var onLoad: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onLoad: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onLoadStart: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onLoadStart: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onLoadedData: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onLoadedData: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onLoadedMetadata: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onLoadedMetadata: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onMouseDown: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onMouseDown: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onMouseEnter: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onMouseEnter: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onMouseLeave: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onMouseLeave: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onMouseMove: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onMouseMove: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onMouseOut: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onMouseOut: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onMouseOver: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onMouseOver: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onMouseUp: js.UndefOr[MouseEventHandler[T]] = js.native
+  var onMouseUp: js.UndefOr[MouseEventHandler[T]] = js.undefined
   
-  var onPaste: js.UndefOr[ClipboardEventHandler[T]] = js.native
+  var onPaste: js.UndefOr[ClipboardEventHandler[T]] = js.undefined
   
-  var onPause: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onPause: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onPlay: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onPlay: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onPlaying: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onPlaying: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onPointerCancel: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerCancel: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
   // Pointer Events
-  var onPointerDown: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerDown: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
-  var onPointerEnter: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerEnter: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
-  var onPointerLeave: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerLeave: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
-  var onPointerMove: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerMove: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
-  var onPointerOut: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerOut: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
-  var onPointerOver: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerOver: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
-  var onPointerUp: js.UndefOr[PointerEventHandler[T]] = js.native
+  var onPointerUp: js.UndefOr[PointerEventHandler[T]] = js.undefined
   
-  var onProgress: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onProgress: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onRateChange: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onRateChange: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onReset: js.UndefOr[FormEventHandler[T]] = js.native
+  var onReset: js.UndefOr[FormEventHandler[T]] = js.undefined
   
   // UI Events
-  var onScroll: js.UndefOr[UIEventHandler[T]] = js.native
+  var onScroll: js.UndefOr[UIEventHandler[T]] = js.undefined
   
-  var onSeeked: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onSeeked: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onSeeking: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onSeeking: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
   // Selection Events
-  var onSelect: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onSelect: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onStalled: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onStalled: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onSubmit: js.UndefOr[FormEventHandler[T]] = js.native
+  var onSubmit: js.UndefOr[FormEventHandler[T]] = js.undefined
   
-  var onSuspend: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onSuspend: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onTimeUpdate: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onTimeUpdate: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
   // Touch Events
-  var onTouchCancel: js.UndefOr[TouchEventHandler[T]] = js.native
+  var onTouchCancel: js.UndefOr[TouchEventHandler[T]] = js.undefined
   
-  var onTouchEnd: js.UndefOr[TouchEventHandler[T]] = js.native
+  var onTouchEnd: js.UndefOr[TouchEventHandler[T]] = js.undefined
   
-  var onTouchMove: js.UndefOr[TouchEventHandler[T]] = js.native
+  var onTouchMove: js.UndefOr[TouchEventHandler[T]] = js.undefined
   
-  var onTouchStart: js.UndefOr[TouchEventHandler[T]] = js.native
+  var onTouchStart: js.UndefOr[TouchEventHandler[T]] = js.undefined
   
   // Transition Events
-  var onTransitionEnd: js.UndefOr[TransitionEventHandler[T]] = js.native
+  var onTransitionEnd: js.UndefOr[TransitionEventHandler[T]] = js.undefined
   
-  var onVolumeChange: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onVolumeChange: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
-  var onWaiting: js.UndefOr[ReactEventHandler[T]] = js.native
+  var onWaiting: js.UndefOr[ReactEventHandler[T]] = js.undefined
   
   // Wheel Events
-  var onWheel: js.UndefOr[WheelEventHandler[T]] = js.native
+  var onWheel: js.UndefOr[WheelEventHandler[T]] = js.undefined
 }
 object DOMAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DOMElement.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DOMElement.scala
@@ -7,12 +7,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 // string fallback for custom web-components
-@js.native
 trait DOMElement[P /* <: HTMLAttributes[T] | SVGAttributes[T] */, T /* <: Element */]
   extends StObject
      with ReactElement {
   
-  var ref: LegacyRef[T] = js.native
+  var ref: LegacyRef[T]
 }
 object DOMElement {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DataHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DataHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DataHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object DataHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DelHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DelHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DelHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var cite: js.UndefOr[String] = js.native
+  var cite: js.UndefOr[String] = js.undefined
   
-  var dateTime: js.UndefOr[String] = js.native
+  var dateTime: js.UndefOr[String] = js.undefined
 }
 object DelHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DeprecatedLifecycle.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DeprecatedLifecycle.scala
@@ -4,7 +4,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DeprecatedLifecycle[P, S] extends StObject {
   
   /**
@@ -20,7 +19,7 @@ trait DeprecatedLifecycle[P, S] extends StObject {
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
     */
-  var UNSAFE_componentWillMount: js.UndefOr[js.Function0[Unit]] = js.native
+  var UNSAFE_componentWillMount: js.UndefOr[js.Function0[Unit]] = js.undefined
   
   /**
     * Called when the component may be receiving new props.
@@ -38,7 +37,7 @@ trait DeprecatedLifecycle[P, S] extends StObject {
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
     */
-  var UNSAFE_componentWillReceiveProps: js.UndefOr[js.Function2[/* nextProps */ P, /* nextContext */ js.Any, Unit]] = js.native
+  var UNSAFE_componentWillReceiveProps: js.UndefOr[js.Function2[/* nextProps */ P, /* nextContext */ js.Any, Unit]] = js.undefined
   
   /**
     * Called immediately before rendering when new props or state is received. Not called for the initial render.
@@ -56,7 +55,7 @@ trait DeprecatedLifecycle[P, S] extends StObject {
     */
   var UNSAFE_componentWillUpdate: js.UndefOr[
     js.Function3[/* nextProps */ P, /* nextState */ S, /* nextContext */ js.Any, Unit]
-  ] = js.native
+  ] = js.undefined
   
   /**
     * Called immediately before mounting occurs, and before `Component#render`.
@@ -69,7 +68,7 @@ trait DeprecatedLifecycle[P, S] extends StObject {
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
     */
-  var componentWillMount: js.UndefOr[js.Function0[Unit]] = js.native
+  var componentWillMount: js.UndefOr[js.Function0[Unit]] = js.undefined
   
   /**
     * Called when the component may be receiving new props.
@@ -85,7 +84,7 @@ trait DeprecatedLifecycle[P, S] extends StObject {
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
     */
-  var componentWillReceiveProps: js.UndefOr[js.Function2[/* nextProps */ P, /* nextContext */ js.Any, Unit]] = js.native
+  var componentWillReceiveProps: js.UndefOr[js.Function2[/* nextProps */ P, /* nextContext */ js.Any, Unit]] = js.undefined
   
   /**
     * Called immediately before rendering when new props or state is received. Not called for the initial render.
@@ -101,7 +100,7 @@ trait DeprecatedLifecycle[P, S] extends StObject {
     */
   var componentWillUpdate: js.UndefOr[
     js.Function3[/* nextProps */ P, /* nextState */ S, /* nextContext */ js.Any, Unit]
-  ] = js.native
+  ] = js.undefined
 }
 object DeprecatedLifecycle {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DetailedReactHTMLElement.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DetailedReactHTMLElement.scala
@@ -5,7 +5,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DetailedReactHTMLElement[P /* <: HTMLAttributes[T] */, T /* <: HTMLElement */]
   extends StObject
      with DOMElement[P, T]

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DetailsHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DetailsHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DetailsHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var open: js.UndefOr[Boolean] = js.native
+  var open: js.UndefOr[Boolean] = js.undefined
 }
 object DetailsHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DialogHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DialogHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DialogHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var open: js.UndefOr[Boolean] = js.native
+  var open: js.UndefOr[Boolean] = js.undefined
 }
 object DialogHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DragEvent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/DragEvent.scala
@@ -6,12 +6,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DragEvent[T]
   extends StObject
      with MouseEvent[T, NativeDragEvent] {
   
-  var dataTransfer: DataTransfer = js.native
+  var dataTransfer: DataTransfer
 }
 object DragEvent {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/EmbedHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/EmbedHTMLAttributes.scala
@@ -4,18 +4,17 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait EmbedHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
 }
 object EmbedHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ErrorInfo.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ErrorInfo.scala
@@ -7,13 +7,12 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 //
 // Error Interfaces
 // ----------------------------------------------------------------------
-@js.native
 trait ErrorInfo extends StObject {
   
   /**
     * Captures which component contained the exception, and its ancestors.
     */
-  var componentStack: String = js.native
+  var componentStack: String
 }
 object ErrorInfo {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/FieldsetHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/FieldsetHTMLAttributes.scala
@@ -4,16 +4,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait FieldsetHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
 }
 object FieldsetHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/FocusEvent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/FocusEvent.scala
@@ -5,15 +5,14 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait FocusEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeFocusEvent, EventTarget & T, EventTarget] {
   
-  var relatedTarget: EventTarget = js.native
+  var relatedTarget: EventTarget
   
   @JSName("target")
-  var target_FocusEvent: EventTarget & T = js.native
+  var target_FocusEvent: EventTarget & T
 }
 object FocusEvent {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/FormHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/FormHTMLAttributes.scala
@@ -4,26 +4,25 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait FormHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var acceptCharset: js.UndefOr[String] = js.native
+  var acceptCharset: js.UndefOr[String] = js.undefined
   
-  var action: js.UndefOr[String] = js.native
+  var action: js.UndefOr[String] = js.undefined
   
-  var autoComplete: js.UndefOr[String] = js.native
+  var autoComplete: js.UndefOr[String] = js.undefined
   
-  var encType: js.UndefOr[String] = js.native
+  var encType: js.UndefOr[String] = js.undefined
   
-  var method: js.UndefOr[String] = js.native
+  var method: js.UndefOr[String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
-  var noValidate: js.UndefOr[Boolean] = js.native
+  var noValidate: js.UndefOr[Boolean] = js.undefined
   
-  var target: js.UndefOr[String] = js.native
+  var target: js.UndefOr[String] = js.undefined
 }
 object FormHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/FunctionComponentElement.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/FunctionComponentElement.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait FunctionComponentElement[P]
   extends StObject
      with ReactElement {
   
-  var ref: js.UndefOr[js.Any] = js.native
+  var ref: js.UndefOr[js.Any] = js.undefined
 }
 object FunctionComponentElement {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/HTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/HTMLAttributes.scala
@@ -6,104 +6,103 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HTMLAttributes[T]
   extends StObject
      with AriaAttributes
      with DOMAttributes[T] {
   
   // RDFa Attributes
-  var about: js.UndefOr[String] = js.native
+  var about: js.UndefOr[String] = js.undefined
   
   // Standard HTML Attributes
-  var accessKey: js.UndefOr[String] = js.native
+  var accessKey: js.UndefOr[String] = js.undefined
   
   // Non-standard Attributes
-  var autoCapitalize: js.UndefOr[String] = js.native
+  var autoCapitalize: js.UndefOr[String] = js.undefined
   
-  var autoCorrect: js.UndefOr[String] = js.native
+  var autoCorrect: js.UndefOr[String] = js.undefined
   
-  var autoSave: js.UndefOr[String] = js.native
+  var autoSave: js.UndefOr[String] = js.undefined
   
-  var className: js.UndefOr[String] = js.native
+  var className: js.UndefOr[String] = js.undefined
   
-  var color: js.UndefOr[String] = js.native
+  var color: js.UndefOr[String] = js.undefined
   
-  var contentEditable: js.UndefOr[Boolean] = js.native
+  var contentEditable: js.UndefOr[Boolean] = js.undefined
   
-  var contextMenu: js.UndefOr[String] = js.native
+  var contextMenu: js.UndefOr[String] = js.undefined
   
-  var datatype: js.UndefOr[String] = js.native
+  var datatype: js.UndefOr[String] = js.undefined
   
   // React-specific Attributes
-  var defaultChecked: js.UndefOr[Boolean] = js.native
+  var defaultChecked: js.UndefOr[Boolean] = js.undefined
   
-  var defaultValue: js.UndefOr[String | js.Array[String]] = js.native
+  var defaultValue: js.UndefOr[String | js.Array[String]] = js.undefined
   
-  var dir: js.UndefOr[String] = js.native
+  var dir: js.UndefOr[String] = js.undefined
   
-  var draggable: js.UndefOr[Boolean] = js.native
+  var draggable: js.UndefOr[Boolean] = js.undefined
   
-  var hidden: js.UndefOr[Boolean] = js.native
+  var hidden: js.UndefOr[Boolean] = js.undefined
   
-  var id: js.UndefOr[String] = js.native
+  var id: js.UndefOr[String] = js.undefined
   
-  var inlist: js.UndefOr[js.Any] = js.native
+  var inlist: js.UndefOr[js.Any] = js.undefined
   
   // Unknown
-  var inputMode: js.UndefOr[String] = js.native
+  var inputMode: js.UndefOr[String] = js.undefined
   
-  var is: js.UndefOr[String] = js.native
+  var is: js.UndefOr[String] = js.undefined
   
-  var itemID: js.UndefOr[String] = js.native
+  var itemID: js.UndefOr[String] = js.undefined
   
-  var itemProp: js.UndefOr[String] = js.native
+  var itemProp: js.UndefOr[String] = js.undefined
   
-  var itemRef: js.UndefOr[String] = js.native
+  var itemRef: js.UndefOr[String] = js.undefined
   
-  var itemScope: js.UndefOr[Boolean] = js.native
+  var itemScope: js.UndefOr[Boolean] = js.undefined
   
-  var itemType: js.UndefOr[String] = js.native
+  var itemType: js.UndefOr[String] = js.undefined
   
-  var lang: js.UndefOr[String] = js.native
+  var lang: js.UndefOr[String] = js.undefined
   
-  var placeholder: js.UndefOr[String] = js.native
+  var placeholder: js.UndefOr[String] = js.undefined
   
-  var prefix: js.UndefOr[String] = js.native
+  var prefix: js.UndefOr[String] = js.undefined
   
-  var property: js.UndefOr[String] = js.native
+  var property: js.UndefOr[String] = js.undefined
   
-  var radioGroup: js.UndefOr[String] = js.native
+  var radioGroup: js.UndefOr[String] = js.undefined
   
-  var resource: js.UndefOr[String] = js.native
+  var resource: js.UndefOr[String] = js.undefined
   
-  var results: js.UndefOr[Double] = js.native
+  var results: js.UndefOr[Double] = js.undefined
   
   // <command>, <menuitem>
   // WAI-ARIA
-  var role: js.UndefOr[String] = js.native
+  var role: js.UndefOr[String] = js.undefined
   
-  var security: js.UndefOr[String] = js.native
+  var security: js.UndefOr[String] = js.undefined
   
-  var slot: js.UndefOr[String] = js.native
+  var slot: js.UndefOr[String] = js.undefined
   
-  var spellCheck: js.UndefOr[Boolean] = js.native
+  var spellCheck: js.UndefOr[Boolean] = js.undefined
   
-  var style: js.UndefOr[CSSProperties] = js.native
+  var style: js.UndefOr[CSSProperties] = js.undefined
   
-  var suppressContentEditableWarning: js.UndefOr[Boolean] = js.native
+  var suppressContentEditableWarning: js.UndefOr[Boolean] = js.undefined
   
-  var suppressHydrationWarning: js.UndefOr[Boolean] = js.native
+  var suppressHydrationWarning: js.UndefOr[Boolean] = js.undefined
   
-  var tabIndex: js.UndefOr[Double] = js.native
+  var tabIndex: js.UndefOr[Double] = js.undefined
   
-  var title: js.UndefOr[String] = js.native
+  var title: js.UndefOr[String] = js.undefined
   
-  var typeof: js.UndefOr[String] = js.native
+  var typeof: js.UndefOr[String] = js.undefined
   
-  var unselectable: js.UndefOr[on | off] = js.native
+  var unselectable: js.UndefOr[on | off] = js.undefined
   
-  var vocab: js.UndefOr[String] = js.native
+  var vocab: js.UndefOr[String] = js.undefined
 }
 object HTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/HTMLProps.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/HTMLProps.scala
@@ -4,7 +4,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HTMLProps[T]
   extends StObject
      with AllHTMLAttributes[T]

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/HtmlHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/HtmlHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HtmlHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var manifest: js.UndefOr[String] = js.native
+  var manifest: js.UndefOr[String] = js.undefined
 }
 object HtmlHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/IframeHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/IframeHTMLAttributes.scala
@@ -4,40 +4,39 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait IframeHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var allow: js.UndefOr[String] = js.native
+  var allow: js.UndefOr[String] = js.undefined
   
-  var allowFullScreen: js.UndefOr[Boolean] = js.native
+  var allowFullScreen: js.UndefOr[Boolean] = js.undefined
   
-  var allowTransparency: js.UndefOr[Boolean] = js.native
+  var allowTransparency: js.UndefOr[Boolean] = js.undefined
   
-  var frameBorder: js.UndefOr[Double | String] = js.native
+  var frameBorder: js.UndefOr[Double | String] = js.undefined
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var marginHeight: js.UndefOr[Double] = js.native
+  var marginHeight: js.UndefOr[Double] = js.undefined
   
-  var marginWidth: js.UndefOr[Double] = js.native
+  var marginWidth: js.UndefOr[Double] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
-  var referrerPolicy: js.UndefOr[String] = js.native
+  var referrerPolicy: js.UndefOr[String] = js.undefined
   
-  var sandbox: js.UndefOr[String] = js.native
+  var sandbox: js.UndefOr[String] = js.undefined
   
-  var scrolling: js.UndefOr[String] = js.native
+  var scrolling: js.UndefOr[String] = js.undefined
   
-  var seamless: js.UndefOr[Boolean] = js.native
+  var seamless: js.UndefOr[Boolean] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var srcDoc: js.UndefOr[String] = js.native
+  var srcDoc: js.UndefOr[String] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
 }
 object IframeHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ImgHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ImgHTMLAttributes.scala
@@ -10,28 +10,27 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ImgHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var alt: js.UndefOr[String] = js.native
+  var alt: js.UndefOr[String] = js.undefined
   
-  var crossOrigin: js.UndefOr[anonymous | `use-credentials` | _empty] = js.native
+  var crossOrigin: js.UndefOr[anonymous | `use-credentials` | _empty] = js.undefined
   
-  var decoding: js.UndefOr[async | auto | sync] = js.native
+  var decoding: js.UndefOr[async | auto | sync] = js.undefined
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var sizes: js.UndefOr[String] = js.native
+  var sizes: js.UndefOr[String] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var srcSet: js.UndefOr[String] = js.native
+  var srcSet: js.UndefOr[String] = js.undefined
   
-  var useMap: js.UndefOr[String] = js.native
+  var useMap: js.UndefOr[String] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
 }
 object ImgHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/InputHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/InputHTMLAttributes.scala
@@ -4,76 +4,75 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait InputHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var accept: js.UndefOr[String] = js.native
+  var accept: js.UndefOr[String] = js.undefined
   
-  var alt: js.UndefOr[String] = js.native
+  var alt: js.UndefOr[String] = js.undefined
   
-  var autoComplete: js.UndefOr[String] = js.native
+  var autoComplete: js.UndefOr[String] = js.undefined
   
-  var autoFocus: js.UndefOr[Boolean] = js.native
+  var autoFocus: js.UndefOr[Boolean] = js.undefined
   
-  var capture: js.UndefOr[Boolean | String] = js.native
+  var capture: js.UndefOr[Boolean | String] = js.undefined
   
   // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
-  var checked: js.UndefOr[Boolean] = js.native
+  var checked: js.UndefOr[Boolean] = js.undefined
   
-  var crossOrigin: js.UndefOr[String] = js.native
+  var crossOrigin: js.UndefOr[String] = js.undefined
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var formAction: js.UndefOr[String] = js.native
+  var formAction: js.UndefOr[String] = js.undefined
   
-  var formEncType: js.UndefOr[String] = js.native
+  var formEncType: js.UndefOr[String] = js.undefined
   
-  var formMethod: js.UndefOr[String] = js.native
+  var formMethod: js.UndefOr[String] = js.undefined
   
-  var formNoValidate: js.UndefOr[Boolean] = js.native
+  var formNoValidate: js.UndefOr[Boolean] = js.undefined
   
-  var formTarget: js.UndefOr[String] = js.native
+  var formTarget: js.UndefOr[String] = js.undefined
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var list: js.UndefOr[String] = js.native
+  var list: js.UndefOr[String] = js.undefined
   
-  var max: js.UndefOr[Double | String] = js.native
+  var max: js.UndefOr[Double | String] = js.undefined
   
-  var maxLength: js.UndefOr[Double] = js.native
+  var maxLength: js.UndefOr[Double] = js.undefined
   
-  var min: js.UndefOr[Double | String] = js.native
+  var min: js.UndefOr[Double | String] = js.undefined
   
-  var minLength: js.UndefOr[Double] = js.native
+  var minLength: js.UndefOr[Double] = js.undefined
   
-  var multiple: js.UndefOr[Boolean] = js.native
+  var multiple: js.UndefOr[Boolean] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
   @JSName("onChange")
-  var onChange_InputHTMLAttributes: js.UndefOr[ChangeEventHandler[T]] = js.native
+  var onChange_InputHTMLAttributes: js.UndefOr[ChangeEventHandler[T]] = js.undefined
   
-  var pattern: js.UndefOr[String] = js.native
+  var pattern: js.UndefOr[String] = js.undefined
   
-  var readOnly: js.UndefOr[Boolean] = js.native
+  var readOnly: js.UndefOr[Boolean] = js.undefined
   
-  var required: js.UndefOr[Boolean] = js.native
+  var required: js.UndefOr[Boolean] = js.undefined
   
-  var size: js.UndefOr[Double] = js.native
+  var size: js.UndefOr[Double] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var step: js.UndefOr[Double | String] = js.native
+  var step: js.UndefOr[Double | String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
 }
 object InputHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/InsHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/InsHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait InsHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var cite: js.UndefOr[String] = js.native
+  var cite: js.UndefOr[String] = js.undefined
   
-  var dateTime: js.UndefOr[String] = js.native
+  var dateTime: js.UndefOr[String] = js.undefined
 }
 object InsHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/InvalidEvent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/InvalidEvent.scala
@@ -6,13 +6,12 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait InvalidEvent[T]
   extends StObject
      with BaseSyntheticEvent[Event, EventTarget & T, EventTarget] {
   
   @JSName("target")
-  var target_InvalidEvent: EventTarget & T = js.native
+  var target_InvalidEvent: EventTarget & T
 }
 object InvalidEvent {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/KeyboardEvent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/KeyboardEvent.scala
@@ -5,40 +5,39 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait KeyboardEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeKeyboardEvent, EventTarget & T, EventTarget] {
   
-  var altKey: Boolean = js.native
+  var altKey: Boolean
   
-  var charCode: Double = js.native
+  var charCode: Double
   
-  var ctrlKey: Boolean = js.native
+  var ctrlKey: Boolean
   
   /**
     * See [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#keys-modifier). for a list of valid (case-sensitive) arguments to this method.
     */
-  def getModifierState(key: String): Boolean = js.native
+  def getModifierState(key: String): Boolean
   
   /**
     * See the [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#named-key-attribute-values). for possible values
     */
-  var key: String = js.native
+  var key: String
   
-  var keyCode: Double = js.native
+  var keyCode: Double
   
-  var locale: String = js.native
+  var locale: String
   
-  var location: Double = js.native
+  var location: Double
   
-  var metaKey: Boolean = js.native
+  var metaKey: Boolean
   
-  var repeat: Boolean = js.native
+  var repeat: Boolean
   
-  var shiftKey: Boolean = js.native
+  var shiftKey: Boolean
   
-  var which: Double = js.native
+  var which: Double
 }
 object KeyboardEvent {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/KeygenHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/KeygenHTMLAttributes.scala
@@ -4,24 +4,23 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait KeygenHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var autoFocus: js.UndefOr[Boolean] = js.native
+  var autoFocus: js.UndefOr[Boolean] = js.undefined
   
-  var challenge: js.UndefOr[String] = js.native
+  var challenge: js.UndefOr[String] = js.undefined
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var keyParams: js.UndefOr[String] = js.native
+  var keyParams: js.UndefOr[String] = js.undefined
   
-  var keyType: js.UndefOr[String] = js.native
+  var keyType: js.UndefOr[String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
 }
 object KeygenHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/LabelHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/LabelHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait LabelHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var htmlFor: js.UndefOr[String] = js.native
+  var htmlFor: js.UndefOr[String] = js.undefined
 }
 object LabelHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/LiHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/LiHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait LiHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object LiHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/LinkHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/LinkHTMLAttributes.scala
@@ -4,28 +4,27 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait LinkHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var as: js.UndefOr[String] = js.native
+  var as: js.UndefOr[String] = js.undefined
   
-  var crossOrigin: js.UndefOr[String] = js.native
+  var crossOrigin: js.UndefOr[String] = js.undefined
   
-  var href: js.UndefOr[String] = js.native
+  var href: js.UndefOr[String] = js.undefined
   
-  var hrefLang: js.UndefOr[String] = js.native
+  var hrefLang: js.UndefOr[String] = js.undefined
   
-  var integrity: js.UndefOr[String] = js.native
+  var integrity: js.UndefOr[String] = js.undefined
   
-  var media: js.UndefOr[String] = js.native
+  var media: js.UndefOr[String] = js.undefined
   
-  var rel: js.UndefOr[String] = js.native
+  var rel: js.UndefOr[String] = js.undefined
   
-  var sizes: js.UndefOr[String] = js.native
+  var sizes: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
 }
 object LinkHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/MapHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/MapHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait MapHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
 }
 object MapHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/MediaHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/MediaHTMLAttributes.scala
@@ -4,30 +4,29 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait MediaHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var autoPlay: js.UndefOr[Boolean] = js.native
+  var autoPlay: js.UndefOr[Boolean] = js.undefined
   
-  var controls: js.UndefOr[Boolean] = js.native
+  var controls: js.UndefOr[Boolean] = js.undefined
   
-  var controlsList: js.UndefOr[String] = js.native
+  var controlsList: js.UndefOr[String] = js.undefined
   
-  var crossOrigin: js.UndefOr[String] = js.native
+  var crossOrigin: js.UndefOr[String] = js.undefined
   
-  var loop: js.UndefOr[Boolean] = js.native
+  var loop: js.UndefOr[Boolean] = js.undefined
   
-  var mediaGroup: js.UndefOr[String] = js.native
+  var mediaGroup: js.UndefOr[String] = js.undefined
   
-  var muted: js.UndefOr[Boolean] = js.native
+  var muted: js.UndefOr[Boolean] = js.undefined
   
-  var playsinline: js.UndefOr[Boolean] = js.native
+  var playsinline: js.UndefOr[Boolean] = js.undefined
   
-  var preload: js.UndefOr[String] = js.native
+  var preload: js.UndefOr[String] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
 }
 object MediaHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/MenuHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/MenuHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait MenuHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
 }
 object MenuHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/MetaHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/MetaHTMLAttributes.scala
@@ -4,18 +4,17 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait MetaHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var charSet: js.UndefOr[String] = js.native
+  var charSet: js.UndefOr[String] = js.undefined
   
-  var content: js.UndefOr[String] = js.native
+  var content: js.UndefOr[String] = js.undefined
   
-  var httpEquiv: js.UndefOr[String] = js.native
+  var httpEquiv: js.UndefOr[String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
 }
 object MetaHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/MeterHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/MeterHTMLAttributes.scala
@@ -4,24 +4,23 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait MeterHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var high: js.UndefOr[Double] = js.native
+  var high: js.UndefOr[Double] = js.undefined
   
-  var low: js.UndefOr[Double] = js.native
+  var low: js.UndefOr[Double] = js.undefined
   
-  var max: js.UndefOr[Double | String] = js.native
+  var max: js.UndefOr[Double | String] = js.undefined
   
-  var min: js.UndefOr[Double | String] = js.native
+  var min: js.UndefOr[Double | String] = js.undefined
   
-  var optimum: js.UndefOr[Double] = js.native
+  var optimum: js.UndefOr[Double] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object MeterHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/Mixin.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/Mixin.scala
@@ -5,26 +5,25 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Mixin[P, S]
   extends StObject
      with ComponentLifecycle[P, S, js.Any] {
   
-  var childContextTypes: js.UndefOr[ValidationMap[js.Any]] = js.native
+  var childContextTypes: js.UndefOr[ValidationMap[js.Any]] = js.undefined
   
-  var contextTypes: js.UndefOr[ValidationMap[js.Any]] = js.native
+  var contextTypes: js.UndefOr[ValidationMap[js.Any]] = js.undefined
   
-  var displayName: js.UndefOr[String] = js.native
+  var displayName: js.UndefOr[String] = js.undefined
   
-  var getDefaultProps: js.UndefOr[js.Function0[P]] = js.native
+  var getDefaultProps: js.UndefOr[js.Function0[P]] = js.undefined
   
-  var getInitialState: js.UndefOr[js.Function0[S]] = js.native
+  var getInitialState: js.UndefOr[js.Function0[S]] = js.undefined
   
-  var mixins: js.UndefOr[js.Array[Mixin[P, S]]] = js.native
+  var mixins: js.UndefOr[js.Array[Mixin[P, S]]] = js.undefined
   
-  var propTypes: js.UndefOr[ValidationMap[js.Any]] = js.native
+  var propTypes: js.UndefOr[ValidationMap[js.Any]] = js.undefined
   
-  var statics: js.UndefOr[StringDictionary[js.Any]] = js.native
+  var statics: js.UndefOr[StringDictionary[js.Any]] = js.undefined
 }
 object Mixin {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/MouseEvent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/MouseEvent.scala
@@ -5,45 +5,44 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait MouseEvent[T, E]
   extends StObject
      with BaseSyntheticEvent[E, EventTarget & T, EventTarget] {
   
-  var altKey: Boolean = js.native
+  var altKey: Boolean
   
-  var button: Double = js.native
+  var button: Double
   
-  var buttons: Double = js.native
+  var buttons: Double
   
-  var clientX: Double = js.native
+  var clientX: Double
   
-  var clientY: Double = js.native
+  var clientY: Double
   
-  var ctrlKey: Boolean = js.native
+  var ctrlKey: Boolean
   
   /**
     * See [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#keys-modifier). for a list of valid (case-sensitive) arguments to this method.
     */
-  def getModifierState(key: String): Boolean = js.native
+  def getModifierState(key: String): Boolean
   
-  var metaKey: Boolean = js.native
+  var metaKey: Boolean
   
-  var movementX: Double = js.native
+  var movementX: Double
   
-  var movementY: Double = js.native
+  var movementY: Double
   
-  var pageX: Double = js.native
+  var pageX: Double
   
-  var pageY: Double = js.native
+  var pageY: Double
   
-  var relatedTarget: EventTarget = js.native
+  var relatedTarget: EventTarget
   
-  var screenX: Double = js.native
+  var screenX: Double
   
-  var screenY: Double = js.native
+  var screenY: Double
   
-  var shiftKey: Boolean = js.native
+  var shiftKey: Boolean
 }
 object MouseEvent {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/MutableRefObject.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/MutableRefObject.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait MutableRefObject[T] extends StObject {
   
-  var current: T = js.native
+  var current: T
 }
 object MutableRefObject {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/NewLifecycle.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/NewLifecycle.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 // This should be "infer SS" but can't use it yet
-@js.native
 trait NewLifecycle[P, S, SS] extends StObject {
   
   /**
@@ -15,7 +14,7 @@ trait NewLifecycle[P, S, SS] extends StObject {
     */
   var componentDidUpdate: js.UndefOr[
     js.Function3[/* prevProps */ P, /* prevState */ S, /* snapshot */ js.UndefOr[SS], Unit]
-  ] = js.native
+  ] = js.undefined
   
   /**
     * Runs before React applies the result of `render` to the document, and
@@ -25,7 +24,7 @@ trait NewLifecycle[P, S, SS] extends StObject {
     * Note: the presence of getSnapshotBeforeUpdate prevents any of the deprecated
     * lifecycle events from running.
     */
-  var getSnapshotBeforeUpdate: js.UndefOr[js.Function2[/* prevProps */ P, /* prevState */ S, SS | Null]] = js.native
+  var getSnapshotBeforeUpdate: js.UndefOr[js.Function2[/* prevProps */ P, /* prevState */ S, SS | Null]] = js.undefined
 }
 object NewLifecycle {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ObjectHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ObjectHTMLAttributes.scala
@@ -4,28 +4,27 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ObjectHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var classID: js.UndefOr[String] = js.native
+  var classID: js.UndefOr[String] = js.undefined
   
-  var data: js.UndefOr[String] = js.native
+  var data: js.UndefOr[String] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
   
-  var useMap: js.UndefOr[String] = js.native
+  var useMap: js.UndefOr[String] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
   
-  var wmode: js.UndefOr[String] = js.native
+  var wmode: js.UndefOr[String] = js.undefined
 }
 object ObjectHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/OlHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/OlHTMLAttributes.scala
@@ -9,16 +9,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait OlHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var reversed: js.UndefOr[Boolean] = js.native
+  var reversed: js.UndefOr[Boolean] = js.undefined
   
-  var start: js.UndefOr[Double] = js.native
+  var start: js.UndefOr[Double] = js.undefined
   
-  var `type`: js.UndefOr[`1` | a_ | A | i_ | I] = js.native
+  var `type`: js.UndefOr[`1` | a_ | A | i_ | I] = js.undefined
 }
 object OlHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/OptgroupHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/OptgroupHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait OptgroupHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var label: js.UndefOr[String] = js.native
+  var label: js.UndefOr[String] = js.undefined
 }
 object OptgroupHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/OptionHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/OptionHTMLAttributes.scala
@@ -4,18 +4,17 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait OptionHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var label: js.UndefOr[String] = js.native
+  var label: js.UndefOr[String] = js.undefined
   
-  var selected: js.UndefOr[Boolean] = js.native
+  var selected: js.UndefOr[Boolean] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object OptionHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/OutputHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/OutputHTMLAttributes.scala
@@ -4,16 +4,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait OutputHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var htmlFor: js.UndefOr[String] = js.native
+  var htmlFor: js.UndefOr[String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
 }
 object OutputHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ParamHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ParamHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ParamHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object ParamHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/PointerEvent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/PointerEvent.scala
@@ -8,26 +8,25 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait PointerEvent[T]
   extends StObject
      with MouseEvent[T, NativePointerEvent] {
   
-  var height: Double = js.native
+  var height: Double
   
-  var isPrimary: Boolean = js.native
+  var isPrimary: Boolean
   
-  var pointerId: Double = js.native
+  var pointerId: Double
   
-  var pointerType: mouse | pen | touch = js.native
+  var pointerType: mouse | pen | touch
   
-  var pressure: Double = js.native
+  var pressure: Double
   
-  var tiltX: Double = js.native
+  var tiltX: Double
   
-  var tiltY: Double = js.native
+  var tiltY: Double
   
-  var width: Double = js.native
+  var width: Double
 }
 object PointerEvent {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ProfilerProps.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ProfilerProps.scala
@@ -6,14 +6,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ProfilerProps extends StObject {
   
-  var children: js.UndefOr[slinky.core.facade.ReactElement] = js.native
+  var children: js.UndefOr[slinky.core.facade.ReactElement] = js.undefined
   
-  var id: String = js.native
+  var id: String
   
-  var onRender: ProfilerOnRenderCallback = js.native
+  var onRender: ProfilerOnRenderCallback
 }
 object ProfilerProps {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ProgressHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ProgressHTMLAttributes.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ProgressHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var max: js.UndefOr[Double | String] = js.native
+  var max: js.UndefOr[Double | String] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object ProgressHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/Props.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/Props.scala
@@ -22,14 +22,13 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
   * };
   * ```
   */
-@js.native
 trait Props[T] extends StObject {
   
-  var children: js.UndefOr[slinky.core.facade.ReactElement] = js.native
+  var children: js.UndefOr[slinky.core.facade.ReactElement] = js.undefined
   
-  var key: js.UndefOr[Key] = js.native
+  var key: js.UndefOr[Key] = js.undefined
   
-  var ref: js.UndefOr[LegacyRef[T]] = js.native
+  var ref: js.UndefOr[LegacyRef[T]] = js.undefined
 }
 object Props {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ProviderProps.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ProviderProps.scala
@@ -5,12 +5,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 // Context via RenderProps
-@js.native
 trait ProviderProps[T] extends StObject {
   
-  var children: js.UndefOr[slinky.core.facade.ReactElement] = js.native
+  var children: js.UndefOr[slinky.core.facade.ReactElement] = js.undefined
   
-  var value: T = js.native
+  var value: T
 }
 object ProviderProps {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/QuoteHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/QuoteHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait QuoteHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var cite: js.UndefOr[String] = js.native
+  var cite: js.UndefOr[String] = js.undefined
 }
 object QuoteHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactDOM.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactDOM.scala
@@ -62,7 +62,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ReactDOM
   extends StObject
      with ReactHTML

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactElement.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactElement.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ReactElement extends StObject {
   
-  var key: Key | Null = js.native
+  var key: Key | Null
   
-  var props: js.Any = js.native
+  var props: js.Any
   
-  var `type`: js.Any = js.native
+  var `type`: js.Any
 }
 object ReactElement {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactHTML.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactHTML.scala
@@ -65,238 +65,237 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 //
 // React.DOM
 // ----------------------------------------------------------------------
-@js.native
 trait ReactHTML extends StObject {
   
-  var a: DetailedHTMLFactory[AnchorHTMLAttributes[HTMLAnchorElement], HTMLAnchorElement] = js.native
+  var a: DetailedHTMLFactory[AnchorHTMLAttributes[HTMLAnchorElement], HTMLAnchorElement]
   
-  var abbr: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var abbr: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var address: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var address: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var area: DetailedHTMLFactory[AreaHTMLAttributes[HTMLAreaElement], HTMLAreaElement] = js.native
+  var area: DetailedHTMLFactory[AreaHTMLAttributes[HTMLAreaElement], HTMLAreaElement]
   
-  var article: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var article: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var aside: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var aside: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var audio: DetailedHTMLFactory[AudioHTMLAttributes[HTMLAudioElement], HTMLAudioElement] = js.native
+  var audio: DetailedHTMLFactory[AudioHTMLAttributes[HTMLAudioElement], HTMLAudioElement]
   
-  var b: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var b: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var base: DetailedHTMLFactory[BaseHTMLAttributes[HTMLBaseElement], HTMLBaseElement] = js.native
+  var base: DetailedHTMLFactory[BaseHTMLAttributes[HTMLBaseElement], HTMLBaseElement]
   
-  var bdi: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var bdi: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var bdo: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var bdo: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var big: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var big: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var blockquote: DetailedHTMLFactory[BlockquoteHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var blockquote: DetailedHTMLFactory[BlockquoteHTMLAttributes[HTMLElement], HTMLElement]
   
-  var body: DetailedHTMLFactory[HTMLAttributes[HTMLBodyElement], HTMLBodyElement] = js.native
+  var body: DetailedHTMLFactory[HTMLAttributes[HTMLBodyElement], HTMLBodyElement]
   
-  var br: DetailedHTMLFactory[HTMLAttributes[HTMLBRElement], HTMLBRElement] = js.native
+  var br: DetailedHTMLFactory[HTMLAttributes[HTMLBRElement], HTMLBRElement]
   
-  var button: DetailedHTMLFactory[ButtonHTMLAttributes[HTMLButtonElement], HTMLButtonElement] = js.native
+  var button: DetailedHTMLFactory[ButtonHTMLAttributes[HTMLButtonElement], HTMLButtonElement]
   
-  var canvas: DetailedHTMLFactory[CanvasHTMLAttributes[HTMLCanvasElement], HTMLCanvasElement] = js.native
+  var canvas: DetailedHTMLFactory[CanvasHTMLAttributes[HTMLCanvasElement], HTMLCanvasElement]
   
-  var caption: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var caption: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var cite: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var cite: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var code: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var code: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var col: DetailedHTMLFactory[ColHTMLAttributes[HTMLTableColElement], HTMLTableColElement] = js.native
+  var col: DetailedHTMLFactory[ColHTMLAttributes[HTMLTableColElement], HTMLTableColElement]
   
-  var colgroup: DetailedHTMLFactory[ColgroupHTMLAttributes[HTMLTableColElement], HTMLTableColElement] = js.native
+  var colgroup: DetailedHTMLFactory[ColgroupHTMLAttributes[HTMLTableColElement], HTMLTableColElement]
   
-  var data: DetailedHTMLFactory[DataHTMLAttributes[HTMLDataElement], HTMLDataElement] = js.native
+  var data: DetailedHTMLFactory[DataHTMLAttributes[HTMLDataElement], HTMLDataElement]
   
-  var datalist: DetailedHTMLFactory[HTMLAttributes[HTMLDataListElement], HTMLDataListElement] = js.native
+  var datalist: DetailedHTMLFactory[HTMLAttributes[HTMLDataListElement], HTMLDataListElement]
   
-  var dd: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var dd: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var del: DetailedHTMLFactory[DelHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var del: DetailedHTMLFactory[DelHTMLAttributes[HTMLElement], HTMLElement]
   
-  var details: DetailedHTMLFactory[DetailsHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var details: DetailedHTMLFactory[DetailsHTMLAttributes[HTMLElement], HTMLElement]
   
-  var dfn: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var dfn: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var dialog: DetailedHTMLFactory[DialogHTMLAttributes[HTMLDialogElement], HTMLDialogElement] = js.native
+  var dialog: DetailedHTMLFactory[DialogHTMLAttributes[HTMLDialogElement], HTMLDialogElement]
   
-  var div: DetailedHTMLFactory[HTMLAttributes[HTMLDivElement], HTMLDivElement] = js.native
+  var div: DetailedHTMLFactory[HTMLAttributes[HTMLDivElement], HTMLDivElement]
   
-  var dl: DetailedHTMLFactory[HTMLAttributes[HTMLDListElement], HTMLDListElement] = js.native
+  var dl: DetailedHTMLFactory[HTMLAttributes[HTMLDListElement], HTMLDListElement]
   
-  var dt: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var dt: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var em: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var em: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var embed: DetailedHTMLFactory[EmbedHTMLAttributes[HTMLEmbedElement], HTMLEmbedElement] = js.native
+  var embed: DetailedHTMLFactory[EmbedHTMLAttributes[HTMLEmbedElement], HTMLEmbedElement]
   
-  var fieldset: DetailedHTMLFactory[FieldsetHTMLAttributes[HTMLFieldSetElement], HTMLFieldSetElement] = js.native
+  var fieldset: DetailedHTMLFactory[FieldsetHTMLAttributes[HTMLFieldSetElement], HTMLFieldSetElement]
   
-  var figcaption: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var figcaption: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var figure: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var figure: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var footer: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var footer: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var form: DetailedHTMLFactory[FormHTMLAttributes[HTMLFormElement], HTMLFormElement] = js.native
+  var form: DetailedHTMLFactory[FormHTMLAttributes[HTMLFormElement], HTMLFormElement]
   
-  var h1: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement] = js.native
+  var h1: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement]
   
-  var h2: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement] = js.native
+  var h2: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement]
   
-  var h3: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement] = js.native
+  var h3: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement]
   
-  var h4: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement] = js.native
+  var h4: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement]
   
-  var h5: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement] = js.native
+  var h5: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement]
   
-  var h6: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement] = js.native
+  var h6: DetailedHTMLFactory[HTMLAttributes[HTMLHeadingElement], HTMLHeadingElement]
   
-  var head: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLHeadElement] = js.native
+  var head: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLHeadElement]
   
-  var header: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var header: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var hgroup: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var hgroup: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var hr: DetailedHTMLFactory[HTMLAttributes[HTMLHRElement], HTMLHRElement] = js.native
+  var hr: DetailedHTMLFactory[HTMLAttributes[HTMLHRElement], HTMLHRElement]
   
-  var html: DetailedHTMLFactory[HtmlHTMLAttributes[HTMLHtmlElement], HTMLHtmlElement] = js.native
+  var html: DetailedHTMLFactory[HtmlHTMLAttributes[HTMLHtmlElement], HTMLHtmlElement]
   
-  var i: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var i: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var iframe: DetailedHTMLFactory[IframeHTMLAttributes[HTMLIFrameElement], HTMLIFrameElement] = js.native
+  var iframe: DetailedHTMLFactory[IframeHTMLAttributes[HTMLIFrameElement], HTMLIFrameElement]
   
-  var img: DetailedHTMLFactory[ImgHTMLAttributes[HTMLImageElement], HTMLImageElement] = js.native
+  var img: DetailedHTMLFactory[ImgHTMLAttributes[HTMLImageElement], HTMLImageElement]
   
-  var input: DetailedHTMLFactory[InputHTMLAttributes[HTMLInputElement], HTMLInputElement] = js.native
+  var input: DetailedHTMLFactory[InputHTMLAttributes[HTMLInputElement], HTMLInputElement]
   
-  var ins: DetailedHTMLFactory[InsHTMLAttributes[HTMLModElement], HTMLModElement] = js.native
+  var ins: DetailedHTMLFactory[InsHTMLAttributes[HTMLModElement], HTMLModElement]
   
-  var kbd: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var kbd: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var keygen: DetailedHTMLFactory[KeygenHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var keygen: DetailedHTMLFactory[KeygenHTMLAttributes[HTMLElement], HTMLElement]
   
-  var label: DetailedHTMLFactory[LabelHTMLAttributes[HTMLLabelElement], HTMLLabelElement] = js.native
+  var label: DetailedHTMLFactory[LabelHTMLAttributes[HTMLLabelElement], HTMLLabelElement]
   
-  var legend: DetailedHTMLFactory[HTMLAttributes[HTMLLegendElement], HTMLLegendElement] = js.native
+  var legend: DetailedHTMLFactory[HTMLAttributes[HTMLLegendElement], HTMLLegendElement]
   
-  var li: DetailedHTMLFactory[LiHTMLAttributes[HTMLLIElement], HTMLLIElement] = js.native
+  var li: DetailedHTMLFactory[LiHTMLAttributes[HTMLLIElement], HTMLLIElement]
   
-  var link: DetailedHTMLFactory[LinkHTMLAttributes[HTMLLinkElement], HTMLLinkElement] = js.native
+  var link: DetailedHTMLFactory[LinkHTMLAttributes[HTMLLinkElement], HTMLLinkElement]
   
-  var main: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var main: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var map: DetailedHTMLFactory[MapHTMLAttributes[HTMLMapElement], HTMLMapElement] = js.native
+  var map: DetailedHTMLFactory[MapHTMLAttributes[HTMLMapElement], HTMLMapElement]
   
-  var mark: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var mark: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var menu: DetailedHTMLFactory[MenuHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var menu: DetailedHTMLFactory[MenuHTMLAttributes[HTMLElement], HTMLElement]
   
-  var menuitem: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var menuitem: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var meta: DetailedHTMLFactory[MetaHTMLAttributes[HTMLMetaElement], HTMLMetaElement] = js.native
+  var meta: DetailedHTMLFactory[MetaHTMLAttributes[HTMLMetaElement], HTMLMetaElement]
   
-  var meter: DetailedHTMLFactory[MeterHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var meter: DetailedHTMLFactory[MeterHTMLAttributes[HTMLElement], HTMLElement]
   
-  var nav: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var nav: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var noscript: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var noscript: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var `object`: DetailedHTMLFactory[ObjectHTMLAttributes[HTMLObjectElement], HTMLObjectElement] = js.native
+  var `object`: DetailedHTMLFactory[ObjectHTMLAttributes[HTMLObjectElement], HTMLObjectElement]
   
-  var ol: DetailedHTMLFactory[OlHTMLAttributes[HTMLOListElement], HTMLOListElement] = js.native
+  var ol: DetailedHTMLFactory[OlHTMLAttributes[HTMLOListElement], HTMLOListElement]
   
-  var optgroup: DetailedHTMLFactory[OptgroupHTMLAttributes[HTMLOptGroupElement], HTMLOptGroupElement] = js.native
+  var optgroup: DetailedHTMLFactory[OptgroupHTMLAttributes[HTMLOptGroupElement], HTMLOptGroupElement]
   
-  var option: DetailedHTMLFactory[OptionHTMLAttributes[HTMLOptionElement], HTMLOptionElement] = js.native
+  var option: DetailedHTMLFactory[OptionHTMLAttributes[HTMLOptionElement], HTMLOptionElement]
   
-  var output: DetailedHTMLFactory[OutputHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var output: DetailedHTMLFactory[OutputHTMLAttributes[HTMLElement], HTMLElement]
   
-  var p: DetailedHTMLFactory[HTMLAttributes[HTMLParagraphElement], HTMLParagraphElement] = js.native
+  var p: DetailedHTMLFactory[HTMLAttributes[HTMLParagraphElement], HTMLParagraphElement]
   
-  var param: DetailedHTMLFactory[ParamHTMLAttributes[HTMLParamElement], HTMLParamElement] = js.native
+  var param: DetailedHTMLFactory[ParamHTMLAttributes[HTMLParamElement], HTMLParamElement]
   
-  var picture: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var picture: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var pre: DetailedHTMLFactory[HTMLAttributes[HTMLPreElement], HTMLPreElement] = js.native
+  var pre: DetailedHTMLFactory[HTMLAttributes[HTMLPreElement], HTMLPreElement]
   
-  var progress: DetailedHTMLFactory[ProgressHTMLAttributes[HTMLProgressElement], HTMLProgressElement] = js.native
+  var progress: DetailedHTMLFactory[ProgressHTMLAttributes[HTMLProgressElement], HTMLProgressElement]
   
-  var q: DetailedHTMLFactory[QuoteHTMLAttributes[HTMLQuoteElement], HTMLQuoteElement] = js.native
+  var q: DetailedHTMLFactory[QuoteHTMLAttributes[HTMLQuoteElement], HTMLQuoteElement]
   
-  var rp: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var rp: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var rt: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var rt: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var ruby: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var ruby: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var s: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var s: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var samp: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var samp: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var script: DetailedHTMLFactory[ScriptHTMLAttributes[HTMLScriptElement], HTMLScriptElement] = js.native
+  var script: DetailedHTMLFactory[ScriptHTMLAttributes[HTMLScriptElement], HTMLScriptElement]
   
-  var section: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var section: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var select: DetailedHTMLFactory[SelectHTMLAttributes[HTMLSelectElement], HTMLSelectElement] = js.native
+  var select: DetailedHTMLFactory[SelectHTMLAttributes[HTMLSelectElement], HTMLSelectElement]
   
-  var small: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var small: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var source: DetailedHTMLFactory[SourceHTMLAttributes[HTMLSourceElement], HTMLSourceElement] = js.native
+  var source: DetailedHTMLFactory[SourceHTMLAttributes[HTMLSourceElement], HTMLSourceElement]
   
-  var span: DetailedHTMLFactory[HTMLAttributes[HTMLSpanElement], HTMLSpanElement] = js.native
+  var span: DetailedHTMLFactory[HTMLAttributes[HTMLSpanElement], HTMLSpanElement]
   
-  var strong: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var strong: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var style: DetailedHTMLFactory[StyleHTMLAttributes[HTMLStyleElement], HTMLStyleElement] = js.native
+  var style: DetailedHTMLFactory[StyleHTMLAttributes[HTMLStyleElement], HTMLStyleElement]
   
-  var sub: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var sub: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var summary: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var summary: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var sup: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var sup: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var table: DetailedHTMLFactory[TableHTMLAttributes[HTMLTableElement], HTMLTableElement] = js.native
+  var table: DetailedHTMLFactory[TableHTMLAttributes[HTMLTableElement], HTMLTableElement]
   
-  var tbody: DetailedHTMLFactory[HTMLAttributes[HTMLTableSectionElement], HTMLTableSectionElement] = js.native
+  var tbody: DetailedHTMLFactory[HTMLAttributes[HTMLTableSectionElement], HTMLTableSectionElement]
   
-  var td: DetailedHTMLFactory[TdHTMLAttributes[HTMLTableDataCellElement], HTMLTableDataCellElement] = js.native
+  var td: DetailedHTMLFactory[TdHTMLAttributes[HTMLTableDataCellElement], HTMLTableDataCellElement]
   
-  var template: DetailedHTMLFactory[HTMLAttributes[HTMLTemplateElement], HTMLTemplateElement] = js.native
+  var template: DetailedHTMLFactory[HTMLAttributes[HTMLTemplateElement], HTMLTemplateElement]
   
-  var textarea: DetailedHTMLFactory[TextareaHTMLAttributes[HTMLTextAreaElement], HTMLTextAreaElement] = js.native
+  var textarea: DetailedHTMLFactory[TextareaHTMLAttributes[HTMLTextAreaElement], HTMLTextAreaElement]
   
-  var tfoot: DetailedHTMLFactory[HTMLAttributes[HTMLTableSectionElement], HTMLTableSectionElement] = js.native
+  var tfoot: DetailedHTMLFactory[HTMLAttributes[HTMLTableSectionElement], HTMLTableSectionElement]
   
-  var th: DetailedHTMLFactory[ThHTMLAttributes[HTMLTableHeaderCellElement], HTMLTableHeaderCellElement] = js.native
+  var th: DetailedHTMLFactory[ThHTMLAttributes[HTMLTableHeaderCellElement], HTMLTableHeaderCellElement]
   
-  var thead: DetailedHTMLFactory[HTMLAttributes[HTMLTableSectionElement], HTMLTableSectionElement] = js.native
+  var thead: DetailedHTMLFactory[HTMLAttributes[HTMLTableSectionElement], HTMLTableSectionElement]
   
-  var time: DetailedHTMLFactory[TimeHTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var time: DetailedHTMLFactory[TimeHTMLAttributes[HTMLElement], HTMLElement]
   
-  var title: DetailedHTMLFactory[HTMLAttributes[HTMLTitleElement], HTMLTitleElement] = js.native
+  var title: DetailedHTMLFactory[HTMLAttributes[HTMLTitleElement], HTMLTitleElement]
   
-  var tr: DetailedHTMLFactory[HTMLAttributes[HTMLTableRowElement], HTMLTableRowElement] = js.native
+  var tr: DetailedHTMLFactory[HTMLAttributes[HTMLTableRowElement], HTMLTableRowElement]
   
-  var track: DetailedHTMLFactory[TrackHTMLAttributes[HTMLTrackElement], HTMLTrackElement] = js.native
+  var track: DetailedHTMLFactory[TrackHTMLAttributes[HTMLTrackElement], HTMLTrackElement]
   
-  var u: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var u: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var ul: DetailedHTMLFactory[HTMLAttributes[HTMLUListElement], HTMLUListElement] = js.native
+  var ul: DetailedHTMLFactory[HTMLAttributes[HTMLUListElement], HTMLUListElement]
   
-  var `var`: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var `var`: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var video: DetailedHTMLFactory[VideoHTMLAttributes[HTMLVideoElement], HTMLVideoElement] = js.native
+  var video: DetailedHTMLFactory[VideoHTMLAttributes[HTMLVideoElement], HTMLVideoElement]
   
-  var wbr: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+  var wbr: DetailedHTMLFactory[HTMLAttributes[HTMLElement], HTMLElement]
   
-  var webview: DetailedHTMLFactory[WebViewHTMLAttributes[HTMLWebViewElement], HTMLWebViewElement] = js.native
+  var webview: DetailedHTMLFactory[WebViewHTMLAttributes[HTMLWebViewElement], HTMLWebViewElement]
 }
 object ReactHTML {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactNodeArray.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactNodeArray.scala
@@ -5,7 +5,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ReactNodeArray
   extends StObject
      with Array[slinky.core.facade.ReactElement]

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactPortal.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactPortal.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ReactPortal
   extends StObject
      with ReactElement {
   
-  var children: slinky.core.facade.ReactElement = js.native
+  var children: slinky.core.facade.ReactElement
 }
 object ReactPortal {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactPropTypes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactPropTypes.scala
@@ -4,40 +4,39 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ReactPropTypes extends StObject {
   
-  var any: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.any */ js.Any = js.native
+  var any: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.any */ js.Any
   
-  var array: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.array */ js.Any = js.native
+  var array: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.array */ js.Any
   
-  var arrayOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.arrayOf */ js.Any = js.native
+  var arrayOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.arrayOf */ js.Any
   
-  var bool: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.bool */ js.Any = js.native
+  var bool: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.bool */ js.Any
   
-  var element: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.element */ js.Any = js.native
+  var element: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.element */ js.Any
   
-  var exact: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.exact */ js.Any = js.native
+  var exact: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.exact */ js.Any
   
-  var func: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.func */ js.Any = js.native
+  var func: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.func */ js.Any
   
-  var instanceOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.instanceOf */ js.Any = js.native
+  var instanceOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.instanceOf */ js.Any
   
-  var node: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.node */ js.Any = js.native
+  var node: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.node */ js.Any
   
-  var number: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.number */ js.Any = js.native
+  var number: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.number */ js.Any
   
-  var `object`: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.object */ js.Any = js.native
+  var `object`: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.object */ js.Any
   
-  var objectOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.objectOf */ js.Any = js.native
+  var objectOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.objectOf */ js.Any
   
-  var oneOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.oneOf */ js.Any = js.native
+  var oneOf: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.oneOf */ js.Any
   
-  var oneOfType: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.oneOfType */ js.Any = js.native
+  var oneOfType: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.oneOfType */ js.Any
   
-  var shape: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.shape */ js.Any = js.native
+  var shape: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.shape */ js.Any
   
-  var string: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.string */ js.Any = js.native
+  var string: /* import warning: ResolveTypeQueries.resolve Couldn't resolve typeof PropTypes.string */ js.Any
 }
 object ReactPropTypes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactSVG.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactSVG.scala
@@ -4,118 +4,117 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ReactSVG extends StObject {
   
-  var animate: SVGFactory = js.native
+  var animate: SVGFactory
   
-  var circle: SVGFactory = js.native
+  var circle: SVGFactory
   
-  var clipPath: SVGFactory = js.native
+  var clipPath: SVGFactory
   
-  var defs: SVGFactory = js.native
+  var defs: SVGFactory
   
-  var desc: SVGFactory = js.native
+  var desc: SVGFactory
   
-  var ellipse: SVGFactory = js.native
+  var ellipse: SVGFactory
   
-  var feBlend: SVGFactory = js.native
+  var feBlend: SVGFactory
   
-  var feColorMatrix: SVGFactory = js.native
+  var feColorMatrix: SVGFactory
   
-  var feComponentTransfer: SVGFactory = js.native
+  var feComponentTransfer: SVGFactory
   
-  var feComposite: SVGFactory = js.native
+  var feComposite: SVGFactory
   
-  var feConvolveMatrix: SVGFactory = js.native
+  var feConvolveMatrix: SVGFactory
   
-  var feDiffuseLighting: SVGFactory = js.native
+  var feDiffuseLighting: SVGFactory
   
-  var feDisplacementMap: SVGFactory = js.native
+  var feDisplacementMap: SVGFactory
   
-  var feDistantLight: SVGFactory = js.native
+  var feDistantLight: SVGFactory
   
-  var feDropShadow: SVGFactory = js.native
+  var feDropShadow: SVGFactory
   
-  var feFlood: SVGFactory = js.native
+  var feFlood: SVGFactory
   
-  var feFuncA: SVGFactory = js.native
+  var feFuncA: SVGFactory
   
-  var feFuncB: SVGFactory = js.native
+  var feFuncB: SVGFactory
   
-  var feFuncG: SVGFactory = js.native
+  var feFuncG: SVGFactory
   
-  var feFuncR: SVGFactory = js.native
+  var feFuncR: SVGFactory
   
-  var feGaussianBlur: SVGFactory = js.native
+  var feGaussianBlur: SVGFactory
   
-  var feImage: SVGFactory = js.native
+  var feImage: SVGFactory
   
-  var feMerge: SVGFactory = js.native
+  var feMerge: SVGFactory
   
-  var feMergeNode: SVGFactory = js.native
+  var feMergeNode: SVGFactory
   
-  var feMorphology: SVGFactory = js.native
+  var feMorphology: SVGFactory
   
-  var feOffset: SVGFactory = js.native
+  var feOffset: SVGFactory
   
-  var fePointLight: SVGFactory = js.native
+  var fePointLight: SVGFactory
   
-  var feSpecularLighting: SVGFactory = js.native
+  var feSpecularLighting: SVGFactory
   
-  var feSpotLight: SVGFactory = js.native
+  var feSpotLight: SVGFactory
   
-  var feTile: SVGFactory = js.native
+  var feTile: SVGFactory
   
-  var feTurbulence: SVGFactory = js.native
+  var feTurbulence: SVGFactory
   
-  var filter: SVGFactory = js.native
+  var filter: SVGFactory
   
-  var foreignObject: SVGFactory = js.native
+  var foreignObject: SVGFactory
   
-  var g: SVGFactory = js.native
+  var g: SVGFactory
   
-  var image: SVGFactory = js.native
+  var image: SVGFactory
   
-  var line: SVGFactory = js.native
+  var line: SVGFactory
   
-  var linearGradient: SVGFactory = js.native
+  var linearGradient: SVGFactory
   
-  var marker: SVGFactory = js.native
+  var marker: SVGFactory
   
-  var mask: SVGFactory = js.native
+  var mask: SVGFactory
   
-  var metadata: SVGFactory = js.native
+  var metadata: SVGFactory
   
-  var path: SVGFactory = js.native
+  var path: SVGFactory
   
-  var pattern: SVGFactory = js.native
+  var pattern: SVGFactory
   
-  var polygon: SVGFactory = js.native
+  var polygon: SVGFactory
   
-  var polyline: SVGFactory = js.native
+  var polyline: SVGFactory
   
-  var radialGradient: SVGFactory = js.native
+  var radialGradient: SVGFactory
   
-  var rect: SVGFactory = js.native
+  var rect: SVGFactory
   
-  var stop: SVGFactory = js.native
+  var stop: SVGFactory
   
-  var svg: SVGFactory = js.native
+  var svg: SVGFactory
   
-  var switch: SVGFactory = js.native
+  var switch: SVGFactory
   
-  var symbol: SVGFactory = js.native
+  var symbol: SVGFactory
   
-  var text: SVGFactory = js.native
+  var text: SVGFactory
   
-  var textPath: SVGFactory = js.native
+  var textPath: SVGFactory
   
-  var tspan: SVGFactory = js.native
+  var tspan: SVGFactory
   
-  var use: SVGFactory = js.native
+  var use: SVGFactory
   
-  var view: SVGFactory = js.native
+  var view: SVGFactory
 }
 object ReactSVG {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactSVGElement.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ReactSVGElement.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 // ReactSVG for ReactSVGElement
-@js.native
 trait ReactSVGElement
   extends StObject
      with DOMElement[SVGAttributes[SVGElement], SVGElement]

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/RefAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/RefAttributes.scala
@@ -5,12 +5,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait RefAttributes[T]
   extends StObject
      with Attributes {
   
-  var ref: js.UndefOr[Ref[T]] = js.native
+  var ref: js.UndefOr[Ref[T]] = js.undefined
 }
 object RefAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/RefObject.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/RefObject.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait RefObject[T] extends StObject {
   
-  val current: T | Null = js.native
+  val current: T | Null
 }
 object RefObject {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/SVGAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/SVGAttributes.scala
@@ -43,529 +43,528 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 //   - "number | string"
 //   - "string"
 //   - union of string literals
-@js.native
 trait SVGAttributes[T]
   extends StObject
      with AriaAttributes
      with DOMAttributes[T] {
   
   // SVG Specific attributes
-  var accentHeight: js.UndefOr[Double | String] = js.native
+  var accentHeight: js.UndefOr[Double | String] = js.undefined
   
-  var accumulate: js.UndefOr[none | sum] = js.native
+  var accumulate: js.UndefOr[none | sum] = js.undefined
   
-  var additive: js.UndefOr[replace | sum] = js.native
+  var additive: js.UndefOr[replace | sum] = js.undefined
   
   var alignmentBaseline: js.UndefOr[
     auto | baseline | `before-edge` | `text-before-edge` | middle | central | `after-edge` | `text-after-edge` | ideographic | alphabetic | hanging | mathematical | inherit
-  ] = js.native
+  ] = js.undefined
   
-  var allowReorder: js.UndefOr[no | yes] = js.native
+  var allowReorder: js.UndefOr[no | yes] = js.undefined
   
-  var alphabetic: js.UndefOr[Double | String] = js.native
+  var alphabetic: js.UndefOr[Double | String] = js.undefined
   
-  var amplitude: js.UndefOr[Double | String] = js.native
+  var amplitude: js.UndefOr[Double | String] = js.undefined
   
-  var arabicForm: js.UndefOr[initial | medial | terminal | isolated] = js.native
+  var arabicForm: js.UndefOr[initial | medial | terminal | isolated] = js.undefined
   
-  var ascent: js.UndefOr[Double | String] = js.native
+  var ascent: js.UndefOr[Double | String] = js.undefined
   
-  var attributeName: js.UndefOr[String] = js.native
+  var attributeName: js.UndefOr[String] = js.undefined
   
-  var attributeType: js.UndefOr[String] = js.native
+  var attributeType: js.UndefOr[String] = js.undefined
   
-  var autoReverse: js.UndefOr[Double | String] = js.native
+  var autoReverse: js.UndefOr[Double | String] = js.undefined
   
-  var azimuth: js.UndefOr[Double | String] = js.native
+  var azimuth: js.UndefOr[Double | String] = js.undefined
   
-  var baseFrequency: js.UndefOr[Double | String] = js.native
+  var baseFrequency: js.UndefOr[Double | String] = js.undefined
   
-  var baseProfile: js.UndefOr[Double | String] = js.native
+  var baseProfile: js.UndefOr[Double | String] = js.undefined
   
-  var baselineShift: js.UndefOr[Double | String] = js.native
+  var baselineShift: js.UndefOr[Double | String] = js.undefined
   
-  var bbox: js.UndefOr[Double | String] = js.native
+  var bbox: js.UndefOr[Double | String] = js.undefined
   
-  var begin: js.UndefOr[Double | String] = js.native
+  var begin: js.UndefOr[Double | String] = js.undefined
   
-  var bias: js.UndefOr[Double | String] = js.native
+  var bias: js.UndefOr[Double | String] = js.undefined
   
-  var by: js.UndefOr[Double | String] = js.native
+  var by: js.UndefOr[Double | String] = js.undefined
   
-  var calcMode: js.UndefOr[Double | String] = js.native
+  var calcMode: js.UndefOr[Double | String] = js.undefined
   
-  var capHeight: js.UndefOr[Double | String] = js.native
+  var capHeight: js.UndefOr[Double | String] = js.undefined
   
   // Attributes which also defined in HTMLAttributes
   // See comment in SVGDOMPropertyConfig.js
-  var className: js.UndefOr[String] = js.native
+  var className: js.UndefOr[String] = js.undefined
   
-  var clip: js.UndefOr[Double | String] = js.native
+  var clip: js.UndefOr[Double | String] = js.undefined
   
-  var clipPath: js.UndefOr[String] = js.native
+  var clipPath: js.UndefOr[String] = js.undefined
   
-  var clipPathUnits: js.UndefOr[Double | String] = js.native
+  var clipPathUnits: js.UndefOr[Double | String] = js.undefined
   
-  var clipRule: js.UndefOr[Double | String] = js.native
+  var clipRule: js.UndefOr[Double | String] = js.undefined
   
-  var color: js.UndefOr[String] = js.native
+  var color: js.UndefOr[String] = js.undefined
   
-  var colorInterpolation: js.UndefOr[Double | String] = js.native
+  var colorInterpolation: js.UndefOr[Double | String] = js.undefined
   
-  var colorInterpolationFilters: js.UndefOr[auto | sRGB | linearRGB | inherit] = js.native
+  var colorInterpolationFilters: js.UndefOr[auto | sRGB | linearRGB | inherit] = js.undefined
   
-  var colorProfile: js.UndefOr[Double | String] = js.native
+  var colorProfile: js.UndefOr[Double | String] = js.undefined
   
-  var colorRendering: js.UndefOr[Double | String] = js.native
+  var colorRendering: js.UndefOr[Double | String] = js.undefined
   
-  var contentScriptType: js.UndefOr[Double | String] = js.native
+  var contentScriptType: js.UndefOr[Double | String] = js.undefined
   
-  var contentStyleType: js.UndefOr[Double | String] = js.native
+  var contentStyleType: js.UndefOr[Double | String] = js.undefined
   
-  var cursor: js.UndefOr[Double | String] = js.native
+  var cursor: js.UndefOr[Double | String] = js.undefined
   
-  var cx: js.UndefOr[Double | String] = js.native
+  var cx: js.UndefOr[Double | String] = js.undefined
   
-  var cy: js.UndefOr[Double | String] = js.native
+  var cy: js.UndefOr[Double | String] = js.undefined
   
-  var d: js.UndefOr[String] = js.native
+  var d: js.UndefOr[String] = js.undefined
   
-  var decelerate: js.UndefOr[Double | String] = js.native
+  var decelerate: js.UndefOr[Double | String] = js.undefined
   
-  var descent: js.UndefOr[Double | String] = js.native
+  var descent: js.UndefOr[Double | String] = js.undefined
   
-  var diffuseConstant: js.UndefOr[Double | String] = js.native
+  var diffuseConstant: js.UndefOr[Double | String] = js.undefined
   
-  var direction: js.UndefOr[Double | String] = js.native
+  var direction: js.UndefOr[Double | String] = js.undefined
   
-  var display: js.UndefOr[Double | String] = js.native
+  var display: js.UndefOr[Double | String] = js.undefined
   
-  var divisor: js.UndefOr[Double | String] = js.native
+  var divisor: js.UndefOr[Double | String] = js.undefined
   
-  var dominantBaseline: js.UndefOr[Double | String] = js.native
+  var dominantBaseline: js.UndefOr[Double | String] = js.undefined
   
-  var dur: js.UndefOr[Double | String] = js.native
+  var dur: js.UndefOr[Double | String] = js.undefined
   
-  var dx: js.UndefOr[Double | String] = js.native
+  var dx: js.UndefOr[Double | String] = js.undefined
   
-  var dy: js.UndefOr[Double | String] = js.native
+  var dy: js.UndefOr[Double | String] = js.undefined
   
-  var edgeMode: js.UndefOr[Double | String] = js.native
+  var edgeMode: js.UndefOr[Double | String] = js.undefined
   
-  var elevation: js.UndefOr[Double | String] = js.native
+  var elevation: js.UndefOr[Double | String] = js.undefined
   
-  var enableBackground: js.UndefOr[Double | String] = js.native
+  var enableBackground: js.UndefOr[Double | String] = js.undefined
   
-  var end: js.UndefOr[Double | String] = js.native
+  var end: js.UndefOr[Double | String] = js.undefined
   
-  var exponent: js.UndefOr[Double | String] = js.native
+  var exponent: js.UndefOr[Double | String] = js.undefined
   
-  var externalResourcesRequired: js.UndefOr[Double | String] = js.native
+  var externalResourcesRequired: js.UndefOr[Double | String] = js.undefined
   
-  var fill: js.UndefOr[String] = js.native
+  var fill: js.UndefOr[String] = js.undefined
   
-  var fillOpacity: js.UndefOr[Double | String] = js.native
+  var fillOpacity: js.UndefOr[Double | String] = js.undefined
   
-  var fillRule: js.UndefOr[nonzero | evenodd | inherit] = js.native
+  var fillRule: js.UndefOr[nonzero | evenodd | inherit] = js.undefined
   
-  var filter: js.UndefOr[String] = js.native
+  var filter: js.UndefOr[String] = js.undefined
   
-  var filterRes: js.UndefOr[Double | String] = js.native
+  var filterRes: js.UndefOr[Double | String] = js.undefined
   
-  var filterUnits: js.UndefOr[Double | String] = js.native
+  var filterUnits: js.UndefOr[Double | String] = js.undefined
   
-  var floodColor: js.UndefOr[Double | String] = js.native
+  var floodColor: js.UndefOr[Double | String] = js.undefined
   
-  var floodOpacity: js.UndefOr[Double | String] = js.native
+  var floodOpacity: js.UndefOr[Double | String] = js.undefined
   
-  var focusable: js.UndefOr[Double | String] = js.native
+  var focusable: js.UndefOr[Double | String] = js.undefined
   
-  var fontFamily: js.UndefOr[String] = js.native
+  var fontFamily: js.UndefOr[String] = js.undefined
   
-  var fontSize: js.UndefOr[Double | String] = js.native
+  var fontSize: js.UndefOr[Double | String] = js.undefined
   
-  var fontSizeAdjust: js.UndefOr[Double | String] = js.native
+  var fontSizeAdjust: js.UndefOr[Double | String] = js.undefined
   
-  var fontStretch: js.UndefOr[Double | String] = js.native
+  var fontStretch: js.UndefOr[Double | String] = js.undefined
   
-  var fontStyle: js.UndefOr[Double | String] = js.native
+  var fontStyle: js.UndefOr[Double | String] = js.undefined
   
-  var fontVariant: js.UndefOr[Double | String] = js.native
+  var fontVariant: js.UndefOr[Double | String] = js.undefined
   
-  var fontWeight: js.UndefOr[Double | String] = js.native
+  var fontWeight: js.UndefOr[Double | String] = js.undefined
   
-  var format: js.UndefOr[Double | String] = js.native
+  var format: js.UndefOr[Double | String] = js.undefined
   
-  var from: js.UndefOr[Double | String] = js.native
+  var from: js.UndefOr[Double | String] = js.undefined
   
-  var fx: js.UndefOr[Double | String] = js.native
+  var fx: js.UndefOr[Double | String] = js.undefined
   
-  var fy: js.UndefOr[Double | String] = js.native
+  var fy: js.UndefOr[Double | String] = js.undefined
   
-  var g1: js.UndefOr[Double | String] = js.native
+  var g1: js.UndefOr[Double | String] = js.undefined
   
-  var g2: js.UndefOr[Double | String] = js.native
+  var g2: js.UndefOr[Double | String] = js.undefined
   
-  var glyphName: js.UndefOr[Double | String] = js.native
+  var glyphName: js.UndefOr[Double | String] = js.undefined
   
-  var glyphOrientationHorizontal: js.UndefOr[Double | String] = js.native
+  var glyphOrientationHorizontal: js.UndefOr[Double | String] = js.undefined
   
-  var glyphOrientationVertical: js.UndefOr[Double | String] = js.native
+  var glyphOrientationVertical: js.UndefOr[Double | String] = js.undefined
   
-  var glyphRef: js.UndefOr[Double | String] = js.native
+  var glyphRef: js.UndefOr[Double | String] = js.undefined
   
-  var gradientTransform: js.UndefOr[String] = js.native
+  var gradientTransform: js.UndefOr[String] = js.undefined
   
-  var gradientUnits: js.UndefOr[String] = js.native
+  var gradientUnits: js.UndefOr[String] = js.undefined
   
-  var hanging: js.UndefOr[Double | String] = js.native
+  var hanging: js.UndefOr[Double | String] = js.undefined
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var horizAdvX: js.UndefOr[Double | String] = js.native
+  var horizAdvX: js.UndefOr[Double | String] = js.undefined
   
-  var horizOriginX: js.UndefOr[Double | String] = js.native
+  var horizOriginX: js.UndefOr[Double | String] = js.undefined
   
-  var href: js.UndefOr[String] = js.native
+  var href: js.UndefOr[String] = js.undefined
   
-  var id: js.UndefOr[String] = js.native
+  var id: js.UndefOr[String] = js.undefined
   
-  var ideographic: js.UndefOr[Double | String] = js.native
+  var ideographic: js.UndefOr[Double | String] = js.undefined
   
-  var imageRendering: js.UndefOr[Double | String] = js.native
+  var imageRendering: js.UndefOr[Double | String] = js.undefined
   
-  var in: js.UndefOr[String] = js.native
+  var in: js.UndefOr[String] = js.undefined
   
-  var in2: js.UndefOr[Double | String] = js.native
+  var in2: js.UndefOr[Double | String] = js.undefined
   
-  var intercept: js.UndefOr[Double | String] = js.native
+  var intercept: js.UndefOr[Double | String] = js.undefined
   
-  var k: js.UndefOr[Double | String] = js.native
+  var k: js.UndefOr[Double | String] = js.undefined
   
-  var k1: js.UndefOr[Double | String] = js.native
+  var k1: js.UndefOr[Double | String] = js.undefined
   
-  var k2: js.UndefOr[Double | String] = js.native
+  var k2: js.UndefOr[Double | String] = js.undefined
   
-  var k3: js.UndefOr[Double | String] = js.native
+  var k3: js.UndefOr[Double | String] = js.undefined
   
-  var k4: js.UndefOr[Double | String] = js.native
+  var k4: js.UndefOr[Double | String] = js.undefined
   
-  var kernelMatrix: js.UndefOr[Double | String] = js.native
+  var kernelMatrix: js.UndefOr[Double | String] = js.undefined
   
-  var kernelUnitLength: js.UndefOr[Double | String] = js.native
+  var kernelUnitLength: js.UndefOr[Double | String] = js.undefined
   
-  var kerning: js.UndefOr[Double | String] = js.native
+  var kerning: js.UndefOr[Double | String] = js.undefined
   
-  var keyPoints: js.UndefOr[Double | String] = js.native
+  var keyPoints: js.UndefOr[Double | String] = js.undefined
   
-  var keySplines: js.UndefOr[Double | String] = js.native
+  var keySplines: js.UndefOr[Double | String] = js.undefined
   
-  var keyTimes: js.UndefOr[Double | String] = js.native
+  var keyTimes: js.UndefOr[Double | String] = js.undefined
   
-  var lang: js.UndefOr[String] = js.native
+  var lang: js.UndefOr[String] = js.undefined
   
-  var lengthAdjust: js.UndefOr[Double | String] = js.native
+  var lengthAdjust: js.UndefOr[Double | String] = js.undefined
   
-  var letterSpacing: js.UndefOr[Double | String] = js.native
+  var letterSpacing: js.UndefOr[Double | String] = js.undefined
   
-  var lightingColor: js.UndefOr[Double | String] = js.native
+  var lightingColor: js.UndefOr[Double | String] = js.undefined
   
-  var limitingConeAngle: js.UndefOr[Double | String] = js.native
+  var limitingConeAngle: js.UndefOr[Double | String] = js.undefined
   
-  var local: js.UndefOr[Double | String] = js.native
+  var local: js.UndefOr[Double | String] = js.undefined
   
-  var markerEnd: js.UndefOr[String] = js.native
+  var markerEnd: js.UndefOr[String] = js.undefined
   
-  var markerHeight: js.UndefOr[Double | String] = js.native
+  var markerHeight: js.UndefOr[Double | String] = js.undefined
   
-  var markerMid: js.UndefOr[String] = js.native
+  var markerMid: js.UndefOr[String] = js.undefined
   
-  var markerStart: js.UndefOr[String] = js.native
+  var markerStart: js.UndefOr[String] = js.undefined
   
-  var markerUnits: js.UndefOr[Double | String] = js.native
+  var markerUnits: js.UndefOr[Double | String] = js.undefined
   
-  var markerWidth: js.UndefOr[Double | String] = js.native
+  var markerWidth: js.UndefOr[Double | String] = js.undefined
   
-  var mask: js.UndefOr[String] = js.native
+  var mask: js.UndefOr[String] = js.undefined
   
-  var maskContentUnits: js.UndefOr[Double | String] = js.native
+  var maskContentUnits: js.UndefOr[Double | String] = js.undefined
   
-  var maskUnits: js.UndefOr[Double | String] = js.native
+  var maskUnits: js.UndefOr[Double | String] = js.undefined
   
-  var mathematical: js.UndefOr[Double | String] = js.native
+  var mathematical: js.UndefOr[Double | String] = js.undefined
   
-  var max: js.UndefOr[Double | String] = js.native
+  var max: js.UndefOr[Double | String] = js.undefined
   
-  var media: js.UndefOr[String] = js.native
+  var media: js.UndefOr[String] = js.undefined
   
-  var method: js.UndefOr[String] = js.native
+  var method: js.UndefOr[String] = js.undefined
   
-  var min: js.UndefOr[Double | String] = js.native
+  var min: js.UndefOr[Double | String] = js.undefined
   
-  var mode: js.UndefOr[Double | String] = js.native
+  var mode: js.UndefOr[Double | String] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
-  var numOctaves: js.UndefOr[Double | String] = js.native
+  var numOctaves: js.UndefOr[Double | String] = js.undefined
   
-  var offset: js.UndefOr[Double | String] = js.native
+  var offset: js.UndefOr[Double | String] = js.undefined
   
-  var opacity: js.UndefOr[Double | String] = js.native
+  var opacity: js.UndefOr[Double | String] = js.undefined
   
-  var operator: js.UndefOr[Double | String] = js.native
+  var operator: js.UndefOr[Double | String] = js.undefined
   
-  var order: js.UndefOr[Double | String] = js.native
+  var order: js.UndefOr[Double | String] = js.undefined
   
-  var orient: js.UndefOr[Double | String] = js.native
+  var orient: js.UndefOr[Double | String] = js.undefined
   
-  var orientation: js.UndefOr[Double | String] = js.native
+  var orientation: js.UndefOr[Double | String] = js.undefined
   
-  var origin: js.UndefOr[Double | String] = js.native
+  var origin: js.UndefOr[Double | String] = js.undefined
   
-  var overflow: js.UndefOr[Double | String] = js.native
+  var overflow: js.UndefOr[Double | String] = js.undefined
   
-  var overlinePosition: js.UndefOr[Double | String] = js.native
+  var overlinePosition: js.UndefOr[Double | String] = js.undefined
   
-  var overlineThickness: js.UndefOr[Double | String] = js.native
+  var overlineThickness: js.UndefOr[Double | String] = js.undefined
   
-  var paintOrder: js.UndefOr[Double | String] = js.native
+  var paintOrder: js.UndefOr[Double | String] = js.undefined
   
-  var panose1: js.UndefOr[Double | String] = js.native
+  var panose1: js.UndefOr[Double | String] = js.undefined
   
-  var pathLength: js.UndefOr[Double | String] = js.native
+  var pathLength: js.UndefOr[Double | String] = js.undefined
   
-  var patternContentUnits: js.UndefOr[String] = js.native
+  var patternContentUnits: js.UndefOr[String] = js.undefined
   
-  var patternTransform: js.UndefOr[Double | String] = js.native
+  var patternTransform: js.UndefOr[Double | String] = js.undefined
   
-  var patternUnits: js.UndefOr[String] = js.native
+  var patternUnits: js.UndefOr[String] = js.undefined
   
-  var pointerEvents: js.UndefOr[Double | String] = js.native
+  var pointerEvents: js.UndefOr[Double | String] = js.undefined
   
-  var points: js.UndefOr[String] = js.native
+  var points: js.UndefOr[String] = js.undefined
   
-  var pointsAtX: js.UndefOr[Double | String] = js.native
+  var pointsAtX: js.UndefOr[Double | String] = js.undefined
   
-  var pointsAtY: js.UndefOr[Double | String] = js.native
+  var pointsAtY: js.UndefOr[Double | String] = js.undefined
   
-  var pointsAtZ: js.UndefOr[Double | String] = js.native
+  var pointsAtZ: js.UndefOr[Double | String] = js.undefined
   
-  var preserveAlpha: js.UndefOr[Double | String] = js.native
+  var preserveAlpha: js.UndefOr[Double | String] = js.undefined
   
-  var preserveAspectRatio: js.UndefOr[String] = js.native
+  var preserveAspectRatio: js.UndefOr[String] = js.undefined
   
-  var primitiveUnits: js.UndefOr[Double | String] = js.native
+  var primitiveUnits: js.UndefOr[Double | String] = js.undefined
   
-  var r: js.UndefOr[Double | String] = js.native
+  var r: js.UndefOr[Double | String] = js.undefined
   
-  var radius: js.UndefOr[Double | String] = js.native
+  var radius: js.UndefOr[Double | String] = js.undefined
   
-  var refX: js.UndefOr[Double | String] = js.native
+  var refX: js.UndefOr[Double | String] = js.undefined
   
-  var refY: js.UndefOr[Double | String] = js.native
+  var refY: js.UndefOr[Double | String] = js.undefined
   
-  var renderingIntent: js.UndefOr[Double | String] = js.native
+  var renderingIntent: js.UndefOr[Double | String] = js.undefined
   
-  var repeatCount: js.UndefOr[Double | String] = js.native
+  var repeatCount: js.UndefOr[Double | String] = js.undefined
   
-  var repeatDur: js.UndefOr[Double | String] = js.native
+  var repeatDur: js.UndefOr[Double | String] = js.undefined
   
-  var requiredExtensions: js.UndefOr[Double | String] = js.native
+  var requiredExtensions: js.UndefOr[Double | String] = js.undefined
   
-  var requiredFeatures: js.UndefOr[Double | String] = js.native
+  var requiredFeatures: js.UndefOr[Double | String] = js.undefined
   
-  var restart: js.UndefOr[Double | String] = js.native
+  var restart: js.UndefOr[Double | String] = js.undefined
   
-  var result: js.UndefOr[String] = js.native
+  var result: js.UndefOr[String] = js.undefined
   
   // Other HTML properties supported by SVG elements in browsers
-  var role: js.UndefOr[String] = js.native
+  var role: js.UndefOr[String] = js.undefined
   
-  var rotate: js.UndefOr[Double | String] = js.native
+  var rotate: js.UndefOr[Double | String] = js.undefined
   
-  var rx: js.UndefOr[Double | String] = js.native
+  var rx: js.UndefOr[Double | String] = js.undefined
   
-  var ry: js.UndefOr[Double | String] = js.native
+  var ry: js.UndefOr[Double | String] = js.undefined
   
-  var scale: js.UndefOr[Double | String] = js.native
+  var scale: js.UndefOr[Double | String] = js.undefined
   
-  var seed: js.UndefOr[Double | String] = js.native
+  var seed: js.UndefOr[Double | String] = js.undefined
   
-  var shapeRendering: js.UndefOr[Double | String] = js.native
+  var shapeRendering: js.UndefOr[Double | String] = js.undefined
   
-  var slope: js.UndefOr[Double | String] = js.native
+  var slope: js.UndefOr[Double | String] = js.undefined
   
-  var spacing: js.UndefOr[Double | String] = js.native
+  var spacing: js.UndefOr[Double | String] = js.undefined
   
-  var specularConstant: js.UndefOr[Double | String] = js.native
+  var specularConstant: js.UndefOr[Double | String] = js.undefined
   
-  var specularExponent: js.UndefOr[Double | String] = js.native
+  var specularExponent: js.UndefOr[Double | String] = js.undefined
   
-  var speed: js.UndefOr[Double | String] = js.native
+  var speed: js.UndefOr[Double | String] = js.undefined
   
-  var spreadMethod: js.UndefOr[String] = js.native
+  var spreadMethod: js.UndefOr[String] = js.undefined
   
-  var startOffset: js.UndefOr[Double | String] = js.native
+  var startOffset: js.UndefOr[Double | String] = js.undefined
   
-  var stdDeviation: js.UndefOr[Double | String] = js.native
+  var stdDeviation: js.UndefOr[Double | String] = js.undefined
   
-  var stemh: js.UndefOr[Double | String] = js.native
+  var stemh: js.UndefOr[Double | String] = js.undefined
   
-  var stemv: js.UndefOr[Double | String] = js.native
+  var stemv: js.UndefOr[Double | String] = js.undefined
   
-  var stitchTiles: js.UndefOr[Double | String] = js.native
+  var stitchTiles: js.UndefOr[Double | String] = js.undefined
   
-  var stopColor: js.UndefOr[String] = js.native
+  var stopColor: js.UndefOr[String] = js.undefined
   
-  var stopOpacity: js.UndefOr[Double | String] = js.native
+  var stopOpacity: js.UndefOr[Double | String] = js.undefined
   
-  var strikethroughPosition: js.UndefOr[Double | String] = js.native
+  var strikethroughPosition: js.UndefOr[Double | String] = js.undefined
   
-  var strikethroughThickness: js.UndefOr[Double | String] = js.native
+  var strikethroughThickness: js.UndefOr[Double | String] = js.undefined
   
-  var string: js.UndefOr[Double | String] = js.native
+  var string: js.UndefOr[Double | String] = js.undefined
   
-  var stroke: js.UndefOr[String] = js.native
+  var stroke: js.UndefOr[String] = js.undefined
   
-  var strokeDasharray: js.UndefOr[String | Double] = js.native
+  var strokeDasharray: js.UndefOr[String | Double] = js.undefined
   
-  var strokeDashoffset: js.UndefOr[String | Double] = js.native
+  var strokeDashoffset: js.UndefOr[String | Double] = js.undefined
   
-  var strokeLinecap: js.UndefOr[butt | round | square | inherit] = js.native
+  var strokeLinecap: js.UndefOr[butt | round | square | inherit] = js.undefined
   
-  var strokeLinejoin: js.UndefOr[miter | round | bevel | inherit] = js.native
+  var strokeLinejoin: js.UndefOr[miter | round | bevel | inherit] = js.undefined
   
-  var strokeMiterlimit: js.UndefOr[Double | String] = js.native
+  var strokeMiterlimit: js.UndefOr[Double | String] = js.undefined
   
-  var strokeOpacity: js.UndefOr[Double | String] = js.native
+  var strokeOpacity: js.UndefOr[Double | String] = js.undefined
   
-  var strokeWidth: js.UndefOr[Double | String] = js.native
+  var strokeWidth: js.UndefOr[Double | String] = js.undefined
   
-  var style: js.UndefOr[CSSProperties] = js.native
+  var style: js.UndefOr[CSSProperties] = js.undefined
   
-  var surfaceScale: js.UndefOr[Double | String] = js.native
+  var surfaceScale: js.UndefOr[Double | String] = js.undefined
   
-  var systemLanguage: js.UndefOr[Double | String] = js.native
+  var systemLanguage: js.UndefOr[Double | String] = js.undefined
   
-  var tabIndex: js.UndefOr[Double] = js.native
+  var tabIndex: js.UndefOr[Double] = js.undefined
   
-  var tableValues: js.UndefOr[Double | String] = js.native
+  var tableValues: js.UndefOr[Double | String] = js.undefined
   
-  var target: js.UndefOr[String] = js.native
+  var target: js.UndefOr[String] = js.undefined
   
-  var targetX: js.UndefOr[Double | String] = js.native
+  var targetX: js.UndefOr[Double | String] = js.undefined
   
-  var targetY: js.UndefOr[Double | String] = js.native
+  var targetY: js.UndefOr[Double | String] = js.undefined
   
-  var textAnchor: js.UndefOr[String] = js.native
+  var textAnchor: js.UndefOr[String] = js.undefined
   
-  var textDecoration: js.UndefOr[Double | String] = js.native
+  var textDecoration: js.UndefOr[Double | String] = js.undefined
   
-  var textLength: js.UndefOr[Double | String] = js.native
+  var textLength: js.UndefOr[Double | String] = js.undefined
   
-  var textRendering: js.UndefOr[Double | String] = js.native
+  var textRendering: js.UndefOr[Double | String] = js.undefined
   
-  var to: js.UndefOr[Double | String] = js.native
+  var to: js.UndefOr[Double | String] = js.undefined
   
-  var transform: js.UndefOr[String] = js.native
+  var transform: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
   
-  var u1: js.UndefOr[Double | String] = js.native
+  var u1: js.UndefOr[Double | String] = js.undefined
   
-  var u2: js.UndefOr[Double | String] = js.native
+  var u2: js.UndefOr[Double | String] = js.undefined
   
-  var underlinePosition: js.UndefOr[Double | String] = js.native
+  var underlinePosition: js.UndefOr[Double | String] = js.undefined
   
-  var underlineThickness: js.UndefOr[Double | String] = js.native
+  var underlineThickness: js.UndefOr[Double | String] = js.undefined
   
-  var unicode: js.UndefOr[Double | String] = js.native
+  var unicode: js.UndefOr[Double | String] = js.undefined
   
-  var unicodeBidi: js.UndefOr[Double | String] = js.native
+  var unicodeBidi: js.UndefOr[Double | String] = js.undefined
   
-  var unicodeRange: js.UndefOr[Double | String] = js.native
+  var unicodeRange: js.UndefOr[Double | String] = js.undefined
   
-  var unitsPerEm: js.UndefOr[Double | String] = js.native
+  var unitsPerEm: js.UndefOr[Double | String] = js.undefined
   
-  var vAlphabetic: js.UndefOr[Double | String] = js.native
+  var vAlphabetic: js.UndefOr[Double | String] = js.undefined
   
-  var vHanging: js.UndefOr[Double | String] = js.native
+  var vHanging: js.UndefOr[Double | String] = js.undefined
   
-  var vIdeographic: js.UndefOr[Double | String] = js.native
+  var vIdeographic: js.UndefOr[Double | String] = js.undefined
   
-  var vMathematical: js.UndefOr[Double | String] = js.native
+  var vMathematical: js.UndefOr[Double | String] = js.undefined
   
-  var values: js.UndefOr[String] = js.native
+  var values: js.UndefOr[String] = js.undefined
   
-  var vectorEffect: js.UndefOr[Double | String] = js.native
+  var vectorEffect: js.UndefOr[Double | String] = js.undefined
   
-  var version: js.UndefOr[String] = js.native
+  var version: js.UndefOr[String] = js.undefined
   
-  var vertAdvY: js.UndefOr[Double | String] = js.native
+  var vertAdvY: js.UndefOr[Double | String] = js.undefined
   
-  var vertOriginX: js.UndefOr[Double | String] = js.native
+  var vertOriginX: js.UndefOr[Double | String] = js.undefined
   
-  var vertOriginY: js.UndefOr[Double | String] = js.native
+  var vertOriginY: js.UndefOr[Double | String] = js.undefined
   
-  var viewBox: js.UndefOr[String] = js.native
+  var viewBox: js.UndefOr[String] = js.undefined
   
-  var viewTarget: js.UndefOr[Double | String] = js.native
+  var viewTarget: js.UndefOr[Double | String] = js.undefined
   
-  var visibility: js.UndefOr[Double | String] = js.native
+  var visibility: js.UndefOr[Double | String] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
   
-  var widths: js.UndefOr[Double | String] = js.native
+  var widths: js.UndefOr[Double | String] = js.undefined
   
-  var wordSpacing: js.UndefOr[Double | String] = js.native
+  var wordSpacing: js.UndefOr[Double | String] = js.undefined
   
-  var writingMode: js.UndefOr[Double | String] = js.native
+  var writingMode: js.UndefOr[Double | String] = js.undefined
   
-  var x: js.UndefOr[Double | String] = js.native
+  var x: js.UndefOr[Double | String] = js.undefined
   
-  var x1: js.UndefOr[Double | String] = js.native
+  var x1: js.UndefOr[Double | String] = js.undefined
   
-  var x2: js.UndefOr[Double | String] = js.native
+  var x2: js.UndefOr[Double | String] = js.undefined
   
-  var xChannelSelector: js.UndefOr[String] = js.native
+  var xChannelSelector: js.UndefOr[String] = js.undefined
   
-  var xHeight: js.UndefOr[Double | String] = js.native
+  var xHeight: js.UndefOr[Double | String] = js.undefined
   
-  var xlinkActuate: js.UndefOr[String] = js.native
+  var xlinkActuate: js.UndefOr[String] = js.undefined
   
-  var xlinkArcrole: js.UndefOr[String] = js.native
+  var xlinkArcrole: js.UndefOr[String] = js.undefined
   
-  var xlinkHref: js.UndefOr[String] = js.native
+  var xlinkHref: js.UndefOr[String] = js.undefined
   
-  var xlinkRole: js.UndefOr[String] = js.native
+  var xlinkRole: js.UndefOr[String] = js.undefined
   
-  var xlinkShow: js.UndefOr[String] = js.native
+  var xlinkShow: js.UndefOr[String] = js.undefined
   
-  var xlinkTitle: js.UndefOr[String] = js.native
+  var xlinkTitle: js.UndefOr[String] = js.undefined
   
-  var xlinkType: js.UndefOr[String] = js.native
+  var xlinkType: js.UndefOr[String] = js.undefined
   
-  var xmlBase: js.UndefOr[String] = js.native
+  var xmlBase: js.UndefOr[String] = js.undefined
   
-  var xmlLang: js.UndefOr[String] = js.native
+  var xmlLang: js.UndefOr[String] = js.undefined
   
-  var xmlSpace: js.UndefOr[String] = js.native
+  var xmlSpace: js.UndefOr[String] = js.undefined
   
-  var xmlns: js.UndefOr[String] = js.native
+  var xmlns: js.UndefOr[String] = js.undefined
   
-  var xmlnsXlink: js.UndefOr[String] = js.native
+  var xmlnsXlink: js.UndefOr[String] = js.undefined
   
-  var y: js.UndefOr[Double | String] = js.native
+  var y: js.UndefOr[Double | String] = js.undefined
   
-  var y1: js.UndefOr[Double | String] = js.native
+  var y1: js.UndefOr[Double | String] = js.undefined
   
-  var y2: js.UndefOr[Double | String] = js.native
+  var y2: js.UndefOr[Double | String] = js.undefined
   
-  var yChannelSelector: js.UndefOr[String] = js.native
+  var yChannelSelector: js.UndefOr[String] = js.undefined
   
-  var z: js.UndefOr[Double | String] = js.native
+  var z: js.UndefOr[Double | String] = js.undefined
   
-  var zoomAndPan: js.UndefOr[String] = js.native
+  var zoomAndPan: js.UndefOr[String] = js.undefined
 }
 object SVGAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/SVGProps.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/SVGProps.scala
@@ -4,7 +4,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SVGProps[T]
   extends StObject
      with SVGAttributes[T]

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/SchedulerInteraction.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/SchedulerInteraction.scala
@@ -7,14 +7,13 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 /**
   * defined in scheduler/tracing
   */
-@js.native
 trait SchedulerInteraction extends StObject {
   
-  var id: Double = js.native
+  var id: Double
   
-  var name: String = js.native
+  var name: String
   
-  var timestamp: Double = js.native
+  var timestamp: Double
 }
 object SchedulerInteraction {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ScriptHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ScriptHTMLAttributes.scala
@@ -4,28 +4,27 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ScriptHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var async: js.UndefOr[Boolean] = js.native
+  var async: js.UndefOr[Boolean] = js.undefined
   
-  var charSet: js.UndefOr[String] = js.native
+  var charSet: js.UndefOr[String] = js.undefined
   
-  var crossOrigin: js.UndefOr[String] = js.native
+  var crossOrigin: js.UndefOr[String] = js.undefined
   
-  var defer: js.UndefOr[Boolean] = js.native
+  var defer: js.UndefOr[Boolean] = js.undefined
   
-  var integrity: js.UndefOr[String] = js.native
+  var integrity: js.UndefOr[String] = js.undefined
   
-  var noModule: js.UndefOr[Boolean] = js.native
+  var noModule: js.UndefOr[Boolean] = js.undefined
   
-  var nonce: js.UndefOr[String] = js.native
+  var nonce: js.UndefOr[String] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
 }
 object ScriptHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/SelectHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/SelectHTMLAttributes.scala
@@ -4,31 +4,30 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SelectHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var autoComplete: js.UndefOr[String] = js.native
+  var autoComplete: js.UndefOr[String] = js.undefined
   
-  var autoFocus: js.UndefOr[Boolean] = js.native
+  var autoFocus: js.UndefOr[Boolean] = js.undefined
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var multiple: js.UndefOr[Boolean] = js.native
+  var multiple: js.UndefOr[Boolean] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
   @JSName("onChange")
-  var onChange_SelectHTMLAttributes: js.UndefOr[ChangeEventHandler[T]] = js.native
+  var onChange_SelectHTMLAttributes: js.UndefOr[ChangeEventHandler[T]] = js.undefined
   
-  var required: js.UndefOr[Boolean] = js.native
+  var required: js.UndefOr[Boolean] = js.undefined
   
-  var size: js.UndefOr[Double] = js.native
+  var size: js.UndefOr[Double] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
 }
 object SelectHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/SourceHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/SourceHTMLAttributes.scala
@@ -4,20 +4,19 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SourceHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var media: js.UndefOr[String] = js.native
+  var media: js.UndefOr[String] = js.undefined
   
-  var sizes: js.UndefOr[String] = js.native
+  var sizes: js.UndefOr[String] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var srcSet: js.UndefOr[String] = js.native
+  var srcSet: js.UndefOr[String] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
 }
 object SourceHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/StaticLifecycle.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/StaticLifecycle.scala
@@ -6,12 +6,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 // Unfortunately, we have no way of declaring that the component constructor must implement this
-@js.native
 trait StaticLifecycle[P, S] extends StObject {
   
-  var getDerivedStateFromError: js.UndefOr[GetDerivedStateFromError[P, S]] = js.native
+  var getDerivedStateFromError: js.UndefOr[GetDerivedStateFromError[P, S]] = js.undefined
   
-  var getDerivedStateFromProps: js.UndefOr[GetDerivedStateFromProps[P, S]] = js.native
+  var getDerivedStateFromProps: js.UndefOr[GetDerivedStateFromProps[P, S]] = js.undefined
 }
 object StaticLifecycle {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/StyleHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/StyleHTMLAttributes.scala
@@ -4,18 +4,17 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait StyleHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var media: js.UndefOr[String] = js.native
+  var media: js.UndefOr[String] = js.undefined
   
-  var nonce: js.UndefOr[String] = js.native
+  var nonce: js.UndefOr[String] = js.undefined
   
-  var scoped: js.UndefOr[Boolean] = js.native
+  var scoped: js.UndefOr[Boolean] = js.undefined
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
 }
 object StyleHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/SuspenseProps.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/SuspenseProps.scala
@@ -4,13 +4,12 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SuspenseProps extends StObject {
   
-  var children: js.UndefOr[slinky.core.facade.ReactElement] = js.native
+  var children: js.UndefOr[slinky.core.facade.ReactElement] = js.undefined
   
   /** A fallback react tree to show when a Suspense child (like React.lazy) suspends */
-  var fallback: (/* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify NonNullable<ReactNode> */ js.Any) | Null = js.native
+  var fallback: (/* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify NonNullable<ReactNode> */ js.Any) | Null
 }
 object SuspenseProps {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TableHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TableHTMLAttributes.scala
@@ -4,16 +4,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TableHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var cellPadding: js.UndefOr[Double | String] = js.native
+  var cellPadding: js.UndefOr[Double | String] = js.undefined
   
-  var cellSpacing: js.UndefOr[Double | String] = js.native
+  var cellSpacing: js.UndefOr[Double | String] = js.undefined
   
-  var summary: js.UndefOr[String] = js.native
+  var summary: js.UndefOr[String] = js.undefined
 }
 object TableHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TdHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TdHTMLAttributes.scala
@@ -13,22 +13,21 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TdHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var align: js.UndefOr[left | center | right | justify | char] = js.native
+  var align: js.UndefOr[left | center | right | justify | char] = js.undefined
   
-  var colSpan: js.UndefOr[Double] = js.native
+  var colSpan: js.UndefOr[Double] = js.undefined
   
-  var headers: js.UndefOr[String] = js.native
+  var headers: js.UndefOr[String] = js.undefined
   
-  var rowSpan: js.UndefOr[Double] = js.native
+  var rowSpan: js.UndefOr[Double] = js.undefined
   
-  var scope: js.UndefOr[String] = js.native
+  var scope: js.UndefOr[String] = js.undefined
   
-  var valign: js.UndefOr[top | middle | bottom | baseline] = js.native
+  var valign: js.UndefOr[top | middle | bottom | baseline] = js.undefined
 }
 object TdHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TextareaHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TextareaHTMLAttributes.scala
@@ -4,41 +4,40 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TextareaHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var autoComplete: js.UndefOr[String] = js.native
+  var autoComplete: js.UndefOr[String] = js.undefined
   
-  var autoFocus: js.UndefOr[Boolean] = js.native
+  var autoFocus: js.UndefOr[Boolean] = js.undefined
   
-  var cols: js.UndefOr[Double] = js.native
+  var cols: js.UndefOr[Double] = js.undefined
   
-  var dirName: js.UndefOr[String] = js.native
+  var dirName: js.UndefOr[String] = js.undefined
   
-  var disabled: js.UndefOr[Boolean] = js.native
+  var disabled: js.UndefOr[Boolean] = js.undefined
   
-  var form: js.UndefOr[String] = js.native
+  var form: js.UndefOr[String] = js.undefined
   
-  var maxLength: js.UndefOr[Double] = js.native
+  var maxLength: js.UndefOr[Double] = js.undefined
   
-  var minLength: js.UndefOr[Double] = js.native
+  var minLength: js.UndefOr[Double] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
   
   @JSName("onChange")
-  var onChange_TextareaHTMLAttributes: js.UndefOr[ChangeEventHandler[T]] = js.native
+  var onChange_TextareaHTMLAttributes: js.UndefOr[ChangeEventHandler[T]] = js.undefined
   
-  var readOnly: js.UndefOr[Boolean] = js.native
+  var readOnly: js.UndefOr[Boolean] = js.undefined
   
-  var required: js.UndefOr[Boolean] = js.native
+  var required: js.UndefOr[Boolean] = js.undefined
   
-  var rows: js.UndefOr[Double] = js.native
+  var rows: js.UndefOr[Double] = js.undefined
   
-  var value: js.UndefOr[String | js.Array[String] | Double] = js.native
+  var value: js.UndefOr[String | js.Array[String] | Double] = js.undefined
   
-  var wrap: js.UndefOr[String] = js.native
+  var wrap: js.UndefOr[String] = js.undefined
 }
 object TextareaHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ThHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/ThHTMLAttributes.scala
@@ -9,20 +9,19 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ThHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var align: js.UndefOr[left | center | right | justify | char] = js.native
+  var align: js.UndefOr[left | center | right | justify | char] = js.undefined
   
-  var colSpan: js.UndefOr[Double] = js.native
+  var colSpan: js.UndefOr[Double] = js.undefined
   
-  var headers: js.UndefOr[String] = js.native
+  var headers: js.UndefOr[String] = js.undefined
   
-  var rowSpan: js.UndefOr[Double] = js.native
+  var rowSpan: js.UndefOr[Double] = js.undefined
   
-  var scope: js.UndefOr[String] = js.native
+  var scope: js.UndefOr[String] = js.undefined
 }
 object ThHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TimeHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TimeHTMLAttributes.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TimeHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var dateTime: js.UndefOr[String] = js.native
+  var dateTime: js.UndefOr[String] = js.undefined
 }
 object TimeHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/Touch.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/Touch.scala
@@ -5,24 +5,23 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Touch extends StObject {
   
-  var clientX: Double = js.native
+  var clientX: Double
   
-  var clientY: Double = js.native
+  var clientY: Double
   
-  var identifier: Double = js.native
+  var identifier: Double
   
-  var pageX: Double = js.native
+  var pageX: Double
   
-  var pageY: Double = js.native
+  var pageY: Double
   
-  var screenX: Double = js.native
+  var screenX: Double
   
-  var screenY: Double = js.native
+  var screenY: Double
   
-  var target: EventTarget = js.native
+  var target: EventTarget
 }
 object Touch {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TouchEvent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TouchEvent.scala
@@ -5,29 +5,28 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TouchEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeTouchEvent, EventTarget & T, EventTarget] {
   
-  var altKey: Boolean = js.native
+  var altKey: Boolean
   
-  var changedTouches: TouchList = js.native
+  var changedTouches: TouchList
   
-  var ctrlKey: Boolean = js.native
+  var ctrlKey: Boolean
   
   /**
     * See [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#keys-modifier). for a list of valid (case-sensitive) arguments to this method.
     */
-  def getModifierState(key: String): Boolean = js.native
+  def getModifierState(key: String): Boolean
   
-  var metaKey: Boolean = js.native
+  var metaKey: Boolean
   
-  var shiftKey: Boolean = js.native
+  var shiftKey: Boolean
   
-  var targetTouches: TouchList = js.native
+  var targetTouches: TouchList
   
-  var touches: TouchList = js.native
+  var touches: TouchList
 }
 object TouchEvent {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TouchList.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TouchList.scala
@@ -5,16 +5,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TouchList
   extends StObject
      with /* index */ NumberDictionary[Touch] {
   
-  def identifiedTouch(identifier: Double): Touch = js.native
+  def identifiedTouch(identifier: Double): Touch
   
-  def item(index: Double): Touch = js.native
+  def item(index: Double): Touch
   
-  var length: Double = js.native
+  var length: Double
 }
 object TouchList {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TrackHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TrackHTMLAttributes.scala
@@ -4,20 +4,19 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TrackHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var default: js.UndefOr[Boolean] = js.native
+  var default: js.UndefOr[Boolean] = js.undefined
   
-  var kind: js.UndefOr[String] = js.native
+  var kind: js.UndefOr[String] = js.undefined
   
-  var label: js.UndefOr[String] = js.native
+  var label: js.UndefOr[String] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var srcLang: js.UndefOr[String] = js.native
+  var srcLang: js.UndefOr[String] = js.undefined
 }
 object TrackHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TransitionEvent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/TransitionEvent.scala
@@ -5,16 +5,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TransitionEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeTransitionEvent, EventTarget & T, EventTarget] {
   
-  var elapsedTime: Double = js.native
+  var elapsedTime: Double
   
-  var propertyName: String = js.native
+  var propertyName: String
   
-  var pseudoElement: String = js.native
+  var pseudoElement: String
 }
 object TransitionEvent {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/UIEvent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/UIEvent.scala
@@ -5,14 +5,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait UIEvent[T]
   extends StObject
      with BaseSyntheticEvent[NativeUIEvent, EventTarget & T, EventTarget] {
   
-  var detail: Double = js.native
+  var detail: Double
   
-  var view: AbstractView = js.native
+  var view: AbstractView
 }
 object UIEvent {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/VideoHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/VideoHTMLAttributes.scala
@@ -4,20 +4,19 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait VideoHTMLAttributes[T]
   extends StObject
      with MediaHTMLAttributes[T] {
   
-  var disablePictureInPicture: js.UndefOr[Boolean] = js.native
+  var disablePictureInPicture: js.UndefOr[Boolean] = js.undefined
   
-  var height: js.UndefOr[Double | String] = js.native
+  var height: js.UndefOr[Double | String] = js.undefined
   
-  var playsInline: js.UndefOr[Boolean] = js.native
+  var playsInline: js.UndefOr[Boolean] = js.undefined
   
-  var poster: js.UndefOr[String] = js.native
+  var poster: js.UndefOr[String] = js.undefined
   
-  var width: js.UndefOr[Double | String] = js.native
+  var width: js.UndefOr[Double | String] = js.undefined
 }
 object VideoHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/WebViewHTMLAttributes.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/WebViewHTMLAttributes.scala
@@ -4,44 +4,43 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait WebViewHTMLAttributes[T]
   extends StObject
      with HTMLAttributes[T] {
   
-  var allowFullScreen: js.UndefOr[Boolean] = js.native
+  var allowFullScreen: js.UndefOr[Boolean] = js.undefined
   
-  var allowpopups: js.UndefOr[Boolean] = js.native
+  var allowpopups: js.UndefOr[Boolean] = js.undefined
   
-  var autoFocus: js.UndefOr[Boolean] = js.native
+  var autoFocus: js.UndefOr[Boolean] = js.undefined
   
-  var autosize: js.UndefOr[Boolean] = js.native
+  var autosize: js.UndefOr[Boolean] = js.undefined
   
-  var blinkfeatures: js.UndefOr[String] = js.native
+  var blinkfeatures: js.UndefOr[String] = js.undefined
   
-  var disableblinkfeatures: js.UndefOr[String] = js.native
+  var disableblinkfeatures: js.UndefOr[String] = js.undefined
   
-  var disableguestresize: js.UndefOr[Boolean] = js.native
+  var disableguestresize: js.UndefOr[Boolean] = js.undefined
   
-  var disablewebsecurity: js.UndefOr[Boolean] = js.native
+  var disablewebsecurity: js.UndefOr[Boolean] = js.undefined
   
-  var guestinstance: js.UndefOr[String] = js.native
+  var guestinstance: js.UndefOr[String] = js.undefined
   
-  var httpreferrer: js.UndefOr[String] = js.native
+  var httpreferrer: js.UndefOr[String] = js.undefined
   
-  var nodeintegration: js.UndefOr[Boolean] = js.native
+  var nodeintegration: js.UndefOr[Boolean] = js.undefined
   
-  var partition: js.UndefOr[String] = js.native
+  var partition: js.UndefOr[String] = js.undefined
   
-  var plugins: js.UndefOr[Boolean] = js.native
+  var plugins: js.UndefOr[Boolean] = js.undefined
   
-  var preload: js.UndefOr[String] = js.native
+  var preload: js.UndefOr[String] = js.undefined
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
   
-  var useragent: js.UndefOr[String] = js.native
+  var useragent: js.UndefOr[String] = js.undefined
   
-  var webpreferences: js.UndefOr[String] = js.native
+  var webpreferences: js.UndefOr[String] = js.undefined
 }
 object WebViewHTMLAttributes {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/WheelEvent.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/WheelEvent.scala
@@ -5,18 +5,17 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait WheelEvent[T]
   extends StObject
      with MouseEvent[T, NativeWheelEvent] {
   
-  var deltaMode: Double = js.native
+  var deltaMode: Double
   
-  var deltaX: Double = js.native
+  var deltaX: Double
   
-  var deltaY: Double = js.native
+  var deltaY: Double
   
-  var deltaZ: Double = js.native
+  var deltaZ: Double
 }
 object WheelEvent {
   

--- a/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/global.scala
+++ b/tests/react-integration-test/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod/global.scala
@@ -17,10 +17,8 @@ object global {
     // tslint:disable-next-line:no-empty-interface
     type Element = slinky.core.facade.ReactElement
     
-    @js.native
     trait ElementAttributesProperty extends StObject
     
-    @js.native
     trait ElementChildrenAttribute extends StObject
     
     @js.native
@@ -33,35 +31,34 @@ object global {
     // tslint:disable-next-line:no-empty-interface
     type IntrinsicClassAttributes[T] = ClassAttributes[T]
     
-    @js.native
     trait IntrinsicElements extends StObject {
       
       // HTML
-      var a: DetailedHTMLProps[AnchorHTMLAttributes[HTMLAnchorElement], HTMLAnchorElement] = js.native
+      var a: DetailedHTMLProps[AnchorHTMLAttributes[HTMLAnchorElement], HTMLAnchorElement]
       
-      var abbr: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var abbr: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var address: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var address: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var area: DetailedHTMLProps[AreaHTMLAttributes[HTMLAreaElement], HTMLAreaElement] = js.native
+      var area: DetailedHTMLProps[AreaHTMLAttributes[HTMLAreaElement], HTMLAreaElement]
       
-      var article: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var article: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var aside: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var aside: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var audio: DetailedHTMLProps[AudioHTMLAttributes[HTMLAudioElement], HTMLAudioElement] = js.native
+      var audio: DetailedHTMLProps[AudioHTMLAttributes[HTMLAudioElement], HTMLAudioElement]
       
-      var b: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var b: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var base: DetailedHTMLProps[BaseHTMLAttributes[HTMLBaseElement], HTMLBaseElement] = js.native
+      var base: DetailedHTMLProps[BaseHTMLAttributes[HTMLBaseElement], HTMLBaseElement]
       
-      var bdi: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var bdi: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var bdo: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var bdo: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var big: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+      var big: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
       
-      var view: SVGProps[SVGViewElement] = js.native
+      var view: SVGProps[SVGViewElement]
     }
     object IntrinsicElements {
       

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-e4ddf1"
+version := "0.0-unknown-35d40f"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-93664c",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ee2ca2",
+  "org.scalablytyped" %%% "react" % "16.9.2-7784a5",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-66db32",
   ("me.shadaj" %%% "slinky-web" % "0.6.7").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/accordionAccordionAccordionMod.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/accordionAccordionAccordionMod.scala
@@ -29,7 +29,6 @@ object accordionAccordionAccordionMod extends Shortcut {
   @js.native
   val default: ReactComponentClass[AccordionAccordionProps] = js.native
   
-  @js.native
   trait AccordionAccordionProps
     extends StObject
        with StrictAccordionAccordionProps
@@ -43,26 +42,25 @@ object accordionAccordionAccordionMod extends Shortcut {
     }
   }
   
-  @js.native
   trait StrictAccordionAccordionProps extends StObject {
     
     /** Index of the currently active panel. */
-    var activeIndex: js.UndefOr[Double | js.Array[Double]] = js.native
+    var activeIndex: js.UndefOr[Double | js.Array[Double]] = js.undefined
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Primary content. */
-    var children: js.UndefOr[ReactElement] = js.native
+    var children: js.UndefOr[ReactElement] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Initial activeIndex value. */
-    var defaultActiveIndex: js.UndefOr[Double | js.Array[Double]] = js.native
+    var defaultActiveIndex: js.UndefOr[Double | js.Array[Double]] = js.undefined
     
     /** Only allow one panel open at a time. */
-    var exclusive: js.UndefOr[Boolean] = js.native
+    var exclusive: js.UndefOr[Boolean] = js.undefined
     
     /**
       * Called when a panel title is clicked.
@@ -76,10 +74,10 @@ object accordionAccordionAccordionMod extends Shortcut {
           /* data */ AccordionTitleProps, 
           Unit
         ]
-      ] = js.native
+      ] = js.undefined
     
     /** Shorthand array of props for Accordion. */
-    var panels: js.UndefOr[SemanticShorthandCollection[AccordionPanelProps]] = js.native
+    var panels: js.UndefOr[SemanticShorthandCollection[AccordionPanelProps]] = js.undefined
   }
   object StrictAccordionAccordionProps {
     

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/accordionAccordionMod.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/accordionAccordionMod.scala
@@ -65,7 +65,6 @@ object accordionAccordionMod {
     var Title: ReactComponentClass[AccordionTitleProps] = js.native
   }
   
-  @js.native
   trait AccordionProps
     extends StObject
        with StrictAccordionProps
@@ -79,19 +78,18 @@ object accordionAccordionMod {
     }
   }
   
-  @js.native
   trait StrictAccordionProps
     extends StObject
        with StrictAccordionAccordionProps {
     
     /** Format to take up the width of its container. */
-    var fluid: js.UndefOr[Boolean] = js.native
+    var fluid: js.UndefOr[Boolean] = js.undefined
     
     /** Format for dark backgrounds. */
-    var inverted: js.UndefOr[Boolean] = js.native
+    var inverted: js.UndefOr[Boolean] = js.undefined
     
     /** Adds some basic styling to accordion panels. */
-    var styled: js.UndefOr[Boolean] = js.native
+    var styled: js.UndefOr[Boolean] = js.undefined
   }
   object StrictAccordionProps {
     

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/accordionContentMod.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/accordionContentMod.scala
@@ -15,7 +15,6 @@ object accordionContentMod extends Shortcut {
   @js.native
   val default: ReactComponentClass[AccordionContentProps] = js.native
   
-  @js.native
   trait AccordionContentProps
     extends StObject
        with StrictAccordionContentProps
@@ -29,23 +28,22 @@ object accordionContentMod extends Shortcut {
     }
   }
   
-  @js.native
   trait StrictAccordionContentProps extends StObject {
     
     /** Whether or not the content is visible. */
-    var active: js.UndefOr[Boolean] = js.native
+    var active: js.UndefOr[Boolean] = js.undefined
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Primary content. */
-    var children: js.UndefOr[ReactElement] = js.native
+    var children: js.UndefOr[ReactElement] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Shorthand for primary content. */
-    var content: js.UndefOr[SemanticShorthandContent] = js.native
+    var content: js.UndefOr[SemanticShorthandContent] = js.undefined
   }
   object StrictAccordionContentProps {
     

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/accordionPanelMod.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/accordionPanelMod.scala
@@ -24,7 +24,6 @@ object accordionPanelMod {
   
   type AccordionPanel = ReactComponentClass[AccordionPanelProps]
   
-  @js.native
   trait AccordionPanelProps
     extends StObject
        with StrictAccordionPanelProps
@@ -38,17 +37,16 @@ object accordionPanelMod {
     }
   }
   
-  @js.native
   trait StrictAccordionPanelProps extends StObject {
     
     /** Whether or not the title is in the open state. */
-    var active: js.UndefOr[Boolean] = js.native
+    var active: js.UndefOr[Boolean] = js.undefined
     
     /** A shorthand for Accordion.Content. */
-    var content: js.UndefOr[SemanticShorthandItem[AccordionContentProps]] = js.native
+    var content: js.UndefOr[SemanticShorthandItem[AccordionContentProps]] = js.undefined
     
     /** A panel index. */
-    var index: js.UndefOr[Double | String] = js.native
+    var index: js.UndefOr[Double | String] = js.undefined
     
     /**
       * Called when a panel title is clicked.
@@ -62,10 +60,10 @@ object accordionPanelMod {
           /* data */ AccordionTitleProps, 
           Unit
         ]
-      ] = js.native
+      ] = js.undefined
     
     /** A shorthand for Accordion.Title. */
-    var title: js.UndefOr[SemanticShorthandItem[AccordionTitleProps]] = js.native
+    var title: js.UndefOr[SemanticShorthandItem[AccordionTitleProps]] = js.undefined
   }
   object StrictAccordionPanelProps {
     

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/accordionTitleMod.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/accordionTitleMod.scala
@@ -29,7 +29,6 @@ object accordionTitleMod extends Shortcut {
   @js.native
   val default: ReactComponentClass[AccordionTitleProps] = js.native
   
-  @js.native
   trait AccordionTitleProps
     extends StObject
        with StrictAccordionTitleProps
@@ -43,33 +42,32 @@ object accordionTitleMod extends Shortcut {
     }
   }
   
-  @js.native
   trait StrictAccordionTitleProps extends StObject {
     
     /** Whether or not the title is in the open state. */
-    var active: js.UndefOr[Boolean] = js.native
+    var active: js.UndefOr[Boolean] = js.undefined
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Primary content. */
-    var children: js.UndefOr[ReactElement] = js.native
+    var children: js.UndefOr[ReactElement] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Shorthand for primary content. */
-    var content: js.UndefOr[SemanticShorthandContent] = js.native
+    var content: js.UndefOr[SemanticShorthandContent] = js.undefined
     
     /** Shorthand for Icon. */
     var icon: js.UndefOr[
         SemanticShorthandItem[
           /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify IconProps */ js.Any
         ]
-      ] = js.native
+      ] = js.undefined
     
     /** AccordionTitle index inside Accordion. */
-    var index: js.UndefOr[Double | String] = js.native
+    var index: js.UndefOr[Double | String] = js.undefined
     
     /**
       * Called on click.
@@ -83,7 +81,7 @@ object accordionTitleMod extends Shortcut {
           /* data */ AccordionTitleProps, 
           Unit
         ]
-      ] = js.native
+      ] = js.undefined
   }
   object StrictAccordionTitleProps {
     

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/buttonContentMod.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/buttonContentMod.scala
@@ -15,7 +15,6 @@ object buttonContentMod extends Shortcut {
   @js.native
   val default: ReactComponentClass[ButtonContentProps] = js.native
   
-  @js.native
   trait ButtonContentProps
     extends StObject
        with StrictButtonContentProps
@@ -29,26 +28,25 @@ object buttonContentMod extends Shortcut {
     }
   }
   
-  @js.native
   trait StrictButtonContentProps extends StObject {
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Primary content. */
-    var children: js.UndefOr[ReactElement] = js.native
+    var children: js.UndefOr[ReactElement] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Shorthand for primary content. */
-    var content: js.UndefOr[SemanticShorthandContent] = js.native
+    var content: js.UndefOr[SemanticShorthandContent] = js.undefined
     
     /** Initially hidden, visible on hover. */
-    var hidden: js.UndefOr[Boolean] = js.native
+    var hidden: js.UndefOr[Boolean] = js.undefined
     
     /** Initially visible, hidden on hover. */
-    var visible: js.UndefOr[Boolean] = js.native
+    var visible: js.UndefOr[Boolean] = js.undefined
   }
   object StrictButtonContentProps {
     

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/buttonGroupMod.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/buttonGroupMod.scala
@@ -26,7 +26,6 @@ object buttonGroupMod extends Shortcut {
   @js.native
   val default: ReactComponentClass[ButtonGroupProps] = js.native
   
-  @js.native
   trait ButtonGroupProps
     extends StObject
        with StrictButtonGroupProps
@@ -40,74 +39,73 @@ object buttonGroupMod extends Shortcut {
     }
   }
   
-  @js.native
   trait StrictButtonGroupProps extends StObject {
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Groups can be attached to other content. */
-    var attached: js.UndefOr[Boolean | left | right | top | bottom] = js.native
+    var attached: js.UndefOr[Boolean | left | right | top | bottom] = js.undefined
     
     /** Groups can be less pronounced. */
-    var basic: js.UndefOr[Boolean] = js.native
+    var basic: js.UndefOr[Boolean] = js.undefined
     
     /** Array of shorthand Button values. */
-    var buttons: js.UndefOr[SemanticShorthandCollection[ButtonProps]] = js.native
+    var buttons: js.UndefOr[SemanticShorthandCollection[ButtonProps]] = js.undefined
     
     /** Primary content. */
-    var children: js.UndefOr[ReactElement] = js.native
+    var children: js.UndefOr[ReactElement] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Groups can have a shared color. */
-    var color: js.UndefOr[SemanticCOLORS] = js.native
+    var color: js.UndefOr[SemanticCOLORS] = js.undefined
     
     /** Groups can reduce their padding to fit into tighter spaces. */
-    var compact: js.UndefOr[Boolean] = js.native
+    var compact: js.UndefOr[Boolean] = js.undefined
     
     /** Shorthand for primary content. */
-    var content: js.UndefOr[SemanticShorthandContent] = js.native
+    var content: js.UndefOr[SemanticShorthandContent] = js.undefined
     
     /** Groups can be aligned to the left or right of its container. */
-    var floated: js.UndefOr[SemanticFLOATS] = js.native
+    var floated: js.UndefOr[SemanticFLOATS] = js.undefined
     
     /** Groups can take the width of their container. */
-    var fluid: js.UndefOr[Boolean] = js.native
+    var fluid: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can be formatted as icons. */
-    var icon: js.UndefOr[Boolean] = js.native
+    var icon: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can be formatted to appear on dark backgrounds. */
-    var inverted: js.UndefOr[Boolean] = js.native
+    var inverted: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can be formatted as labeled icon buttons. */
-    var labeled: js.UndefOr[Boolean] = js.native
+    var labeled: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can hint towards a negative consequence. */
-    var negative: js.UndefOr[Boolean] = js.native
+    var negative: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can hint towards a positive consequence. */
-    var positive: js.UndefOr[Boolean] = js.native
+    var positive: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can be formatted to show different levels of emphasis. */
-    var primary: js.UndefOr[Boolean] = js.native
+    var primary: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can be formatted to show different levels of emphasis. */
-    var secondary: js.UndefOr[Boolean] = js.native
+    var secondary: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can have different sizes. */
-    var size: js.UndefOr[SemanticSIZES] = js.native
+    var size: js.UndefOr[SemanticSIZES] = js.undefined
     
     /** Groups can be formatted to toggle on and off. */
-    var toggle: js.UndefOr[Boolean] = js.native
+    var toggle: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can be formatted to appear vertically. */
-    var vertical: js.UndefOr[Boolean] = js.native
+    var vertical: js.UndefOr[Boolean] = js.undefined
     
     /** Groups can have their widths divided evenly. */
-    var widths: js.UndefOr[SemanticWIDTHS] = js.native
+    var widths: js.UndefOr[SemanticWIDTHS] = js.undefined
   }
   object StrictButtonGroupProps {
     

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/buttonMod.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/buttonMod.scala
@@ -65,72 +65,71 @@ object buttonMod {
   
   type ButtonProps = StrictButtonProps
   
-  @js.native
   trait StrictButtonProps
     extends StObject
        with ButtonHTMLAttributes[HTMLButtonElement] {
     
     /** A button can show it is currently the active user selection. */
-    var active: js.UndefOr[Boolean] = js.native
+    var active: js.UndefOr[Boolean] = js.undefined
     
     /** A button can animate to show hidden content. */
-    var animated: js.UndefOr[Boolean | fade | vertical] = js.native
+    var animated: js.UndefOr[Boolean | fade | vertical] = js.undefined
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** A button can be attached to other content. */
-    var attached: js.UndefOr[Boolean | left | right | top | bottom] = js.native
+    var attached: js.UndefOr[Boolean | left | right | top | bottom] = js.undefined
     
     /** A basic button is less pronounced. */
-    var basic: js.UndefOr[Boolean] = js.native
+    var basic: js.UndefOr[Boolean] = js.undefined
     
     /** A button can be circular. */
-    var circular: js.UndefOr[Boolean] = js.native
+    var circular: js.UndefOr[Boolean] = js.undefined
     
     /** A button can have different colors. */
     @JSName("color")
     var color_StrictButtonProps: js.UndefOr[
         SemanticCOLORS | facebook | (`google plus`) | vk | twitter | linkedin | instagram | youtube
-      ] = js.native
+      ] = js.undefined
     
     /** A button can reduce its padding to fit into tighter spaces. */
-    var compact: js.UndefOr[Boolean] = js.native
+    var compact: js.UndefOr[Boolean] = js.undefined
     
     /** Shorthand for primary content. */
-    var content: js.UndefOr[SemanticShorthandContent] = js.native
+    var content: js.UndefOr[SemanticShorthandContent] = js.undefined
     
     /** A button can be aligned to the left or right of its container. */
-    var floated: js.UndefOr[SemanticFLOATS] = js.native
+    var floated: js.UndefOr[SemanticFLOATS] = js.undefined
     
     /** A button can take the width of its container. */
-    var fluid: js.UndefOr[Boolean] = js.native
+    var fluid: js.UndefOr[Boolean] = js.undefined
     
     /** Add an Icon by name, props object, or pass an <Icon />. */
     var icon: js.UndefOr[
         Boolean | (SemanticShorthandItem[
           /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify IconProps */ js.Any
         ])
-      ] = js.native
+      ] = js.undefined
     
     /** A button can be formatted to appear on dark backgrounds. */
-    var inverted: js.UndefOr[Boolean] = js.native
+    var inverted: js.UndefOr[Boolean] = js.undefined
     
     /** Add a Label by text, props object, or pass a <Label />. */
     var label: js.UndefOr[
         SemanticShorthandItem[
           /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify LabelProps */ js.Any
         ]
-      ] = js.native
+      ] = js.undefined
     
     /** A labeled button can format a Label or Icon to appear on the left or right. */
-    var labelPosition: js.UndefOr[right | left] = js.native
+    var labelPosition: js.UndefOr[right | left] = js.undefined
     
     /** A button can show a loading indicator. */
-    var loading: js.UndefOr[Boolean] = js.native
+    var loading: js.UndefOr[Boolean] = js.undefined
     
     /** A button can hint towards a negative consequence. */
-    var negative: js.UndefOr[Boolean] = js.native
+    var negative: js.UndefOr[Boolean] = js.undefined
     
     /**
       * Called after user's click.
@@ -140,26 +139,26 @@ object buttonMod {
     @JSName("onClick")
     var onClick_StrictButtonProps: js.UndefOr[
         js.Function2[/* event */ SyntheticMouseEvent[HTMLButtonElement], /* data */ ButtonProps, Unit]
-      ] = js.native
+      ] = js.undefined
     
     /** A button can hint towards a positive consequence. */
-    var positive: js.UndefOr[Boolean] = js.native
+    var positive: js.UndefOr[Boolean] = js.undefined
     
     /** A button can be formatted to show different levels of emphasis. */
-    var primary: js.UndefOr[Boolean] = js.native
+    var primary: js.UndefOr[Boolean] = js.undefined
     
     /** A button can be formatted to show different levels of emphasis. */
-    var secondary: js.UndefOr[Boolean] = js.native
+    var secondary: js.UndefOr[Boolean] = js.undefined
     
     /** A button can have different sizes. */
-    var size: js.UndefOr[SemanticSIZES] = js.native
+    var size: js.UndefOr[SemanticSIZES] = js.undefined
     
     /** A button can receive focus. */
     @JSName("tabIndex")
-    var tabIndex_StrictButtonProps: js.UndefOr[Double | String] = js.native
+    var tabIndex_StrictButtonProps: js.UndefOr[Double | String] = js.undefined
     
     /** A button can be formatted to toggle on and off. */
-    var toggle: js.UndefOr[Boolean] = js.native
+    var toggle: js.UndefOr[Boolean] = js.undefined
   }
   object StrictButtonProps {
     

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/buttonOrMod.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/buttonOrMod.scala
@@ -13,7 +13,6 @@ object buttonOrMod extends Shortcut {
   @js.native
   val default: ReactComponentClass[ButtonOrProps] = js.native
   
-  @js.native
   trait ButtonOrProps
     extends StObject
        with StrictButtonOrProps
@@ -27,17 +26,16 @@ object buttonOrMod extends Shortcut {
     }
   }
   
-  @js.native
   trait StrictButtonOrProps extends StObject {
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Or buttons can have their text localized, or adjusted by using the text prop. */
-    var text: js.UndefOr[Double | String] = js.native
+    var text: js.UndefOr[Double | String] = js.undefined
   }
   object StrictButtonOrProps {
     

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/containerContainerMod.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/containerContainerMod.scala
@@ -16,7 +16,6 @@ object containerContainerMod extends Shortcut {
   @js.native
   val default: ReactComponentClass[ContainerProps] = js.native
   
-  @js.native
   trait ContainerProps
     extends StObject
        with StrictContainerProps
@@ -30,29 +29,28 @@ object containerContainerMod extends Shortcut {
     }
   }
   
-  @js.native
   trait StrictContainerProps extends StObject {
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Primary content. */
-    var children: js.UndefOr[ReactElement] = js.native
+    var children: js.UndefOr[ReactElement] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Shorthand for primary content. */
-    var content: js.UndefOr[SemanticShorthandContent] = js.native
+    var content: js.UndefOr[SemanticShorthandContent] = js.undefined
     
     /** Container has no maximum width. */
-    var fluid: js.UndefOr[Boolean] = js.native
+    var fluid: js.UndefOr[Boolean] = js.undefined
     
     /** Reduce maximum width to more naturally accommodate text. */
-    var text: js.UndefOr[Boolean] = js.native
+    var text: js.UndefOr[Boolean] = js.undefined
     
     /** Describes how the text inside this component should be aligned. */
-    var textAlign: js.UndefOr[SemanticTEXTALIGNMENTS] = js.native
+    var textAlign: js.UndefOr[SemanticTEXTALIGNMENTS] = js.undefined
   }
   object StrictContainerProps {
     

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/HtmlIframeProps.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/HtmlIframeProps.scala
@@ -5,7 +5,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HtmlIframeProps
   extends StObject
      with StrictHtmlIframeProps

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/HtmlImageProps.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/HtmlImageProps.scala
@@ -5,7 +5,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HtmlImageProps
   extends StObject
      with StrictHtmlImageProps

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/HtmlInputrops.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/HtmlInputrops.scala
@@ -5,7 +5,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HtmlInputrops
   extends StObject
      with StrictHtmlInputrops

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/HtmlLabelProps.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/HtmlLabelProps.scala
@@ -5,7 +5,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HtmlLabelProps
   extends StObject
      with StrictHtmlLabelProps

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/HtmlSpanProps.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/HtmlSpanProps.scala
@@ -5,7 +5,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HtmlSpanProps
   extends StObject
      with StrictHtmlSpanProps

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/StrictHtmlIframeProps.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/StrictHtmlIframeProps.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait StrictHtmlIframeProps extends StObject {
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
 }
 object StrictHtmlIframeProps {
   

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/StrictHtmlImageProps.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/StrictHtmlImageProps.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait StrictHtmlImageProps extends StObject {
   
-  var src: js.UndefOr[String] = js.native
+  var src: js.UndefOr[String] = js.undefined
 }
 object StrictHtmlImageProps {
   

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/StrictHtmlInputrops.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/StrictHtmlInputrops.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait StrictHtmlInputrops extends StObject {
   
-  var `type`: js.UndefOr[String] = js.native
+  var `type`: js.UndefOr[String] = js.undefined
 }
 object StrictHtmlInputrops {
   

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/StrictHtmlLabelProps.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/StrictHtmlLabelProps.scala
@@ -5,10 +5,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait StrictHtmlLabelProps extends StObject {
   
-  var children: js.UndefOr[ReactElement] = js.native
+  var children: js.UndefOr[ReactElement] = js.undefined
 }
 object StrictHtmlLabelProps {
   

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/StrictHtmlSpanProps.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/genericMod/StrictHtmlSpanProps.scala
@@ -5,10 +5,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait StrictHtmlSpanProps extends StObject {
   
-  var children: js.UndefOr[ReactElement] = js.native
+  var children: js.UndefOr[ReactElement] = js.undefined
 }
 object StrictHtmlSpanProps {
   

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/inputInputMod.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/inputInputMod.scala
@@ -38,13 +38,12 @@ object inputInputMod {
     def select(): Unit = js.native
   }
   
-  @js.native
   trait InputOnChangeData
     extends StObject
        with StrictInputProps {
     
     @JSName("value")
-    var value_InputOnChangeData: String = js.native
+    var value_InputOnChangeData: String
   }
   object InputOnChangeData {
     
@@ -64,53 +63,52 @@ object inputInputMod {
   
   type InputProps = StrictInputProps
   
-  @js.native
   trait StrictInputProps
     extends StObject
        with InputHTMLAttributes[HTMLInputElement] {
     
     /** An Input can be formatted to alert the user to an action they may perform. */
-    var action: js.UndefOr[js.Any | Boolean] = js.native
+    var action: js.UndefOr[js.Any | Boolean] = js.undefined
     
     /** An action can appear along side an Input on the left or right. */
-    var actionPosition: js.UndefOr[left] = js.native
+    var actionPosition: js.UndefOr[left] = js.undefined
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** An Input field can show the data contains errors. */
-    var error: js.UndefOr[Boolean] = js.native
+    var error: js.UndefOr[Boolean] = js.undefined
     
     /** Take on the size of its container. */
-    var fluid: js.UndefOr[Boolean] = js.native
+    var fluid: js.UndefOr[Boolean] = js.undefined
     
     /** An Input field can show a user is currently interacting with it. */
-    var focus: js.UndefOr[Boolean] = js.native
+    var focus: js.UndefOr[Boolean] = js.undefined
     
     /** Optional Icon to display inside the Input. */
-    var icon: js.UndefOr[js.Any | SemanticShorthandItem[InputProps]] = js.native
+    var icon: js.UndefOr[js.Any | SemanticShorthandItem[InputProps]] = js.undefined
     
     /** An Icon can appear inside an Input on the left. */
-    var iconPosition: js.UndefOr[left] = js.native
+    var iconPosition: js.UndefOr[left] = js.undefined
     
     /** Shorthand for creating the HTML Input. */
-    var input: js.UndefOr[SemanticShorthandItem[HtmlInputrops]] = js.native
+    var input: js.UndefOr[SemanticShorthandItem[HtmlInputrops]] = js.undefined
     
     /** Format to appear on dark backgrounds. */
-    var inverted: js.UndefOr[Boolean] = js.native
+    var inverted: js.UndefOr[Boolean] = js.undefined
     
     /** Optional Label to display along side the Input. */
     var label: js.UndefOr[
         SemanticShorthandItem[
           /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify LabelProps */ js.Any
         ]
-      ] = js.native
+      ] = js.undefined
     
     /** A Label can appear outside an Input on the left or right. */
-    var labelPosition: js.UndefOr[left | right | (`left corner`) | (`right corner`)] = js.native
+    var labelPosition: js.UndefOr[left | right | (`left corner`) | (`right corner`)] = js.undefined
     
     /** An Icon Input field can show that it is currently loading data. */
-    var loading: js.UndefOr[Boolean] = js.native
+    var loading: js.UndefOr[Boolean] = js.undefined
     
     /**
       * Called on change.
@@ -121,18 +119,18 @@ object inputInputMod {
     @JSName("onChange")
     var onChange_StrictInputProps: js.UndefOr[
         js.Function2[/* event */ ChangeEvent[HTMLInputElement], /* data */ InputOnChangeData, Unit]
-      ] = js.native
+      ] = js.undefined
     
     /** An Input can vary in size. */
     @JSName("size")
-    var size_StrictInputProps: js.UndefOr[mini | small | large | big | huge | massive] = js.native
+    var size_StrictInputProps: js.UndefOr[mini | small | large | big | huge | massive] = js.undefined
     
     /** An Input can receive focus. */
     @JSName("tabIndex")
-    var tabIndex_StrictInputProps: js.UndefOr[Double | String] = js.native
+    var tabIndex_StrictInputProps: js.UndefOr[Double | String] = js.undefined
     
     /** Transparent Input has no background. */
-    var transparent: js.UndefOr[Boolean] = js.native
+    var transparent: js.UndefOr[Boolean] = js.undefined
   }
   object StrictInputProps {
     

--- a/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/testContainerTestContainerMod.scala
+++ b/tests/react-integration-test/check-slinky/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/testContainerTestContainerMod.scala
@@ -16,53 +16,52 @@ object testContainerTestContainerMod extends Shortcut {
   @js.native
   val default: ReactComponentClass[TestContainerProps] = js.native
   
-  @js.native
   trait StrictTestContainerProps extends StObject {
     
     /** An element type to render as (string or function). */
-    var as: js.UndefOr[js.Any] = js.native
+    var as: js.UndefOr[js.Any] = js.undefined
     
     /** Primary content. */
-    var children: js.UndefOr[ReactElement] = js.native
+    var children: js.UndefOr[ReactElement] = js.undefined
     
     /** Additional classes. */
-    var className: js.UndefOr[String] = js.native
+    var className: js.UndefOr[String] = js.undefined
     
     /** Shorthand for primary content. */
-    var content: js.UndefOr[SemanticShorthandContent] = js.native
+    var content: js.UndefOr[SemanticShorthandContent] = js.undefined
     
     /** TestContainer has no maximum width. */
-    var fluid: js.UndefOr[Boolean] = js.native
+    var fluid: js.UndefOr[Boolean] = js.undefined
     
     /**Should be CallbackTo[Number]*/
-    var optFn0Number: js.UndefOr[js.Function0[Double]] = js.native
+    var optFn0Number: js.UndefOr[js.Function0[Double]] = js.undefined
     
     /**Should be Callback*/
-    var optFn0Void: js.UndefOr[js.Function0[Unit]] = js.native
+    var optFn0Void: js.UndefOr[js.Function0[Unit]] = js.undefined
     
     /**Should be (x:Number) => CallbackTo[Number]*/
-    var optFn1Number: js.UndefOr[js.Function1[/* x */ Double, Double]] = js.native
+    var optFn1Number: js.UndefOr[js.Function1[/* x */ Double, Double]] = js.undefined
     
     /**Should be (x:Number) => Callback*/
-    var optFn1Void: js.UndefOr[js.Function1[/* x */ Double, Unit]] = js.native
+    var optFn1Void: js.UndefOr[js.Function1[/* x */ Double, Unit]] = js.undefined
     
     /**Should be CallbackTo[Number]*/
-    def requiredFn0Number(): Double = js.native
+    def requiredFn0Number(): Double
     
     /**Should be Callback*/
-    def requiredFn0Void(): Unit = js.native
+    def requiredFn0Void(): Unit
     
     /**Should be (x:Number) => CallbackTo[Number]*/
-    def requiredFn1Number(x: Double): Double = js.native
+    def requiredFn1Number(x: Double): Double
     
     /**Should be (x:Number) => Callback*/
-    def requiredFn1Void(x: Double): Unit = js.native
+    def requiredFn1Void(x: Double): Unit
     
     /** Reduce maximum width to more naturally accommodate text. */
-    var text: js.UndefOr[Boolean] = js.native
+    var text: js.UndefOr[Boolean] = js.undefined
     
     /** Describes how the text inside this component should be aligned. */
-    var textAlign: js.UndefOr[SemanticTEXTALIGNMENTS] = js.native
+    var textAlign: js.UndefOr[SemanticTEXTALIGNMENTS] = js.undefined
   }
   object StrictTestContainerProps {
     
@@ -160,7 +159,6 @@ object testContainerTestContainerMod extends Shortcut {
     }
   }
   
-  @js.native
   trait TestContainerProps
     extends StObject
        with StrictTestContainerProps

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-b50a3c"
+version := "0.38.0-cf7fd0"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-93664c",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ee2ca2",
+  "org.scalablytyped" %%% "react" % "16.9.2-7784a5",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-66db32",
   ("me.shadaj" %%% "slinky-web" % "0.6.7").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/src/main/scala/typingsSlinky/stardustUiReactComponentEventListener/anon.scala
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/src/main/scala/typingsSlinky/stardustUiReactComponentEventListener/anon.scala
@@ -6,16 +6,15 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Capture extends StObject {
     
-    var capture: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Requireable<boolean> */ js.Any = js.native
+    var capture: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Requireable<boolean> */ js.Any
     
-    var listener: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<(args : ...any): any> */ js.Any = js.native
+    var listener: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<(args : ...any): any> */ js.Any
     
-    var targetRef: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<imported_react.RefObject<Node | Window>> */ js.Any = js.native
+    var targetRef: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<imported_react.RefObject<Node | Window>> */ js.Any
     
-    var `type`: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<'waiting' | 'error' | 'abort' | 'cancel' | 'progress' | 'ended' | 'change' | 'input' | 'select' | 'fullscreenchange' | 'fullscreenerror' | 'readystatechange' | 'visibilitychange' | 'animationcancel' | 'animationend' | 'animationiteration' | 'animationstart' | 'auxclick' | 'blur' | 'canplay' | 'canplaythrough' | 'click' | 'close' | 'contextmenu' | 'cuechange' | 'dblclick' | 'drag' | 'dragend' | 'dragenter' | 'dragexit' | 'dragleave' | 'dragover' | 'dragstart' | 'drop' | 'durationchange' | 'emptied' | 'focus' | 'gotpointercapture' | 'invalid' | 'keydown' | 'keypress' | 'keyup' | 'load' | 'loadeddata' | 'loadedmetadata' | 'loadend' | 'loadstart' | 'lostpointercapture' | 'mousedown' | 'mouseenter' | 'mouseleave' | 'mousemove' | 'mouseout' | 'mouseover' | 'mouseup' | 'pause' | 'play' | 'playing' | 'pointercancel' | 'pointerdown' | 'pointerenter' | 'pointerleave' | 'pointermove' | 'pointerout' | 'pointerover' | 'pointerup' | 'ratechange' | 'reset' | 'resize' | 'scroll' | 'securitypolicyviolation' | 'seeked' | 'seeking' | 'stalled' | 'submit' | 'suspend' | 'timeupdate' | 'toggle' | 'touchcancel' | 'touchend' | 'touchmove' | 'touchstart' | 'transitioncancel' | 'transitionend' | 'transitionrun' | 'transitionstart' | 'volumechange' | 'wheel' | 'copy' | 'cut' | 'paste'> */ js.Any = js.native
+    var `type`: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<'waiting' | 'error' | 'abort' | 'cancel' | 'progress' | 'ended' | 'change' | 'input' | 'select' | 'fullscreenchange' | 'fullscreenerror' | 'readystatechange' | 'visibilitychange' | 'animationcancel' | 'animationend' | 'animationiteration' | 'animationstart' | 'auxclick' | 'blur' | 'canplay' | 'canplaythrough' | 'click' | 'close' | 'contextmenu' | 'cuechange' | 'dblclick' | 'drag' | 'dragend' | 'dragenter' | 'dragexit' | 'dragleave' | 'dragover' | 'dragstart' | 'drop' | 'durationchange' | 'emptied' | 'focus' | 'gotpointercapture' | 'invalid' | 'keydown' | 'keypress' | 'keyup' | 'load' | 'loadeddata' | 'loadedmetadata' | 'loadend' | 'loadstart' | 'lostpointercapture' | 'mousedown' | 'mouseenter' | 'mouseleave' | 'mousemove' | 'mouseout' | 'mouseover' | 'mouseup' | 'pause' | 'play' | 'playing' | 'pointercancel' | 'pointerdown' | 'pointerenter' | 'pointerleave' | 'pointermove' | 'pointerout' | 'pointerover' | 'pointerup' | 'ratechange' | 'reset' | 'resize' | 'scroll' | 'securitypolicyviolation' | 'seeked' | 'seeking' | 'stalled' | 'submit' | 'suspend' | 'timeupdate' | 'toggle' | 'touchcancel' | 'touchend' | 'touchmove' | 'touchstart' | 'transitioncancel' | 'transitionend' | 'transitionrun' | 'transitionstart' | 'volumechange' | 'wheel' | 'copy' | 'cut' | 'paste'> */ js.Any
   }
   object Capture {
     
@@ -56,16 +55,15 @@ object anon {
     }
   }
   
-  @js.native
   trait Listener extends StObject {
     
-    var capture: Unit = js.native
+    var capture: Unit
     
-    var listener: Unit = js.native
+    var listener: Unit
     
-    var targetRef: Unit = js.native
+    var targetRef: Unit
     
-    var `type`: Unit = js.native
+    var `type`: Unit
   }
   object Listener {
     

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/src/main/scala/typingsSlinky/stardustUiReactComponentEventListener/typesMod.scala
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-event-listener/src/main/scala/typingsSlinky/stardustUiReactComponentEventListener/typesMod.scala
@@ -12,22 +12,21 @@ object typesMod {
     Unit
   ]
   
-  @js.native
   trait EventListenerOptions[T /* <: EventTypes */] extends StObject {
     
     /** Indicating that events of this type will be dispatched to the registered listener before being dispatched to any EventTarget beneath it in the DOM tree. */
-    var capture: js.UndefOr[Boolean] = js.native
+    var capture: js.UndefOr[Boolean] = js.undefined
     
     /** A function which receives a notification when an event of the specified type occurs. */
-    var listener: EventHandler[T] = js.native
+    var listener: EventHandler[T]
     
     /** A ref object with a target node. */
     var targetRef: ReactRef[
         /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify Node */ js.Any
-      ] = js.native
+      ]
     
     /** A case-sensitive string representing the event type to listen for. */
-    var `type`: T = js.native
+    var `type`: T
   }
   object EventListenerOptions {
     

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-3ff800"
+version := "0.38.0-eb98a6"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-93664c",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-ee2ca2",
+  "org.scalablytyped" %%% "react" % "16.9.2-7784a5",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-66db32",
   ("me.shadaj" %%% "slinky-web" % "0.6.7").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/src/main/scala/typingsSlinky/stardustUiReactComponentRef/anon.scala
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/src/main/scala/typingsSlinky/stardustUiReactComponentRef/anon.scala
@@ -6,12 +6,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Children extends StObject {
     
-    var children: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<PropTypes.ReactElementLike> */ js.Any = js.native
+    var children: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<PropTypes.ReactElementLike> */ js.Any
     
-    var innerRef: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<React.Ref<any>> */ js.Any = js.native
+    var innerRef: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Validator<React.Ref<any>> */ js.Any
   }
   object Children {
     
@@ -39,12 +38,11 @@ object anon {
     }
   }
   
-  @js.native
   trait InnerRef extends StObject {
     
-    var children: Unit = js.native
+    var children: Unit
     
-    var innerRef: Unit = js.native
+    var innerRef: Unit
   }
   object InnerRef {
     

--- a/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/src/main/scala/typingsSlinky/stardustUiReactComponentRef/typesMod.scala
+++ b/tests/react-integration-test/check-slinky/s/stardust-ui__react-component-ref/src/main/scala/typingsSlinky/stardustUiReactComponentRef/typesMod.scala
@@ -13,17 +13,16 @@ object typesMod {
   @js.native
   val refPropType: /* import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify PropTypes.Requireable<React.Ref<any>> */ js.Any = js.native
   
-  @js.native
   trait RefProps extends StObject {
     
-    var children: ReactElement = js.native
+    var children: ReactElement
     
     /**
       * Called when a child component will be mounted or updated.
       *
       * @param {HTMLElement} node - Referred node.
       */
-    var innerRef: Ref[js.Any] = js.native
+    var innerRef: Ref[js.Any]
   }
   object RefProps {
     

--- a/tests/react-integration-test/check-slinky/s/std/build.sbt
+++ b/tests/react-integration-test/check-slinky/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-ee2ca2"
+version := "0.0-unknown-66db32"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/Array.scala
+++ b/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/DataTransfer.scala
+++ b/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/DataTransfer.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait DataTransfer extends StObject

--- a/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/Document.scala
+++ b/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/Document.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Document extends StObject

--- a/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/Element.scala
+++ b/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/Element.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Element extends StObject

--- a/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/Event.scala
+++ b/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/Event.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Event extends StObject

--- a/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/EventTarget.scala
+++ b/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/EventTarget.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait EventTarget extends StObject

--- a/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/HTMLElementTagNameMap.scala
+++ b/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/HTMLElementTagNameMap.scala
@@ -4,216 +4,215 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HTMLElementTagNameMap extends StObject {
   
-  var a: org.scalajs.dom.raw.HTMLAnchorElement = js.native
+  var a: org.scalajs.dom.raw.HTMLAnchorElement
   
-  var abbr: org.scalajs.dom.raw.HTMLElement = js.native
+  var abbr: org.scalajs.dom.raw.HTMLElement
   
-  var address: org.scalajs.dom.raw.HTMLElement = js.native
+  var address: org.scalajs.dom.raw.HTMLElement
   
-  var area: org.scalajs.dom.raw.HTMLAreaElement = js.native
+  var area: org.scalajs.dom.raw.HTMLAreaElement
   
-  var article: org.scalajs.dom.raw.HTMLElement = js.native
+  var article: org.scalajs.dom.raw.HTMLElement
   
-  var aside: org.scalajs.dom.raw.HTMLElement = js.native
+  var aside: org.scalajs.dom.raw.HTMLElement
   
-  var audio: org.scalajs.dom.raw.HTMLAudioElement = js.native
+  var audio: org.scalajs.dom.raw.HTMLAudioElement
   
-  var b: org.scalajs.dom.raw.HTMLElement = js.native
+  var b: org.scalajs.dom.raw.HTMLElement
   
-  var base: org.scalajs.dom.raw.HTMLBaseElement = js.native
+  var base: org.scalajs.dom.raw.HTMLBaseElement
   
-  var bdi: org.scalajs.dom.raw.HTMLElement = js.native
+  var bdi: org.scalajs.dom.raw.HTMLElement
   
-  var bdo: org.scalajs.dom.raw.HTMLElement = js.native
+  var bdo: org.scalajs.dom.raw.HTMLElement
   
-  var blockquote: org.scalajs.dom.raw.HTMLQuoteElement = js.native
+  var blockquote: org.scalajs.dom.raw.HTMLQuoteElement
   
-  var body: org.scalajs.dom.raw.HTMLBodyElement = js.native
+  var body: org.scalajs.dom.raw.HTMLBodyElement
   
-  var br: org.scalajs.dom.raw.HTMLBRElement = js.native
+  var br: org.scalajs.dom.raw.HTMLBRElement
   
-  var button: org.scalajs.dom.raw.HTMLButtonElement = js.native
+  var button: org.scalajs.dom.raw.HTMLButtonElement
   
-  var canvas: org.scalajs.dom.raw.HTMLCanvasElement = js.native
+  var canvas: org.scalajs.dom.raw.HTMLCanvasElement
   
-  var cite: org.scalajs.dom.raw.HTMLElement = js.native
+  var cite: org.scalajs.dom.raw.HTMLElement
   
-  var code: org.scalajs.dom.raw.HTMLElement = js.native
+  var code: org.scalajs.dom.raw.HTMLElement
   
-  var col: org.scalajs.dom.raw.HTMLTableColElement = js.native
+  var col: org.scalajs.dom.raw.HTMLTableColElement
   
-  var colgroup: org.scalajs.dom.raw.HTMLTableColElement = js.native
+  var colgroup: org.scalajs.dom.raw.HTMLTableColElement
   
-  var data: org.scalajs.dom.raw.Element = js.native
+  var data: org.scalajs.dom.raw.Element
   
-  var datalist: org.scalajs.dom.raw.HTMLDataListElement = js.native
+  var datalist: org.scalajs.dom.raw.HTMLDataListElement
   
-  var dd: org.scalajs.dom.raw.HTMLElement = js.native
+  var dd: org.scalajs.dom.raw.HTMLElement
   
-  var del: org.scalajs.dom.raw.HTMLModElement = js.native
+  var del: org.scalajs.dom.raw.HTMLModElement
   
-  var dfn: org.scalajs.dom.raw.HTMLElement = js.native
+  var dfn: org.scalajs.dom.raw.HTMLElement
   
-  var dialog: org.scalajs.dom.raw.Element = js.native
+  var dialog: org.scalajs.dom.raw.Element
   
-  var div: org.scalajs.dom.raw.HTMLDivElement = js.native
+  var div: org.scalajs.dom.raw.HTMLDivElement
   
-  var dl: org.scalajs.dom.raw.HTMLDListElement = js.native
+  var dl: org.scalajs.dom.raw.HTMLDListElement
   
-  var dt: org.scalajs.dom.raw.HTMLElement = js.native
+  var dt: org.scalajs.dom.raw.HTMLElement
   
-  var em: org.scalajs.dom.raw.HTMLElement = js.native
+  var em: org.scalajs.dom.raw.HTMLElement
   
-  var embed: org.scalajs.dom.raw.HTMLEmbedElement = js.native
+  var embed: org.scalajs.dom.raw.HTMLEmbedElement
   
-  var fieldset: org.scalajs.dom.raw.HTMLFieldSetElement = js.native
+  var fieldset: org.scalajs.dom.raw.HTMLFieldSetElement
   
-  var figcaption: org.scalajs.dom.raw.HTMLElement = js.native
+  var figcaption: org.scalajs.dom.raw.HTMLElement
   
-  var figure: org.scalajs.dom.raw.HTMLElement = js.native
+  var figure: org.scalajs.dom.raw.HTMLElement
   
-  var footer: org.scalajs.dom.raw.HTMLElement = js.native
+  var footer: org.scalajs.dom.raw.HTMLElement
   
-  var form: org.scalajs.dom.raw.HTMLFormElement = js.native
+  var form: org.scalajs.dom.raw.HTMLFormElement
   
-  var h1: org.scalajs.dom.raw.HTMLHeadingElement = js.native
+  var h1: org.scalajs.dom.raw.HTMLHeadingElement
   
-  var h2: org.scalajs.dom.raw.HTMLHeadingElement = js.native
+  var h2: org.scalajs.dom.raw.HTMLHeadingElement
   
-  var h3: org.scalajs.dom.raw.HTMLHeadingElement = js.native
+  var h3: org.scalajs.dom.raw.HTMLHeadingElement
   
-  var h4: org.scalajs.dom.raw.HTMLHeadingElement = js.native
+  var h4: org.scalajs.dom.raw.HTMLHeadingElement
   
-  var h5: org.scalajs.dom.raw.HTMLHeadingElement = js.native
+  var h5: org.scalajs.dom.raw.HTMLHeadingElement
   
-  var h6: org.scalajs.dom.raw.HTMLHeadingElement = js.native
+  var h6: org.scalajs.dom.raw.HTMLHeadingElement
   
-  var head: org.scalajs.dom.raw.HTMLHeadElement = js.native
+  var head: org.scalajs.dom.raw.HTMLHeadElement
   
-  var header: org.scalajs.dom.raw.HTMLElement = js.native
+  var header: org.scalajs.dom.raw.HTMLElement
   
-  var hgroup: org.scalajs.dom.raw.HTMLElement = js.native
+  var hgroup: org.scalajs.dom.raw.HTMLElement
   
-  var hr: org.scalajs.dom.raw.HTMLHRElement = js.native
+  var hr: org.scalajs.dom.raw.HTMLHRElement
   
-  var html: org.scalajs.dom.raw.HTMLHtmlElement = js.native
+  var html: org.scalajs.dom.raw.HTMLHtmlElement
   
-  var i: org.scalajs.dom.raw.HTMLElement = js.native
+  var i: org.scalajs.dom.raw.HTMLElement
   
-  var iframe: org.scalajs.dom.raw.HTMLIFrameElement = js.native
+  var iframe: org.scalajs.dom.raw.HTMLIFrameElement
   
-  var img: org.scalajs.dom.raw.HTMLImageElement = js.native
+  var img: org.scalajs.dom.raw.HTMLImageElement
   
-  var input: org.scalajs.dom.raw.HTMLInputElement = js.native
+  var input: org.scalajs.dom.raw.HTMLInputElement
   
-  var ins: org.scalajs.dom.raw.HTMLModElement = js.native
+  var ins: org.scalajs.dom.raw.HTMLModElement
   
-  var kbd: org.scalajs.dom.raw.HTMLElement = js.native
+  var kbd: org.scalajs.dom.raw.HTMLElement
   
-  var label: org.scalajs.dom.raw.HTMLLabelElement = js.native
+  var label: org.scalajs.dom.raw.HTMLLabelElement
   
-  var legend: org.scalajs.dom.raw.HTMLLegendElement = js.native
+  var legend: org.scalajs.dom.raw.HTMLLegendElement
   
-  var li: org.scalajs.dom.raw.HTMLLIElement = js.native
+  var li: org.scalajs.dom.raw.HTMLLIElement
   
-  var link: org.scalajs.dom.raw.HTMLLinkElement = js.native
+  var link: org.scalajs.dom.raw.HTMLLinkElement
   
-  var main: org.scalajs.dom.raw.HTMLElement = js.native
+  var main: org.scalajs.dom.raw.HTMLElement
   
-  var map: org.scalajs.dom.raw.HTMLMapElement = js.native
+  var map: org.scalajs.dom.raw.HTMLMapElement
   
-  var mark: org.scalajs.dom.raw.HTMLElement = js.native
+  var mark: org.scalajs.dom.raw.HTMLElement
   
-  var meta: org.scalajs.dom.raw.HTMLMetaElement = js.native
+  var meta: org.scalajs.dom.raw.HTMLMetaElement
   
-  var nav: org.scalajs.dom.raw.HTMLElement = js.native
+  var nav: org.scalajs.dom.raw.HTMLElement
   
-  var noscript: org.scalajs.dom.raw.HTMLElement = js.native
+  var noscript: org.scalajs.dom.raw.HTMLElement
   
-  var `object`: org.scalajs.dom.raw.HTMLObjectElement = js.native
+  var `object`: org.scalajs.dom.raw.HTMLObjectElement
   
-  var ol: org.scalajs.dom.raw.HTMLOListElement = js.native
+  var ol: org.scalajs.dom.raw.HTMLOListElement
   
-  var optgroup: org.scalajs.dom.raw.HTMLOptGroupElement = js.native
+  var optgroup: org.scalajs.dom.raw.HTMLOptGroupElement
   
-  var option: org.scalajs.dom.raw.HTMLOptionElement = js.native
+  var option: org.scalajs.dom.raw.HTMLOptionElement
   
-  var p: org.scalajs.dom.raw.HTMLParagraphElement = js.native
+  var p: org.scalajs.dom.raw.HTMLParagraphElement
   
-  var param: org.scalajs.dom.raw.HTMLParamElement = js.native
+  var param: org.scalajs.dom.raw.HTMLParamElement
   
-  var pre: org.scalajs.dom.raw.HTMLPreElement = js.native
+  var pre: org.scalajs.dom.raw.HTMLPreElement
   
-  var progress: org.scalajs.dom.raw.HTMLProgressElement = js.native
+  var progress: org.scalajs.dom.raw.HTMLProgressElement
   
-  var q: org.scalajs.dom.raw.HTMLQuoteElement = js.native
+  var q: org.scalajs.dom.raw.HTMLQuoteElement
   
-  var rp: org.scalajs.dom.raw.HTMLElement = js.native
+  var rp: org.scalajs.dom.raw.HTMLElement
   
-  var rt: org.scalajs.dom.raw.HTMLElement = js.native
+  var rt: org.scalajs.dom.raw.HTMLElement
   
-  var ruby: org.scalajs.dom.raw.HTMLElement = js.native
+  var ruby: org.scalajs.dom.raw.HTMLElement
   
-  var s: org.scalajs.dom.raw.HTMLElement = js.native
+  var s: org.scalajs.dom.raw.HTMLElement
   
-  var samp: org.scalajs.dom.raw.HTMLElement = js.native
+  var samp: org.scalajs.dom.raw.HTMLElement
   
-  var script: org.scalajs.dom.raw.HTMLScriptElement = js.native
+  var script: org.scalajs.dom.raw.HTMLScriptElement
   
-  var section: org.scalajs.dom.raw.HTMLElement = js.native
+  var section: org.scalajs.dom.raw.HTMLElement
   
-  var select: org.scalajs.dom.raw.HTMLSelectElement = js.native
+  var select: org.scalajs.dom.raw.HTMLSelectElement
   
-  var small: org.scalajs.dom.raw.HTMLElement = js.native
+  var small: org.scalajs.dom.raw.HTMLElement
   
-  var source: org.scalajs.dom.raw.HTMLSourceElement = js.native
+  var source: org.scalajs.dom.raw.HTMLSourceElement
   
-  var span: org.scalajs.dom.raw.HTMLSpanElement = js.native
+  var span: org.scalajs.dom.raw.HTMLSpanElement
   
-  var strong: org.scalajs.dom.raw.HTMLElement = js.native
+  var strong: org.scalajs.dom.raw.HTMLElement
   
-  var style: org.scalajs.dom.raw.HTMLStyleElement = js.native
+  var style: org.scalajs.dom.raw.HTMLStyleElement
   
-  var sub: org.scalajs.dom.raw.HTMLElement = js.native
+  var sub: org.scalajs.dom.raw.HTMLElement
   
-  var summary: org.scalajs.dom.raw.HTMLElement = js.native
+  var summary: org.scalajs.dom.raw.HTMLElement
   
-  var sup: org.scalajs.dom.raw.HTMLElement = js.native
+  var sup: org.scalajs.dom.raw.HTMLElement
   
-  var table: org.scalajs.dom.raw.HTMLTableElement = js.native
+  var table: org.scalajs.dom.raw.HTMLTableElement
   
-  var tbody: org.scalajs.dom.raw.HTMLTableSectionElement = js.native
+  var tbody: org.scalajs.dom.raw.HTMLTableSectionElement
   
-  var td: org.scalajs.dom.raw.Element = js.native
+  var td: org.scalajs.dom.raw.Element
   
-  var template: org.scalajs.dom.raw.Element = js.native
+  var template: org.scalajs.dom.raw.Element
   
-  var textarea: org.scalajs.dom.raw.HTMLTextAreaElement = js.native
+  var textarea: org.scalajs.dom.raw.HTMLTextAreaElement
   
-  var tfoot: org.scalajs.dom.raw.HTMLTableSectionElement = js.native
+  var tfoot: org.scalajs.dom.raw.HTMLTableSectionElement
   
-  var th: org.scalajs.dom.raw.Element = js.native
+  var th: org.scalajs.dom.raw.Element
   
-  var thead: org.scalajs.dom.raw.HTMLTableSectionElement = js.native
+  var thead: org.scalajs.dom.raw.HTMLTableSectionElement
   
-  var title: org.scalajs.dom.raw.HTMLTitleElement = js.native
+  var title: org.scalajs.dom.raw.HTMLTitleElement
   
-  var tr: org.scalajs.dom.raw.HTMLTableRowElement = js.native
+  var tr: org.scalajs.dom.raw.HTMLTableRowElement
   
-  var track: org.scalajs.dom.raw.HTMLTrackElement = js.native
+  var track: org.scalajs.dom.raw.HTMLTrackElement
   
-  var u: org.scalajs.dom.raw.HTMLElement = js.native
+  var u: org.scalajs.dom.raw.HTMLElement
   
-  var ul: org.scalajs.dom.raw.HTMLUListElement = js.native
+  var ul: org.scalajs.dom.raw.HTMLUListElement
   
-  var `var`: org.scalajs.dom.raw.HTMLElement = js.native
+  var `var`: org.scalajs.dom.raw.HTMLElement
   
-  var video: org.scalajs.dom.raw.HTMLVideoElement = js.native
+  var video: org.scalajs.dom.raw.HTMLVideoElement
   
-  var wbr: org.scalajs.dom.raw.HTMLElement = js.native
+  var wbr: org.scalajs.dom.raw.HTMLElement
 }
 object HTMLElementTagNameMap {
   

--- a/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/SVGElementTagNameMap.scala
+++ b/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/SVGElementTagNameMap.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SVGElementTagNameMap extends StObject {
   
-  var circle: org.scalajs.dom.raw.SVGCircleElement = js.native
+  var circle: org.scalajs.dom.raw.SVGCircleElement
   
-  var clipPath: org.scalajs.dom.raw.SVGClipPathElement = js.native
+  var clipPath: org.scalajs.dom.raw.SVGClipPathElement
   
-  var defs: org.scalajs.dom.raw.SVGDefsElement = js.native
+  var defs: org.scalajs.dom.raw.SVGDefsElement
 }
 object SVGElementTagNameMap {
   

--- a/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/StyleMedia.scala
+++ b/tests/react-integration-test/check-slinky/s/std/src/main/scala/typingsSlinky/std/StyleMedia.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait StyleMedia extends StObject

--- a/tests/react-transition-group/check-japgolly/r/react-transition-group/build.sbt
+++ b/tests/react-transition-group/check-japgolly/r/react-transition-group/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-transition-group"
-version := "2.0-c06564"
+version := "2.0-ba8951"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-a96c72",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-d868fd",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-35cc8b",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d1536c",
   ("com.github.japgolly.scalajs-react" %%% "core" % "1.7.5").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-transition-group/check-japgolly/r/react-transition-group/src/main/scala/typingsJapgolly/reactTransitionGroup/anon.scala
+++ b/tests/react-transition-group/check-japgolly/r/react-transition-group/src/main/scala/typingsJapgolly/reactTransitionGroup/anon.scala
@@ -7,10 +7,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait ChildFactory extends StObject {
     
-    var childFactory: js.UndefOr[js.Function1[/* child */ Element, Element]] = js.native
+    var childFactory: js.UndefOr[js.Function1[/* child */ Element, Element]] = js.undefined
   }
   object ChildFactory {
     

--- a/tests/react-transition-group/check-japgolly/r/react-transition-group/src/main/scala/typingsJapgolly/reactTransitionGroup/transitionGroupMod.scala
+++ b/tests/react-transition-group/check-japgolly/r/react-transition-group/src/main/scala/typingsJapgolly/reactTransitionGroup/transitionGroupMod.scala
@@ -17,10 +17,9 @@ object transitionGroupMod {
     extends StObject
        with Component[TransitionGroupProps[abbr, js.Any], js.Object]
   
-  @js.native
   trait ComponentTransitionGroupProps[T /* <: ReactType[js.Any] */] extends StObject {
     
-    var component: T = js.native
+    var component: T
   }
   object ComponentTransitionGroupProps {
     
@@ -31,10 +30,9 @@ object transitionGroupMod {
     }
   }
   
-  @js.native
   trait IntrinsicTransitionGroupProps[T /* <: abbr | animate */] extends StObject {
     
-    var component: js.UndefOr[T] = js.native
+    var component: js.UndefOr[T] = js.undefined
   }
   object IntrinsicTransitionGroupProps {
     

--- a/tests/react-transition-group/check-japgolly/r/react/build.sbt
+++ b/tests/react-transition-group/check-japgolly/r/react/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-a96c72"
+version := "0.0-unknown-35cc8b"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-d868fd",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d1536c",
   ("com.github.japgolly.scalajs-react" %%% "core" % "1.7.5").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-transition-group/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/anon.scala
+++ b/tests/react-transition-group/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/anon.scala
@@ -8,10 +8,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Children extends StObject {
     
-    var children: js.UndefOr[Node] = js.native
+    var children: js.UndefOr[Node] = js.undefined
   }
   object Children {
     
@@ -23,10 +22,9 @@ object anon {
     }
   }
   
-  @js.native
   trait Html extends StObject {
     
-    var __html: String = js.native
+    var __html: String
   }
   object Html {
     

--- a/tests/react-transition-group/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod.scala
+++ b/tests/react-transition-group/check-japgolly/r/react/src/main/scala/typingsJapgolly/react/mod.scala
@@ -19,14 +19,13 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
-  @js.native
   trait AllHTMLAttributes[T]
     extends StObject
        with HTMLAttributes[T] {
     
-    var accept: js.UndefOr[String] = js.native
+    var accept: js.UndefOr[String] = js.undefined
     
-    var acceptCharset: js.UndefOr[String] = js.native
+    var acceptCharset: js.UndefOr[String] = js.undefined
   }
   object AllHTMLAttributes {
     
@@ -54,10 +53,9 @@ object mod {
   // interface AnimationEvent<T> extends SyntheticEvent<T> {
   //     nativeEvent: NativeAnimationEvent;
   // }
-  @js.native
   trait Attributes extends StObject {
     
-    var key: js.UndefOr[Key] = js.native
+    var key: js.UndefOr[Key] = js.undefined
   }
   object Attributes {
     
@@ -69,12 +67,11 @@ object mod {
     }
   }
   
-  @js.native
   trait ClassAttributes[T]
     extends StObject
        with Attributes {
     
-    var ref: js.UndefOr[Ref[T]] = js.native
+    var ref: js.UndefOr[Ref[T]] = js.undefined
   }
   object ClassAttributes {
     
@@ -87,7 +84,6 @@ object mod {
     }
   }
   
-  @js.native
   trait Component[P, S] extends StObject
   
   @js.native
@@ -112,12 +108,11 @@ object mod {
   
   type ComponentType[P] = (ComponentClassP[P & js.Object]) | StatelessComponent[P]
   
-  @js.native
   trait DOMAttributes[T] extends StObject {
     
-    var children: js.UndefOr[Node] = js.native
+    var children: js.UndefOr[Node] = js.undefined
     
-    var dangerouslySetInnerHTML: js.UndefOr[Html] = js.native
+    var dangerouslySetInnerHTML: js.UndefOr[Html] = js.undefined
   }
   object DOMAttributes {
     
@@ -132,12 +127,11 @@ object mod {
   
   type DetailedHTMLProps[E /* <: HTMLAttributes[T] */, T] = ClassAttributes[T] & E
   
-  @js.native
   trait HTMLAttributes[T]
     extends StObject
        with DOMAttributes[T] {
     
-    var defaultChecked: js.UndefOr[Boolean] = js.native
+    var defaultChecked: js.UndefOr[Boolean] = js.undefined
   }
   object HTMLAttributes {
     
@@ -155,7 +149,6 @@ object mod {
     }
   }
   
-  @js.native
   trait HTMLProps[T]
     extends StObject
        with AllHTMLAttributes[T]
@@ -188,14 +181,13 @@ object mod {
   
   type NativeAnimationEvent = AnimationEvent
   
-  @js.native
   trait ReactElement extends StObject {
     
-    var key: Key | Null = js.native
+    var key: Key | Null
     
-    var props: js.Any = js.native
+    var props: js.Any
     
-    var `type`: String | (ComponentClassP[js.Any & js.Object]) | SFC[js.Any] = js.native
+    var `type`: String | (ComponentClassP[js.Any & js.Object]) | SFC[js.Any]
   }
   object ReactElement {
     
@@ -242,18 +234,15 @@ object mod {
       // tslint:disable-next-line:no-empty-interface
       type Element = japgolly.scalajs.react.raw.React.Element
       
-      @js.native
       trait ElementAttributesProperty extends StObject
       
-      @js.native
       trait ElementChildrenAttribute extends StObject
       
-      @js.native
       trait ElementClass
         extends StObject
            with Component[js.Any, js.Object] {
         
-        def render(): Node = js.native
+        def render(): Node
       }
       object ElementClass {
         
@@ -270,13 +259,12 @@ object mod {
       // tslint:disable-next-line:no-empty-interface
       type IntrinsicClassAttributes[T] = ClassAttributes[T]
       
-      @js.native
       trait IntrinsicElements extends StObject {
         
         // HTML
-        var abbr: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+        var abbr: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
         
-        var animate: SVGProps[SVGElement] = js.native
+        var animate: SVGProps[SVGElement]
       }
       object IntrinsicElements {
         

--- a/tests/react-transition-group/check-japgolly/s/std/build.sbt
+++ b/tests/react-transition-group/check-japgolly/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-d868fd"
+version := "0.0-unknown-d1536c"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-transition-group/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Array.scala
+++ b/tests/react-transition-group/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/react-transition-group/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Element.scala
+++ b/tests/react-transition-group/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Element.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Element extends StObject

--- a/tests/react-transition-group/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Event.scala
+++ b/tests/react-transition-group/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/Event.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Event extends StObject

--- a/tests/react-transition-group/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/EventTarget.scala
+++ b/tests/react-transition-group/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/EventTarget.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait EventTarget extends StObject

--- a/tests/react-transition-group/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/HTMLElementTagNameMap.scala
+++ b/tests/react-transition-group/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/HTMLElementTagNameMap.scala
@@ -4,22 +4,21 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HTMLElementTagNameMap extends StObject {
   
-  var a: org.scalajs.dom.raw.HTMLAnchorElement = js.native
+  var a: org.scalajs.dom.raw.HTMLAnchorElement
   
-  var abbr: org.scalajs.dom.raw.HTMLElement = js.native
+  var abbr: org.scalajs.dom.raw.HTMLElement
   
-  var address: org.scalajs.dom.raw.HTMLElement = js.native
+  var address: org.scalajs.dom.raw.HTMLElement
   
-  var area: org.scalajs.dom.raw.HTMLAreaElement = js.native
+  var area: org.scalajs.dom.raw.HTMLAreaElement
   
-  var article: org.scalajs.dom.raw.HTMLElement = js.native
+  var article: org.scalajs.dom.raw.HTMLElement
   
-  var aside: org.scalajs.dom.raw.HTMLElement = js.native
+  var aside: org.scalajs.dom.raw.HTMLElement
   
-  var audio: org.scalajs.dom.raw.HTMLAudioElement = js.native
+  var audio: org.scalajs.dom.raw.HTMLAudioElement
 }
 object HTMLElementTagNameMap {
   

--- a/tests/react-transition-group/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/SVGElementTagNameMap.scala
+++ b/tests/react-transition-group/check-japgolly/s/std/src/main/scala/typingsJapgolly/std/SVGElementTagNameMap.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SVGElementTagNameMap extends StObject {
   
-  var circle: org.scalajs.dom.raw.SVGCircleElement = js.native
+  var circle: org.scalajs.dom.raw.SVGCircleElement
 }
 object SVGElementTagNameMap {
   

--- a/tests/react-transition-group/check-slinky/r/react-transition-group/build.sbt
+++ b/tests/react-transition-group/check-slinky/r/react-transition-group/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-transition-group"
-version := "2.0-93e855"
+version := "2.0-e9c3ce"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-ff66d5",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-d24ea5",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-e0ad90",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-469e1f",
   ("me.shadaj" %%% "slinky-web" % "0.6.7").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-transition-group/check-slinky/r/react-transition-group/src/main/scala/typingsSlinky/reactTransitionGroup/anon.scala
+++ b/tests/react-transition-group/check-slinky/r/react-transition-group/src/main/scala/typingsSlinky/reactTransitionGroup/anon.scala
@@ -7,10 +7,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait ChildFactory extends StObject {
     
-    var childFactory: js.UndefOr[js.Function1[/* child */ ReactElement, ReactElement]] = js.native
+    var childFactory: js.UndefOr[js.Function1[/* child */ ReactElement, ReactElement]] = js.undefined
   }
   object ChildFactory {
     

--- a/tests/react-transition-group/check-slinky/r/react-transition-group/src/main/scala/typingsSlinky/reactTransitionGroup/transitionGroupMod.scala
+++ b/tests/react-transition-group/check-slinky/r/react-transition-group/src/main/scala/typingsSlinky/reactTransitionGroup/transitionGroupMod.scala
@@ -18,10 +18,9 @@ object transitionGroupMod {
     extends StObject
        with Component[TransitionGroupProps[abbr, js.Any], js.Object]
   
-  @js.native
   trait ComponentTransitionGroupProps[T /* <: ReactType[js.Any] */] extends StObject {
     
-    var component: T = js.native
+    var component: T
   }
   object ComponentTransitionGroupProps {
     
@@ -39,10 +38,9 @@ object transitionGroupMod {
     }
   }
   
-  @js.native
   trait IntrinsicTransitionGroupProps[T /* <: abbr | animate */] extends StObject {
     
-    var component: js.UndefOr[T] = js.native
+    var component: js.UndefOr[T] = js.undefined
   }
   object IntrinsicTransitionGroupProps {
     

--- a/tests/react-transition-group/check-slinky/r/react/build.sbt
+++ b/tests/react-transition-group/check-slinky/r/react/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-ff66d5"
+version := "0.0-unknown-e0ad90"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-d24ea5",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-469e1f",
   ("me.shadaj" %%% "slinky-web" % "0.6.7").cross(CrossVersion.for3Use2_13))
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-transition-group/check-slinky/r/react/src/main/scala/typingsSlinky/react/anon.scala
+++ b/tests/react-transition-group/check-slinky/r/react/src/main/scala/typingsSlinky/react/anon.scala
@@ -7,10 +7,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Children extends StObject {
     
-    var children: js.UndefOr[ReactElement] = js.native
+    var children: js.UndefOr[ReactElement] = js.undefined
   }
   object Children {
     
@@ -31,10 +30,9 @@ object anon {
     }
   }
   
-  @js.native
   trait Html extends StObject {
     
-    var __html: String = js.native
+    var __html: String
   }
   object Html {
     

--- a/tests/react-transition-group/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod.scala
+++ b/tests/react-transition-group/check-slinky/r/react/src/main/scala/typingsSlinky/react/mod.scala
@@ -15,14 +15,13 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
-  @js.native
   trait AllHTMLAttributes[T]
     extends StObject
        with HTMLAttributes[T] {
     
-    var accept: js.UndefOr[String] = js.native
+    var accept: js.UndefOr[String] = js.undefined
     
-    var acceptCharset: js.UndefOr[String] = js.native
+    var acceptCharset: js.UndefOr[String] = js.undefined
   }
   object AllHTMLAttributes {
     
@@ -55,10 +54,9 @@ object mod {
   // interface AnimationEvent<T> extends SyntheticEvent<T> {
   //     nativeEvent: NativeAnimationEvent;
   // }
-  @js.native
   trait Attributes extends StObject {
     
-    var key: js.UndefOr[Key] = js.native
+    var key: js.UndefOr[Key] = js.undefined
   }
   object Attributes {
     
@@ -79,12 +77,11 @@ object mod {
     }
   }
   
-  @js.native
   trait ClassAttributes[T]
     extends StObject
        with Attributes {
     
-    var ref: js.UndefOr[Ref[T]] = js.native
+    var ref: js.UndefOr[Ref[T]] = js.undefined
   }
   object ClassAttributes {
     
@@ -108,7 +105,6 @@ object mod {
     }
   }
   
-  @js.native
   trait Component[P, S] extends StObject
   
   @js.native
@@ -126,12 +122,11 @@ object mod {
   
   type ComponentType[P] = ReactComponentClass[P]
   
-  @js.native
   trait DOMAttributes[T] extends StObject {
     
-    var children: js.UndefOr[slinky.core.facade.ReactElement] = js.native
+    var children: js.UndefOr[slinky.core.facade.ReactElement] = js.undefined
     
-    var dangerouslySetInnerHTML: js.UndefOr[Html] = js.native
+    var dangerouslySetInnerHTML: js.UndefOr[Html] = js.undefined
   }
   object DOMAttributes {
     
@@ -160,12 +155,11 @@ object mod {
   
   type DetailedHTMLProps[E /* <: HTMLAttributes[T] */, T] = ClassAttributes[T] & E
   
-  @js.native
   trait HTMLAttributes[T]
     extends StObject
        with DOMAttributes[T] {
     
-    var defaultChecked: js.UndefOr[Boolean] = js.native
+    var defaultChecked: js.UndefOr[Boolean] = js.undefined
   }
   object HTMLAttributes {
     
@@ -186,7 +180,6 @@ object mod {
     }
   }
   
-  @js.native
   trait HTMLProps[T]
     extends StObject
        with AllHTMLAttributes[T]
@@ -204,14 +197,13 @@ object mod {
   
   type NativeAnimationEvent = AnimationEvent
   
-  @js.native
   trait ReactElement extends StObject {
     
-    var key: Key | Null = js.native
+    var key: Key | Null
     
-    var props: js.Any = js.native
+    var props: js.Any
     
-    var `type`: String | ReactComponentClass[js.Any] = js.native
+    var `type`: String | ReactComponentClass[js.Any]
   }
   object ReactElement {
     
@@ -272,18 +264,15 @@ object mod {
       // tslint:disable-next-line:no-empty-interface
       type Element = slinky.core.facade.ReactElement
       
-      @js.native
       trait ElementAttributesProperty extends StObject
       
-      @js.native
       trait ElementChildrenAttribute extends StObject
       
-      @js.native
       trait ElementClass
         extends StObject
            with Component[js.Any, js.Object] {
         
-        def render(): slinky.core.facade.ReactElement = js.native
+        def render(): slinky.core.facade.ReactElement
       }
       object ElementClass {
         
@@ -307,13 +296,12 @@ object mod {
       // tslint:disable-next-line:no-empty-interface
       type IntrinsicClassAttributes[T] = ClassAttributes[T]
       
-      @js.native
       trait IntrinsicElements extends StObject {
         
         // HTML
-        var abbr: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement] = js.native
+        var abbr: DetailedHTMLProps[HTMLAttributes[HTMLElement], HTMLElement]
         
-        var animate: SVGProps[SVGElement] = js.native
+        var animate: SVGProps[SVGElement]
       }
       object IntrinsicElements {
         

--- a/tests/react-transition-group/check-slinky/s/std/build.sbt
+++ b/tests/react-transition-group/check-slinky/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-d24ea5"
+version := "0.0-unknown-469e1f"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-transition-group/check-slinky/s/std/src/main/scala/typingsSlinky/std/Array.scala
+++ b/tests/react-transition-group/check-slinky/s/std/src/main/scala/typingsSlinky/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/react-transition-group/check-slinky/s/std/src/main/scala/typingsSlinky/std/Element.scala
+++ b/tests/react-transition-group/check-slinky/s/std/src/main/scala/typingsSlinky/std/Element.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Element extends StObject

--- a/tests/react-transition-group/check-slinky/s/std/src/main/scala/typingsSlinky/std/Event.scala
+++ b/tests/react-transition-group/check-slinky/s/std/src/main/scala/typingsSlinky/std/Event.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Event extends StObject

--- a/tests/react-transition-group/check-slinky/s/std/src/main/scala/typingsSlinky/std/EventTarget.scala
+++ b/tests/react-transition-group/check-slinky/s/std/src/main/scala/typingsSlinky/std/EventTarget.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait EventTarget extends StObject

--- a/tests/react-transition-group/check-slinky/s/std/src/main/scala/typingsSlinky/std/HTMLElementTagNameMap.scala
+++ b/tests/react-transition-group/check-slinky/s/std/src/main/scala/typingsSlinky/std/HTMLElementTagNameMap.scala
@@ -4,22 +4,21 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HTMLElementTagNameMap extends StObject {
   
-  var a: org.scalajs.dom.raw.HTMLAnchorElement = js.native
+  var a: org.scalajs.dom.raw.HTMLAnchorElement
   
-  var abbr: org.scalajs.dom.raw.HTMLElement = js.native
+  var abbr: org.scalajs.dom.raw.HTMLElement
   
-  var address: org.scalajs.dom.raw.HTMLElement = js.native
+  var address: org.scalajs.dom.raw.HTMLElement
   
-  var area: org.scalajs.dom.raw.HTMLAreaElement = js.native
+  var area: org.scalajs.dom.raw.HTMLAreaElement
   
-  var article: org.scalajs.dom.raw.HTMLElement = js.native
+  var article: org.scalajs.dom.raw.HTMLElement
   
-  var aside: org.scalajs.dom.raw.HTMLElement = js.native
+  var aside: org.scalajs.dom.raw.HTMLElement
   
-  var audio: org.scalajs.dom.raw.HTMLAudioElement = js.native
+  var audio: org.scalajs.dom.raw.HTMLAudioElement
 }
 object HTMLElementTagNameMap {
   

--- a/tests/react-transition-group/check-slinky/s/std/src/main/scala/typingsSlinky/std/SVGElementTagNameMap.scala
+++ b/tests/react-transition-group/check-slinky/s/std/src/main/scala/typingsSlinky/std/SVGElementTagNameMap.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SVGElementTagNameMap extends StObject {
   
-  var circle: org.scalajs.dom.raw.SVGCircleElement = js.native
+  var circle: org.scalajs.dom.raw.SVGCircleElement
 }
 object SVGElementTagNameMap {
   

--- a/tests/recharts/check/r/recharts/build.sbt
+++ b/tests/recharts/check/r/recharts/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "recharts"
-version := "0.0-unknown-ac67bf"
+version := "0.0-unknown-abf83c"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/recharts/check/r/recharts/src/main/scala/typings/recharts/anon.scala
+++ b/tests/recharts/check/r/recharts/src/main/scala/typings/recharts/anon.scala
@@ -6,16 +6,15 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Height extends StObject {
     
-    var height: Double = js.native
+    var height: Double
     
-    var width: Double = js.native
+    var width: Double
     
-    var x: Double = js.native
+    var x: Double
     
-    var y: Double = js.native
+    var y: Double
   }
   object Height {
     

--- a/tests/recharts/check/r/recharts/src/main/scala/typings/recharts/mod.scala
+++ b/tests/recharts/check/r/recharts/src/main/scala/typings/recharts/mod.scala
@@ -14,12 +14,11 @@ object mod {
   @scala.inline
   def rectWithPoints(hasX1Y1: Coordinate, hasX2Y2: Coordinate): Height = (^.asInstanceOf[js.Dynamic].applyDynamic("rectWithPoints")(hasX1Y1.asInstanceOf[js.Any], hasX2Y2.asInstanceOf[js.Any])).asInstanceOf[Height]
   
-  @js.native
   trait Coordinate extends StObject {
     
-    var x: Double = js.native
+    var x: Double
     
-    var y: Double = js.native
+    var y: Double
   }
   object Coordinate {
     

--- a/tests/rxjs/check/r/rxjs/build.sbt
+++ b/tests/rxjs/check/r/rxjs/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "rxjs"
-version := "0.0-unknown-c346d2"
+version := "0.0-unknown-e6aaa5"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/rxjs/check/r/rxjs/src/main/scala/typings/rxjs/subscriptionMod.scala
+++ b/tests/rxjs/check/r/rxjs/src/main/scala/typings/rxjs/subscriptionMod.scala
@@ -20,6 +20,12 @@ object subscriptionMod {
     
     /** @internal */
     var _subscriptions: js.Any = js.native
+    
+    /* CompleteClass */
+    override val closed: Boolean = js.native
+    
+    /* CompleteClass */
+    override def unsubscribe(): Unit = js.native
   }
   /* static members */
   object Subscription {

--- a/tests/rxjs/check/r/rxjs/src/main/scala/typings/rxjs/typesMod.scala
+++ b/tests/rxjs/check/r/rxjs/src/main/scala/typings/rxjs/typesMod.scala
@@ -8,18 +8,17 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object typesMod {
   
-  @js.native
   trait CompletionObserver[T]
     extends StObject
        with PartialObserver[T] {
     
-    var closed: js.UndefOr[Boolean] = js.native
+    var closed: js.UndefOr[Boolean] = js.undefined
     
-    def complete(): Unit = js.native
+    def complete(): Unit
     
-    var error: js.UndefOr[js.Function1[/* err */ js.Any, Unit]] = js.native
+    var error: js.UndefOr[js.Function1[/* err */ js.Any, Unit]] = js.undefined
     
-    var next: js.UndefOr[js.Function1[/* value */ T, Unit]] = js.native
+    var next: js.UndefOr[js.Function1[/* value */ T, Unit]] = js.undefined
   }
   object CompletionObserver {
     
@@ -55,18 +54,17 @@ object typesMod {
     }
   }
   
-  @js.native
   trait ErrorObserver[T]
     extends StObject
        with PartialObserver[T] {
     
-    var closed: js.UndefOr[Boolean] = js.native
+    var closed: js.UndefOr[Boolean] = js.undefined
     
-    var complete: js.UndefOr[js.Function0[Unit]] = js.native
+    var complete: js.UndefOr[js.Function0[Unit]] = js.undefined
     
-    def error(err: js.Any): Unit = js.native
+    def error(err: js.Any): Unit
     
-    var next: js.UndefOr[js.Function1[/* value */ T, Unit]] = js.native
+    var next: js.UndefOr[js.Function1[/* value */ T, Unit]] = js.undefined
   }
   object ErrorObserver {
     
@@ -102,18 +100,17 @@ object typesMod {
     }
   }
   
-  @js.native
   trait NextObserver[T]
     extends StObject
        with PartialObserver[T] {
     
-    var closed: js.UndefOr[Boolean] = js.native
+    var closed: js.UndefOr[Boolean] = js.undefined
     
-    var complete: js.UndefOr[js.Function0[Unit]] = js.native
+    var complete: js.UndefOr[js.Function0[Unit]] = js.undefined
     
-    var error: js.UndefOr[js.Function1[/* err */ js.Any, Unit]] = js.native
+    var error: js.UndefOr[js.Function1[/* err */ js.Any, Unit]] = js.undefined
     
-    def next(value: T): Unit = js.native
+    def next(value: T): Unit
   }
   object NextObserver {
     
@@ -149,16 +146,15 @@ object typesMod {
     }
   }
   
-  @js.native
   trait Observer[T] extends StObject {
     
-    var closed: js.UndefOr[Boolean] = js.native
+    var closed: js.UndefOr[Boolean] = js.undefined
     
-    def complete(): Unit = js.native
+    def complete(): Unit
     
-    def error(err: js.Any): Unit = js.native
+    def error(err: js.Any): Unit
     
-    def next(value: T): Unit = js.native
+    def next(value: T): Unit
   }
   object Observer {
     
@@ -273,12 +269,11 @@ object typesMod {
     def subscribe(observerOrNext: PartialObserver[T], error: Unit, complete: js.Function0[Unit]): Unsubscribable = js.native
   }
   
-  @js.native
   trait SubscriptionLike
     extends StObject
        with Unsubscribable {
     
-    val closed: Boolean = js.native
+    val closed: Boolean
   }
   object SubscriptionLike {
     
@@ -298,10 +293,9 @@ object typesMod {
   
   type UnaryFunction[T, R] = js.Function1[/* source */ T, R]
   
-  @js.native
   trait Unsubscribable extends StObject {
     
-    def unsubscribe(): Unit = js.native
+    def unsubscribe(): Unit
   }
   object Unsubscribable {
     

--- a/tests/sax/check/n/node/build.sbt
+++ b/tests/sax/check/n/node/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "9.6.x-1df50c"
+version := "9.6.x-d9a59d"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-0c0327")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4bcd46")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/sax/check/n/node/src/main/scala/typings/node/Error.scala
+++ b/tests/sax/check/n/node/src/main/scala/typings/node/Error.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Error extends StObject {
   
-  var stack: js.UndefOr[String] = js.native
+  var stack: js.UndefOr[String] = js.undefined
 }
 object Error {
   

--- a/tests/sax/check/n/node/src/main/scala/typings/node/NodeJS.scala
+++ b/tests/sax/check/n/node/src/main/scala/typings/node/NodeJS.scala
@@ -19,12 +19,11 @@ object NodeJS {
     def on(event: js.Symbol, listener: js.Function1[/* repeated */ js.Any, Unit]): this.type = js.native
   }
   
-  @js.native
   trait Global extends StObject {
     
-    var Array: ArrayConstrucor = js.native
+    var Array: ArrayConstrucor
     
-    var global: Global = js.native
+    var global: Global
   }
   object Global {
     

--- a/tests/sax/check/n/node/src/main/scala/typings/node/anon.scala
+++ b/tests/sax/check/n/node/src/main/scala/typings/node/anon.scala
@@ -6,10 +6,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait End extends StObject {
     
-    var end: js.UndefOr[Boolean] = js.native
+    var end: js.UndefOr[Boolean] = js.undefined
   }
   object End {
     

--- a/tests/sax/check/n/node/src/main/scala/typings/node/streamMod.scala
+++ b/tests/sax/check/n/node/src/main/scala/typings/node/streamMod.scala
@@ -71,13 +71,12 @@ object streamMod {
     def on_close(event: close, listener: js.Function0[Unit]): this.type = js.native
   }
   
-  @js.native
   trait DuplexOptions
     extends StObject
        with ReadableOptions
        with WritableOptions {
     
-    var allowHalfOpen: js.UndefOr[Boolean] = js.native
+    var allowHalfOpen: js.UndefOr[Boolean] = js.undefined
   }
   object DuplexOptions {
     
@@ -98,18 +97,17 @@ object streamMod {
     }
   }
   
-  @js.native
   trait ReadableOptions extends StObject {
     
-    var destroy: js.UndefOr[js.Function1[/* error */ js.UndefOr[Error], js.Any]] = js.native
+    var destroy: js.UndefOr[js.Function1[/* error */ js.UndefOr[Error], js.Any]] = js.undefined
     
-    var encoding: js.UndefOr[String] = js.native
+    var encoding: js.UndefOr[String] = js.undefined
     
-    var highWaterMark: js.UndefOr[Double] = js.native
+    var highWaterMark: js.UndefOr[Double] = js.undefined
     
-    var objectMode: js.UndefOr[Boolean] = js.native
+    var objectMode: js.UndefOr[Boolean] = js.undefined
     
-    var read: js.UndefOr[js.ThisFunction1[/* this */ Readable, /* size */ js.UndefOr[Double], js.Any]] = js.native
+    var read: js.UndefOr[js.ThisFunction1[/* this */ Readable, /* size */ js.UndefOr[Double], js.Any]] = js.undefined
   }
   object ReadableOptions {
     
@@ -154,12 +152,11 @@ object streamMod {
     }
   }
   
-  @js.native
   trait WritableOptions extends StObject {
     
     var `final`: js.UndefOr[
         js.Function1[/* callback */ js.Function1[/* error */ js.UndefOr[Error], Unit], Unit]
-      ] = js.native
+      ] = js.undefined
   }
   object WritableOptions {
     

--- a/tests/sax/check/s/sax/build.sbt
+++ b/tests/sax/check/s/sax/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "sax"
-version := "1.x-dc02b5"
+version := "1.x-5a1791"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "node" % "9.6.x-1df50c",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-0c0327")
+  "org.scalablytyped" %%% "node" % "9.6.x-d9a59d",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4bcd46")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/sax/check/s/sax/src/main/scala/typings/sax/mod.scala
+++ b/tests/sax/check/s/sax/src/main/scala/typings/sax/mod.scala
@@ -40,12 +40,11 @@ object mod {
   @scala.inline
   def parser(strict: Boolean, opt: SAXOptions): SAXParser = (^.asInstanceOf[js.Dynamic].applyDynamic("parser")(strict.asInstanceOf[js.Any], opt.asInstanceOf[js.Any])).asInstanceOf[SAXParser]
   
-  @js.native
   trait BaseTag extends StObject {
     
-    var isSelfClosing: Boolean = js.native
+    var isSelfClosing: Boolean
     
-    var name: String = js.native
+    var name: String
   }
   object BaseTag {
     
@@ -66,12 +65,11 @@ object mod {
     }
   }
   
-  @js.native
   trait QualifiedAttribute
     extends StObject
        with QualifiedName {
     
-    var value: String = js.native
+    var value: String
   }
   object QualifiedAttribute {
     
@@ -89,16 +87,15 @@ object mod {
     }
   }
   
-  @js.native
   trait QualifiedName extends StObject {
     
-    var local: String = js.native
+    var local: String
     
-    var name: String = js.native
+    var name: String
     
-    var prefix: String = js.native
+    var prefix: String
     
-    var uri: String = js.native
+    var uri: String
   }
   object QualifiedName {
     
@@ -126,16 +123,15 @@ object mod {
   }
   
   /* import warning: transforms.RemoveMultipleInheritance#findNewParents newComments Dropped parents 
-  - typings.sax.mod.BaseTag because var conflicts: name. Inlined isSelfClosing */ @js.native
-  trait QualifiedTag
+  - typings.sax.mod.BaseTag because var conflicts: name. Inlined isSelfClosing */ trait QualifiedTag
     extends StObject
        with QualifiedName {
     
-    var attributes: StringDictionary[QualifiedAttribute] = js.native
+    var attributes: StringDictionary[QualifiedAttribute]
     
-    var isSelfClosing: Boolean = js.native
+    var isSelfClosing: Boolean
     
-    var ns: StringDictionary[String] = js.native
+    var ns: StringDictionary[String]
   }
   object QualifiedTag {
     
@@ -167,20 +163,19 @@ object mod {
     }
   }
   
-  @js.native
   trait SAXOptions extends StObject {
     
-    var lowercase: js.UndefOr[Boolean] = js.native
+    var lowercase: js.UndefOr[Boolean] = js.undefined
     
-    var normalize: js.UndefOr[Boolean] = js.native
+    var normalize: js.UndefOr[Boolean] = js.undefined
     
-    var noscript: js.UndefOr[Boolean] = js.native
+    var noscript: js.UndefOr[Boolean] = js.undefined
     
-    var position: js.UndefOr[Boolean] = js.native
+    var position: js.UndefOr[Boolean] = js.undefined
     
-    var trim: js.UndefOr[Boolean] = js.native
+    var trim: js.UndefOr[Boolean] = js.undefined
     
-    var xmlns: js.UndefOr[Boolean] = js.native
+    var xmlns: js.UndefOr[Boolean] = js.undefined
   }
   object SAXOptions {
     
@@ -231,12 +226,11 @@ object mod {
     }
   }
   
-  @js.native
   trait Tag
     extends StObject
        with BaseTag {
     
-    var attributes: StringDictionary[String] = js.native
+    var attributes: StringDictionary[String]
   }
   object Tag {
     

--- a/tests/sax/check/s/std/build.sbt
+++ b/tests/sax/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-0c0327"
+version := "0.0-unknown-4bcd46"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/sax/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/sax/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/sax/check/s/std/src/main/scala/typings/std/ArrayBuffer.scala
+++ b/tests/sax/check/s/std/src/main/scala/typings/std/ArrayBuffer.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ArrayBuffer extends StObject

--- a/tests/sax/check/s/std/src/main/scala/typings/std/ArrayConstrucor.scala
+++ b/tests/sax/check/s/std/src/main/scala/typings/std/ArrayConstrucor.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ArrayConstrucor extends StObject

--- a/tests/sax/check/s/std/src/main/scala/typings/std/Uint8Array.scala
+++ b/tests/sax/check/s/std/src/main/scala/typings/std/Uint8Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Uint8Array extends StObject

--- a/tests/serve-static/check/e/express-serve-static-core/build.sbt
+++ b/tests/serve-static/check/e/express-serve-static-core/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "express-serve-static-core"
-version := "0.0-unknown-b24e7d"
+version := "0.0-unknown-bcd658"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/serve-static/check/e/express-serve-static-core/src/main/scala/typings/expressServeStaticCore/mod.scala
+++ b/tests/serve-static/check/e/express-serve-static-core/src/main/scala/typings/expressServeStaticCore/mod.scala
@@ -10,12 +10,11 @@ object mod {
   
   type NextFunction = js.Function1[/* err */ js.UndefOr[js.Any], Unit]
   
-  @js.native
   trait Request
     extends StObject
        with typings.expressServeStaticCore.mod.global.Express.Request {
     
-    var url: String = js.native
+    var url: String
   }
   object Request {
     
@@ -35,12 +34,11 @@ object mod {
   
   type RequestHandler = js.Function3[/* req */ Request, /* res */ Response, /* next */ NextFunction, js.Any]
   
-  @js.native
   trait Response
     extends StObject
        with typings.expressServeStaticCore.mod.global.Express.Response {
     
-    def location(url: String): Response = js.native
+    def location(url: String): Response
   }
   object Response {
     
@@ -62,15 +60,12 @@ object mod {
     
     object Express {
       
-      @js.native
       trait Application extends StObject
       
       // These open interfaces may be extended in an application-specific manner via declaration merging.
       // See for example method-override.d.ts (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/method-override/index.d.ts)
-      @js.native
       trait Request extends StObject
       
-      @js.native
       trait Response extends StObject
     }
   }

--- a/tests/serve-static/check/m/mime/build.sbt
+++ b/tests/serve-static/check/m/mime/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "mime"
-version := "2.0-784bf3"
+version := "2.0-418b03"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-823ce5")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-53c51d")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/serve-static/check/s/serve-static/build.sbt
+++ b/tests/serve-static/check/s/serve-static/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "serve-static"
-version := "0.0-unknown-3ea942"
+version := "0.0-unknown-41a5a3"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "express-serve-static-core" % "0.0-unknown-b24e7d",
-  "org.scalablytyped" %%% "mime" % "2.0-784bf3",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-823ce5")
+  "org.scalablytyped" %%% "express-serve-static-core" % "0.0-unknown-bcd658",
+  "org.scalablytyped" %%% "mime" % "2.0-418b03",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-53c51d")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/serve-static/check/s/serve-static/src/main/scala/typings/serveStatic/mod.scala
+++ b/tests/serve-static/check/s/serve-static/src/main/scala/typings/serveStatic/mod.scala
@@ -45,10 +45,9 @@ object mod {
   @scala.inline
   def serveStatic(root: String, options: ServeStaticOptions): Handler = (^.asInstanceOf[js.Dynamic].applyDynamic("serveStatic")(root.asInstanceOf[js.Any], options.asInstanceOf[js.Any])).asInstanceOf[Handler]
   
-  @js.native
   trait ServeStaticOptions extends StObject {
     
-    var setHeaders: js.UndefOr[js.Function3[/* res */ Response, /* path */ String, /* stat */ js.Any, js.Any]] = js.native
+    var setHeaders: js.UndefOr[js.Function3[/* res */ Response, /* path */ String, /* stat */ js.Any, js.Any]] = js.undefined
   }
   object ServeStaticOptions {
     

--- a/tests/serve-static/check/s/std/build.sbt
+++ b/tests/serve-static/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-823ce5"
+version := "0.0-unknown-53c51d"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/serve-static/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/serve-static/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/stylis/check/s/std/build.sbt
+++ b/tests/stylis/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-823ce5"
+version := "0.0-unknown-53c51d"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/stylis/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/stylis/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/stylis/check/s/stylis/build.sbt
+++ b/tests/stylis/check/s/stylis/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "stylis"
-version := "0.0-unknown-12c45a"
+version := "0.0-unknown-81cf97"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-823ce5")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-53c51d")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/stylis/check/s/stylis/src/main/scala/typings/stylis/mod.scala
+++ b/tests/stylis/check/s/stylis/src/main/scala/typings/stylis/mod.scala
@@ -73,24 +73,23 @@ object mod extends Shortcut {
     val stylis: Stylis = js.native
   }
   
-  @js.native
   trait Options extends StObject {
     
-    var cascade: js.UndefOr[Boolean] = js.native
+    var cascade: js.UndefOr[Boolean] = js.undefined
     
-    var compress: js.UndefOr[Boolean] = js.native
+    var compress: js.UndefOr[Boolean] = js.undefined
     
-    var global: js.UndefOr[Boolean] = js.native
+    var global: js.UndefOr[Boolean] = js.undefined
     
-    var keyframe: js.UndefOr[Boolean] = js.native
+    var keyframe: js.UndefOr[Boolean] = js.undefined
     
     var prefix: js.UndefOr[
         Boolean | (js.Function3[/* key */ String, /* value */ String, /* context */ Double, Boolean])
-      ] = js.native
+      ] = js.undefined
     
-    var preserve: js.UndefOr[Boolean] = js.native
+    var preserve: js.UndefOr[Boolean] = js.undefined
     
-    var semicolon: js.UndefOr[Boolean] = js.native
+    var semicolon: js.UndefOr[Boolean] = js.undefined
   }
   object Options {
     

--- a/tests/swiz/check/s/std/build.sbt
+++ b/tests/swiz/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-823ce5"
+version := "0.0-unknown-53c51d"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/swiz/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/swiz/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/swiz/check/s/swiz/build.sbt
+++ b/tests/swiz/check/s/swiz/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "swiz"
-version := "0.0-unknown-709690"
+version := "0.0-unknown-753684"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-823ce5")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-53c51d")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/swiz/check/s/swiz/src/main/scala/typings/swiz/mod.scala
+++ b/tests/swiz/check/s/swiz/src/main/scala/typings/swiz/mod.scala
@@ -75,10 +75,9 @@ object mod {
     ): Unit = js.native
   }
   
-  @js.native
   trait ISerializable extends StObject {
     
-    def getSerializerType(): String = js.native
+    def getSerializerType(): String
   }
   object ISerializable {
     
@@ -96,14 +95,13 @@ object mod {
     }
   }
   
-  @js.native
   trait ISwizOptions extends StObject {
     
-    var `for`: js.UndefOr[String] = js.native
+    var `for`: js.UndefOr[String] = js.undefined
     
-    var stripNulls: js.UndefOr[Boolean] = js.native
+    var stripNulls: js.UndefOr[Boolean] = js.undefined
     
-    var stripSerializerType: js.UndefOr[Boolean] = js.native
+    var stripSerializerType: js.UndefOr[Boolean] = js.undefined
   }
   object ISwizOptions {
     
@@ -138,10 +136,8 @@ object mod {
   
   object struct {
     
-    @js.native
     trait IField extends StObject
     
-    @js.native
     trait IObj extends StObject
   }
 }

--- a/tests/tstl/check/t/tstl/build.sbt
+++ b/tests/tstl/check/t/tstl/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "tstl"
-version := "0.0-unknown-038d13"
+version := "0.0-unknown-36a681"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/tstl/check/t/tstl/src/main/scala/typings/tstl/global.scala
+++ b/tests/tstl/check/t/tstl/src/main/scala/typings/tstl/global.scala
@@ -14,6 +14,12 @@ object global {
       extends StObject
          with typings.tstl.std.Queue_[T] {
       def this(container: typings.tstl.std.Queue_[T]) = this()
+      
+      /* CompleteClass */
+      var container_ : js.Any = js.native
+      
+      /* CompleteClass */
+      override def empty(): Boolean = js.native
     }
     
     /* was `typeof Queue` */
@@ -23,6 +29,12 @@ object global {
       extends StObject
          with typings.tstl.std.Queue_[T] {
       def this(container: typings.tstl.std.Queue_[T]) = this()
+      
+      /* CompleteClass */
+      var container_ : js.Any = js.native
+      
+      /* CompleteClass */
+      override def empty(): Boolean = js.native
     }
   }
 }

--- a/tests/tstl/check/t/tstl/src/main/scala/typings/tstl/std.scala
+++ b/tests/tstl/check/t/tstl/src/main/scala/typings/tstl/std.scala
@@ -6,12 +6,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object std {
   
-  @js.native
   trait Queue_[T] extends StObject {
     
-    var container_ : js.Any = js.native
+    var container_ : js.Any
     
-    def empty(): Boolean = js.native
+    def empty(): Boolean
   }
   object Queue_ {
     

--- a/tests/type-mappings/check/t/type-mappings/build.sbt
+++ b/tests/type-mappings/check/t/type-mappings/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "type-mappings"
-version := "0.0-unknown-db99b0"
+version := "0.0-unknown-6c1576"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/CSSProperties.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/CSSProperties.scala
@@ -4,22 +4,21 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait CSSProperties extends StObject {
   
-  var color: String = js.native
+  var color: String
   
-  var fontFamily: String = js.native
+  var fontFamily: String
   
-  var fontSize: String = js.native
+  var fontSize: String
   
-  var fontWeight: String = js.native
+  var fontWeight: String
   
-  var letterSpacing: String = js.native
+  var letterSpacing: String
   
-  var lineHeight: String = js.native
+  var lineHeight: String
   
-  var textTransform: String = js.native
+  var textTransform: String
 }
 object CSSProperties {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/Excluded.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/Excluded.scala
@@ -5,20 +5,19 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* Inlined type-mappings.Omit<type-mappings.CSSProperties, 'color'> */
-@js.native
 trait Excluded extends StObject {
   
-  var fontFamily: String = js.native
+  var fontFamily: String
   
-  var fontSize: String = js.native
+  var fontSize: String
   
-  var fontWeight: String = js.native
+  var fontWeight: String
   
-  var letterSpacing: String = js.native
+  var letterSpacing: String
   
-  var lineHeight: String = js.native
+  var lineHeight: String
   
-  var textTransform: String = js.native
+  var textTransform: String
 }
 object Excluded {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/IProxiedPerson.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/IProxiedPerson.scala
@@ -7,12 +7,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* Inlined parent type-mappings.Proxify<type-mappings.Person> */
-@js.native
 trait IProxiedPerson extends StObject {
   
-  var age: js.UndefOr[Get] = js.native
+  var age: js.UndefOr[Get] = js.undefined
   
-  var name: Set = js.native
+  var name: Set
 }
 object IProxiedPerson {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/Marking.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/Marking.scala
@@ -5,12 +5,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* Inlined std.Record<type-mappings.Mark['type'], string> */
-@js.native
 trait Marking extends StObject {
   
-  var text: String = js.native
+  var text: String
   
-  var trail: String = js.native
+  var trail: String
 }
 object Marking {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/NamePerson.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/NamePerson.scala
@@ -5,10 +5,9 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* Inlined std.Pick<type-mappings.Person, 'name'> */
-@js.native
 trait NamePerson extends StObject {
   
-  var name: String = js.native
+  var name: String
 }
 object NamePerson {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/PartialPerson.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/PartialPerson.scala
@@ -5,12 +5,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* Inlined std.Partial<type-mappings.Person> */
-@js.native
 trait PartialPerson extends StObject {
   
-  var age: js.UndefOr[scala.Double | Null] = js.native
+  var age: js.UndefOr[scala.Double | Null] = js.undefined
   
-  var name: js.UndefOr[String] = js.native
+  var name: js.UndefOr[String] = js.undefined
 }
 object PartialPerson {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/Person.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/Person.scala
@@ -4,12 +4,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Person extends StObject {
   
-  var age: js.UndefOr[scala.Double | Null] = js.native
+  var age: js.UndefOr[scala.Double | Null] = js.undefined
   
-  var name: String = js.native
+  var name: String
 }
 object Person {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/PersonRecord.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/PersonRecord.scala
@@ -5,12 +5,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* Inlined std.Record<'name' | 'age', string> */
-@js.native
 trait PersonRecord extends StObject {
   
-  var age: String = js.native
+  var age: String
   
-  var name: String = js.native
+  var name: String
 }
 object PersonRecord {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/ProxiedPerson.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/ProxiedPerson.scala
@@ -7,12 +7,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* Inlined type-mappings.Proxify<type-mappings.Person> */
-@js.native
 trait ProxiedPerson extends StObject {
   
-  var age: js.UndefOr[Get] = js.native
+  var age: js.UndefOr[Get] = js.undefined
   
-  var name: Set = js.native
+  var name: Set
 }
 object ProxiedPerson {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/ReadonlyPerson.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/ReadonlyPerson.scala
@@ -5,12 +5,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* Inlined std.Readonly<type-mappings.Person> */
-@js.native
 trait ReadonlyPerson extends StObject {
   
-  val age: js.UndefOr[scala.Double | Null] = js.native
+  val age: js.UndefOr[scala.Double | Null] = js.undefined
   
-  val name: String = js.native
+  val name: String
 }
 object ReadonlyPerson {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/RequiredPerson.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/RequiredPerson.scala
@@ -5,12 +5,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* Inlined std.Required<type-mappings.Person> */
-@js.native
 trait RequiredPerson extends StObject {
   
-  var age: scala.Double = js.native
+  var age: scala.Double
   
-  var name: String = js.native
+  var name: String
 }
 object RequiredPerson {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/TextMark.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/TextMark.scala
@@ -5,12 +5,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TextMark
   extends StObject
      with Mark {
   
-  var `type`: text = js.native
+  var `type`: text
 }
 object TextMark {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/TrailMark.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/TrailMark.scala
@@ -5,12 +5,11 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait TrailMark
   extends StObject
      with Mark {
   
-  var `type`: trail = js.native
+  var `type`: trail
 }
 object TrailMark {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/TypographyStyle.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/TypographyStyle.scala
@@ -5,22 +5,21 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* Inlined std.Required<std.Pick<type-mappings.CSSProperties, 'fontFamily' | 'fontSize' | 'fontWeight' | 'color'>> & std.Partial<std.Pick<type-mappings.CSSProperties, 'letterSpacing' | 'lineHeight' | 'textTransform'>> */
-@js.native
 trait TypographyStyle extends StObject {
   
-  var color: String = js.native
+  var color: String
   
-  var fontFamily: String = js.native
+  var fontFamily: String
   
-  var fontSize: String = js.native
+  var fontSize: String
   
-  var fontWeight: String = js.native
+  var fontWeight: String
   
-  var letterSpacing: js.UndefOr[String] = js.native
+  var letterSpacing: js.UndefOr[String] = js.undefined
   
-  var lineHeight: js.UndefOr[String] = js.native
+  var lineHeight: js.UndefOr[String] = js.undefined
   
-  var textTransform: js.UndefOr[String] = js.native
+  var textTransform: js.UndefOr[String] = js.undefined
 }
 object TypographyStyle {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/TypographyStyleOptions.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/TypographyStyleOptions.scala
@@ -5,22 +5,21 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* Inlined std.Partial<type-mappings.TypographyStyle> */
-@js.native
 trait TypographyStyleOptions extends StObject {
   
-  var color: js.UndefOr[String] = js.native
+  var color: js.UndefOr[String] = js.undefined
   
-  var fontFamily: js.UndefOr[String] = js.native
+  var fontFamily: js.UndefOr[String] = js.undefined
   
-  var fontSize: js.UndefOr[String] = js.native
+  var fontSize: js.UndefOr[String] = js.undefined
   
-  var fontWeight: js.UndefOr[String] = js.native
+  var fontWeight: js.UndefOr[String] = js.undefined
   
-  var letterSpacing: js.UndefOr[String] = js.native
+  var letterSpacing: js.UndefOr[String] = js.undefined
   
-  var lineHeight: js.UndefOr[String] = js.native
+  var lineHeight: js.UndefOr[String] = js.undefined
   
-  var textTransform: js.UndefOr[String] = js.native
+  var textTransform: js.UndefOr[String] = js.undefined
 }
 object TypographyStyleOptions {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/U.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/U.scala
@@ -5,12 +5,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* Inlined std.Pick<{  name :string,   age :number}, 'name' | 'age'> */
-@js.native
 trait U extends StObject {
   
-  var age: scala.Double = js.native
+  var age: scala.Double
   
-  var name: String = js.native
+  var name: String
 }
 object U {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/V.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/V.scala
@@ -5,10 +5,9 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* Inlined std.Pick<{  name :string,   age :number}, 'age'> */
-@js.native
 trait V extends StObject {
   
-  var age: scala.Double = js.native
+  var age: scala.Double
 }
 object V {
   

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/anon.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/anon.scala
@@ -6,10 +6,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Age extends StObject {
     
-    var age: scala.Double = js.native
+    var age: scala.Double
   }
   object Age {
     
@@ -36,10 +35,9 @@ object anon {
     def set(v: scala.Double): Unit = js.native
   }
   
-  @js.native
   trait Name extends StObject {
     
-    var name: String = js.native
+    var name: String
   }
   object Name {
     
@@ -57,12 +55,11 @@ object anon {
     }
   }
   
-  @js.native
   trait Set extends StObject {
     
-    def get(): String = js.native
+    def get(): String
     
-    def set(v: String): Unit = js.native
+    def set(v: String): Unit
   }
   object Set {
     

--- a/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/global.scala
+++ b/tests/type-mappings/check/t/type-mappings/src/main/scala/typings/typeMappings/global.scala
@@ -15,7 +15,11 @@ object global {
   @js.native
   class newPerson ()
     extends StObject
-       with Person
+       with Person {
+    
+    /* CompleteClass */
+    var name: String = js.native
+  }
   @JSGlobal("newPerson")
   @js.native
   val newPerson: Instantiable0[Person] = js.native

--- a/tests/typings-json/check/p/phaser/build.sbt
+++ b/tests/typings-json/check/p/phaser/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "phaser"
-version := "2.6.2-1437ff"
+version := "2.6.2-043792"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-823ce5")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-53c51d")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/typings-json/check/p/phaser/src/main/scala/typings/phaser/Phaser.scala
+++ b/tests/typings-json/check/p/phaser/src/main/scala/typings/phaser/Phaser.scala
@@ -4,7 +4,6 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Phaser extends StObject
 object Phaser {
   
@@ -13,6 +12,5 @@ object Phaser {
     *
     * It is created by the AnimationManager, consists of Animation.Frame objects and belongs to a single Game Object such as a Sprite.
     */
-  @js.native
   trait Animation extends StObject
 }

--- a/tests/typings-json/check/p/phaser/src/main/scala/typings/phaser/anon.scala
+++ b/tests/typings-json/check/p/phaser/src/main/scala/typings/phaser/anon.scala
@@ -6,12 +6,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait LowerBound extends StObject {
     
-    var lowerBound: js.UndefOr[js.Array[Double]] = js.native
+    var lowerBound: js.UndefOr[js.Array[Double]] = js.undefined
     
-    var upperBound: js.UndefOr[js.Array[Double]] = js.native
+    var upperBound: js.UndefOr[js.Array[Double]] = js.undefined
   }
   object LowerBound {
     

--- a/tests/typings-json/check/p/phaser/src/main/scala/typings/phaser/global.scala
+++ b/tests/typings-json/check/p/phaser/src/main/scala/typings/phaser/global.scala
@@ -96,6 +96,9 @@ object global {
       extends StObject
          with typings.phaser.p2.AABB {
       def this(options: LowerBound) = this()
+      
+      /* CompleteClass */
+      override def copy(aabb: typings.phaser.p2.AABB): Unit = js.native
     }
   }
 }

--- a/tests/typings-json/check/p/phaser/src/main/scala/typings/phaser/p2.scala
+++ b/tests/typings-json/check/p/phaser/src/main/scala/typings/phaser/p2.scala
@@ -6,10 +6,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object p2 {
   
-  @js.native
   trait AABB extends StObject {
     
-    def copy(aabb: AABB): Unit = js.native
+    def copy(aabb: AABB): Unit
   }
   object AABB {
     

--- a/tests/typings-json/check/s/std/build.sbt
+++ b/tests/typings-json/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-823ce5"
+version := "0.0-unknown-53c51d"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/typings-json/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/typings-json/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/union-to-inheritance/check/s/std/build.sbt
+++ b/tests/union-to-inheritance/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-52fd2b"
+version := "0.0-unknown-9007d5"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/union-to-inheritance/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/union-to-inheritance/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/union-to-inheritance/check/s/std/src/main/scala/typings/std/HTMLInputElement.scala
+++ b/tests/union-to-inheritance/check/s/std/src/main/scala/typings/std/HTMLInputElement.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait HTMLInputElement extends StObject

--- a/tests/union-to-inheritance/check/s/std/src/main/scala/typings/std/TwoFoo.scala
+++ b/tests/union-to-inheritance/check/s/std/src/main/scala/typings/std/TwoFoo.scala
@@ -5,10 +5,9 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 /* let's pretend */
-@js.native
 trait TwoFoo[Foo1, Foo2] extends StObject {
   
-  var value: Foo1 = js.native
+  var value: Foo1
 }
 object TwoFoo {
   

--- a/tests/union-to-inheritance/check/u/union-to-inheritance/build.sbt
+++ b/tests/union-to-inheritance/check/u/union-to-inheritance/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "union-to-inheritance"
-version := "0.0-unknown-b2bd5f"
+version := "0.0-unknown-19ff95"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-52fd2b")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-9007d5")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/union-to-inheritance/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Either.scala
+++ b/tests/union-to-inheritance/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Either.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Either[L, R]
   extends StObject
      with Legal3[js.Any, L, R]
      with _Test[js.Any, L, R]
      with _Test2[R, L] {
   
-  var value: R = js.native
+  var value: R
 }
 object Either {
   

--- a/tests/union-to-inheritance/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Foo.scala
+++ b/tests/union-to-inheritance/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Foo.scala
@@ -4,14 +4,13 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Foo[U]
   extends StObject
      with Legal1[U]
      with Legal2[U, js.Any]
      with Legal3[js.Any, js.Any, U] {
   
-  var value: U = js.native
+  var value: U
 }
 object Foo {
   

--- a/tests/union-to-inheritance/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Foo2.scala
+++ b/tests/union-to-inheritance/check/u/union-to-inheritance/src/main/scala/typings/unionToInheritance/Foo2.scala
@@ -4,16 +4,15 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Foo2[U, V]
   extends StObject
      with Legal2[V, U]
      with Legal3[U, js.Any, V]
      with _Test[U, js.Any, V] {
   
-  var u: U = js.native
+  var u: U
   
-  var v: V = js.native
+  var v: V
 }
 object Foo2 {
   

--- a/tests/vfile/check/s/std/build.sbt
+++ b/tests/vfile/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-a3ec8f"
+version := "0.0-unknown-a2efc1"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/vfile/check/s/std/src/main/scala/typings/std/Uint8Array.scala
+++ b/tests/vfile/check/s/std/src/main/scala/typings/std/Uint8Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Uint8Array extends StObject

--- a/tests/vfile/check/v/vfile/build.sbt
+++ b/tests/vfile/check/v/vfile/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "vfile"
-version := "0.0-unknown-1a19c2"
+version := "0.0-unknown-724378"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-a3ec8f")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-a2efc1")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/vfile/check/v/vfile/src/main/scala/typings/vfile/VFileOptions.scala
+++ b/tests/vfile/check/v/vfile/src/main/scala/typings/vfile/VFileOptions.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait VFileOptions extends StObject {
   
-  var contents: js.UndefOr[VFileContents] = js.native
+  var contents: js.UndefOr[VFileContents] = js.undefined
 }
 object VFileOptions {
   

--- a/tests/void-elements/check/s/std/build.sbt
+++ b/tests/void-elements/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-a61c1d"
+version := "0.0-unknown-f437ac"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/void-elements/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/void-elements/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/void-elements/check/v/void-elements/build.sbt
+++ b/tests/void-elements/check/v/void-elements/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "void-elements"
-version := "3.1-cd2617"
+version := "3.1-959205"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-a61c1d")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-f437ac")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/vue/check/n/node/build.sbt
+++ b/tests/vue/check/n/node/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "0.0-unknown-6f2875"
+version := "0.0-unknown-fbed7c"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/vue/check/n/node/src/main/scala/typings/node/NodeJS.scala
+++ b/tests/vue/check/n/node/src/main/scala/typings/node/NodeJS.scala
@@ -6,6 +6,5 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object NodeJS {
   
-  @js.native
   trait Process extends StObject
 }

--- a/tests/vue/check/s/std/build.sbt
+++ b/tests/vue/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-b9c231"
+version := "0.0-unknown-dcb159"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/vue/check/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/vue/check/s/std/src/main/scala/typings/std/Array.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Array[T] extends StObject

--- a/tests/vue/check/s/std/src/main/scala/typings/std/Blob.scala
+++ b/tests/vue/check/s/std/src/main/scala/typings/std/Blob.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Blob extends StObject

--- a/tests/vue/check/s/std/src/main/scala/typings/std/Error.scala
+++ b/tests/vue/check/s/std/src/main/scala/typings/std/Error.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Error extends StObject

--- a/tests/vue/check/s/std/src/main/scala/typings/std/Node.scala
+++ b/tests/vue/check/s/std/src/main/scala/typings/std/Node.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Node extends StObject

--- a/tests/vue/check/s/std/src/main/scala/typings/std/Object.scala
+++ b/tests/vue/check/s/std/src/main/scala/typings/std/Object.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Object extends StObject

--- a/tests/vue/check/s/std/src/main/scala/typings/std/Promise.scala
+++ b/tests/vue/check/s/std/src/main/scala/typings/std/Promise.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Promise[T] extends StObject

--- a/tests/vue/check/s/std/src/main/scala/typings/std/PromiseLike.scala
+++ b/tests/vue/check/s/std/src/main/scala/typings/std/PromiseLike.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait PromiseLike[T] extends StObject

--- a/tests/vue/check/s/std/src/main/scala/typings/std/RegExp.scala
+++ b/tests/vue/check/s/std/src/main/scala/typings/std/RegExp.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait RegExp extends StObject

--- a/tests/vue/check/s/std/src/main/scala/typings/std/ThisType.scala
+++ b/tests/vue/check/s/std/src/main/scala/typings/std/ThisType.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait ThisType[T] extends StObject

--- a/tests/vue/check/s/storybook__vue/build.sbt
+++ b/tests/vue/check/s/storybook__vue/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "storybook__vue"
-version := "3.3-b2f832"
+version := "3.3-0ec981"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-b9c231",
-  "org.scalablytyped" %%% "vue" % "2.5.13-c2fcf3",
-  "org.scalablytyped" %%% "webpack-env" % "1.13-b65c7d")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-dcb159",
+  "org.scalablytyped" %%% "vue" % "2.5.13-ea809d",
+  "org.scalablytyped" %%% "webpack-env" % "1.13-3b324f")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/vue/check/s/storybook__vue/src/main/scala/typings/storybookVue/anon.scala
+++ b/tests/vue/check/s/storybook__vue/src/main/scala/typings/storybookVue/anon.scala
@@ -6,12 +6,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Kind extends StObject {
     
-    var kind: String = js.native
+    var kind: String
     
-    var story: String = js.native
+    var story: String
   }
   object Kind {
     

--- a/tests/vue/check/s/storybook__vue/src/main/scala/typings/storybookVue/mod.scala
+++ b/tests/vue/check/s/storybook__vue/src/main/scala/typings/storybookVue/mod.scala
@@ -37,14 +37,13 @@ object mod {
   
   type Addon = StringDictionary[js.Function2[/* storyName */ String, /* storyFn */ StoryFunction, Unit]]
   
-  @js.native
   trait Story extends StObject {
     
-    def add(storyName: String, getStory: StoryFunction): this.type = js.native
+    def add(storyName: String, getStory: StoryFunction): this.type
     
-    def addDecorator(decorator: StoryDecorator): this.type = js.native
+    def addDecorator(decorator: StoryDecorator): this.type
     
-    val kind: String = js.native
+    val kind: String
   }
   object Story {
     
@@ -98,10 +97,9 @@ object mod {
     ]) | String
   ]
   
-  @js.native
   trait StoryObject extends StObject {
     
-    var name: String = js.native
+    var name: String
     
     def render(): (ComponentOptions[
         Vue, 
@@ -109,9 +107,9 @@ object mod {
         DefaultMethods[Vue], 
         DefaultComputed, 
         PropsDefinition[DefaultProps]
-      ]) | String = js.native
+      ]) | String
     @JSName("render")
-    var render_Original: StoryFunction = js.native
+    var render_Original: StoryFunction
   }
   object StoryObject {
     
@@ -149,14 +147,13 @@ object mod {
     }
   }
   
-  @js.native
   trait StoryStore extends StObject {
     
-    var fileName: js.UndefOr[String] = js.native
+    var fileName: js.UndefOr[String] = js.undefined
     
-    var kind: String = js.native
+    var kind: String
     
-    var stories: js.Array[StoryObject] = js.native
+    var stories: js.Array[StoryObject]
   }
   object StoryStore {
     

--- a/tests/vue/check/v/vue-resource/build.sbt
+++ b/tests/vue/check/v/vue-resource/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "vue-resource"
-version := "0.9.3-8a142c"
+version := "0.9.3-2c6fcd"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-b9c231")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-dcb159")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/vue/check/v/vue-resource/src/main/scala/typings/vueResource/anon.scala
+++ b/tests/vue/check/v/vue-resource/src/main/scala/typings/vueResource/anon.scala
@@ -66,30 +66,29 @@ object anon {
   }
   
   /* Inlined vue-resource.vuejs.HttpOptions & {  root :string} */
-  @js.native
   trait HttpOptionsrootstring extends StObject {
     
-    var before: js.UndefOr[js.Function1[/* request */ js.Any, js.Any]] = js.native
+    var before: js.UndefOr[js.Function1[/* request */ js.Any, js.Any]] = js.undefined
     
-    var body: js.UndefOr[js.Any] = js.native
+    var body: js.UndefOr[js.Any] = js.undefined
     
-    var credentials: js.UndefOr[Boolean] = js.native
+    var credentials: js.UndefOr[Boolean] = js.undefined
     
-    var emulateHTTP: js.UndefOr[Boolean] = js.native
+    var emulateHTTP: js.UndefOr[Boolean] = js.undefined
     
-    var emulateJSON: js.UndefOr[Boolean] = js.native
+    var emulateJSON: js.UndefOr[Boolean] = js.undefined
     
-    var headers: js.UndefOr[js.Any] = js.native
+    var headers: js.UndefOr[js.Any] = js.undefined
     
-    var method: js.UndefOr[String] = js.native
+    var method: js.UndefOr[String] = js.undefined
     
-    var params: js.UndefOr[js.Any] = js.native
+    var params: js.UndefOr[js.Any] = js.undefined
     
-    var progress: js.UndefOr[js.Function1[/* event */ js.Any, js.Any]] = js.native
+    var progress: js.UndefOr[js.Function1[/* event */ js.Any, js.Any]] = js.undefined
     
-    var root: String = js.native
+    var root: String
     
-    var url: js.UndefOr[String] = js.native
+    var url: js.UndefOr[String] = js.undefined
   }
   object HttpOptionsrootstring {
     
@@ -167,10 +166,9 @@ object anon {
     }
   }
   
-  @js.native
   trait Method extends StObject {
     
-    var method: String = js.native
+    var method: String
   }
   object Method {
     
@@ -189,30 +187,29 @@ object anon {
   }
   
   /* Inlined {  headers :vue-resource.vuejs.HttpHeaders | undefined, [key: string] : any} & vue-resource.vuejs.HttpOptions */
-  @js.native
   trait headersHttpHeadersundefin
     extends StObject
        with /* key */ StringDictionary[js.Any] {
     
-    var before: js.UndefOr[js.Function1[/* request */ js.Any, js.Any]] = js.native
+    var before: js.UndefOr[js.Function1[/* request */ js.Any, js.Any]] = js.undefined
     
-    var body: js.UndefOr[js.Any] = js.native
+    var body: js.UndefOr[js.Any] = js.undefined
     
-    var credentials: js.UndefOr[Boolean] = js.native
+    var credentials: js.UndefOr[Boolean] = js.undefined
     
-    var emulateHTTP: js.UndefOr[Boolean] = js.native
+    var emulateHTTP: js.UndefOr[Boolean] = js.undefined
     
-    var emulateJSON: js.UndefOr[Boolean] = js.native
+    var emulateJSON: js.UndefOr[Boolean] = js.undefined
     
-    var headers: js.UndefOr[HttpHeaders] & js.UndefOr[js.Any] = js.native
+    var headers: js.UndefOr[HttpHeaders] & js.UndefOr[js.Any]
     
-    var method: js.UndefOr[String] = js.native
+    var method: js.UndefOr[String] = js.undefined
     
-    var params: js.UndefOr[js.Any] = js.native
+    var params: js.UndefOr[js.Any] = js.undefined
     
-    var progress: js.UndefOr[js.Function1[/* event */ js.Any, js.Any]] = js.native
+    var progress: js.UndefOr[js.Function1[/* event */ js.Any, js.Any]] = js.undefined
     
-    var url: js.UndefOr[String] = js.native
+    var url: js.UndefOr[String] = js.undefined
   }
   object headersHttpHeadersundefin {
     

--- a/tests/vue/check/v/vue-resource/src/main/scala/typings/vueResource/vuejs.scala
+++ b/tests/vue/check/v/vue-resource/src/main/scala/typings/vueResource/vuejs.scala
@@ -12,10 +12,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object vuejs {
   
-  @js.native
   trait ComponentOption extends StObject {
     
-    var http: js.UndefOr[headersHttpHeadersundefin] = js.native
+    var http: js.UndefOr[headersHttpHeadersundefin] = js.undefined
   }
   object ComponentOption {
     
@@ -36,22 +35,21 @@ object vuejs {
     }
   }
   
-  @js.native
   trait HttpHeaders
     extends StObject
        with /* key */ StringDictionary[js.Any] {
     
-    var common: js.UndefOr[StringDictionary[String]] = js.native
+    var common: js.UndefOr[StringDictionary[String]] = js.undefined
     
-    var custom: js.UndefOr[StringDictionary[String]] = js.native
+    var custom: js.UndefOr[StringDictionary[String]] = js.undefined
     
-    var delete: js.UndefOr[StringDictionary[String]] = js.native
+    var delete: js.UndefOr[StringDictionary[String]] = js.undefined
     
-    var patch: js.UndefOr[StringDictionary[String]] = js.native
+    var patch: js.UndefOr[StringDictionary[String]] = js.undefined
     
-    var post: js.UndefOr[StringDictionary[String]] = js.native
+    var post: js.UndefOr[StringDictionary[String]] = js.undefined
     
-    var put: js.UndefOr[StringDictionary[String]] = js.native
+    var put: js.UndefOr[StringDictionary[String]] = js.undefined
   }
   object HttpHeaders {
     
@@ -102,12 +100,11 @@ object vuejs {
     }
   }
   
-  @js.native
   trait HttpInterceptor extends StObject {
     
-    var request: js.UndefOr[js.Function1[/* request */ HttpOptions, HttpOptions]] = js.native
+    var request: js.UndefOr[js.Function1[/* request */ HttpOptions, HttpOptions]] = js.undefined
     
-    var response: js.UndefOr[js.Function1[/* response */ HttpResponse, HttpResponse]] = js.native
+    var response: js.UndefOr[js.Function1[/* response */ HttpResponse, HttpResponse]] = js.undefined
   }
   object HttpInterceptor {
     
@@ -134,28 +131,27 @@ object vuejs {
     }
   }
   
-  @js.native
   trait HttpOptions extends StObject {
     
-    var before: js.UndefOr[js.Function1[/* request */ js.Any, js.Any]] = js.native
+    var before: js.UndefOr[js.Function1[/* request */ js.Any, js.Any]] = js.undefined
     
-    var body: js.UndefOr[js.Any] = js.native
+    var body: js.UndefOr[js.Any] = js.undefined
     
-    var credentials: js.UndefOr[Boolean] = js.native
+    var credentials: js.UndefOr[Boolean] = js.undefined
     
-    var emulateHTTP: js.UndefOr[Boolean] = js.native
+    var emulateHTTP: js.UndefOr[Boolean] = js.undefined
     
-    var emulateJSON: js.UndefOr[Boolean] = js.native
+    var emulateJSON: js.UndefOr[Boolean] = js.undefined
     
-    var headers: js.UndefOr[js.Any] = js.native
+    var headers: js.UndefOr[js.Any] = js.undefined
     
-    var method: js.UndefOr[String] = js.native
+    var method: js.UndefOr[String] = js.undefined
     
-    var params: js.UndefOr[js.Any] = js.native
+    var params: js.UndefOr[js.Any] = js.undefined
     
-    var progress: js.UndefOr[js.Function1[/* event */ js.Any, js.Any]] = js.native
+    var progress: js.UndefOr[js.Function1[/* event */ js.Any, js.Any]] = js.undefined
     
-    var url: js.UndefOr[String] = js.native
+    var url: js.UndefOr[String] = js.undefined
   }
   object HttpOptions {
     
@@ -230,24 +226,23 @@ object vuejs {
     }
   }
   
-  @js.native
   trait HttpResponse extends StObject {
     
-    def blob(): Blob = js.native
+    def blob(): Blob
     
-    var data: js.Object = js.native
+    var data: js.Object
     
-    var headers: js.Function = js.native
+    var headers: js.Function
     
-    def json(): js.Any = js.native
+    def json(): js.Any
     
-    var ok: Boolean = js.native
+    var ok: Boolean
     
-    var status: Double = js.native
+    var status: Double
     
-    var statusText: String = js.native
+    var statusText: String
     
-    def text(): String = js.native
+    def text(): String
   }
   object HttpResponse {
     
@@ -295,62 +290,61 @@ object vuejs {
     }
   }
   
-  @js.native
   trait Http_ extends StObject {
     
-    def delete(url: String): js.Thenable[HttpResponse] = js.native
-    def delete(url: String, data: js.Any): js.Thenable[HttpResponse] = js.native
-    def delete(url: String, data: js.Any, options: HttpOptions): js.Thenable[HttpResponse] = js.native
-    def delete(url: String, data: Unit, options: HttpOptions): js.Thenable[HttpResponse] = js.native
-    def delete(url: String, options: HttpOptions): js.Thenable[HttpResponse] = js.native
+    def delete(url: String): js.Thenable[HttpResponse]
+    def delete(url: String, data: js.Any): js.Thenable[HttpResponse]
+    def delete(url: String, data: js.Any, options: HttpOptions): js.Thenable[HttpResponse]
+    def delete(url: String, data: Unit, options: HttpOptions): js.Thenable[HttpResponse]
+    def delete(url: String, options: HttpOptions): js.Thenable[HttpResponse]
     @JSName("delete")
-    var delete_Original: http = js.native
+    var delete_Original: http
     
-    def get(url: String): js.Thenable[HttpResponse] = js.native
-    def get(url: String, data: js.Any): js.Thenable[HttpResponse] = js.native
-    def get(url: String, data: js.Any, options: HttpOptions): js.Thenable[HttpResponse] = js.native
-    def get(url: String, data: Unit, options: HttpOptions): js.Thenable[HttpResponse] = js.native
-    def get(url: String, options: HttpOptions): js.Thenable[HttpResponse] = js.native
+    def get(url: String): js.Thenable[HttpResponse]
+    def get(url: String, data: js.Any): js.Thenable[HttpResponse]
+    def get(url: String, data: js.Any, options: HttpOptions): js.Thenable[HttpResponse]
+    def get(url: String, data: Unit, options: HttpOptions): js.Thenable[HttpResponse]
+    def get(url: String, options: HttpOptions): js.Thenable[HttpResponse]
     @JSName("get")
-    var get_Original: http = js.native
+    var get_Original: http
     
-    var headers: HttpHeaders = js.native
+    var headers: HttpHeaders
     
-    var interceptors: js.Array[HttpInterceptor | js.Function0[HttpInterceptor]] = js.native
+    var interceptors: js.Array[HttpInterceptor | js.Function0[HttpInterceptor]]
     
-    def jsonp(url: String): js.Thenable[HttpResponse] = js.native
-    def jsonp(url: String, data: js.Any): js.Thenable[HttpResponse] = js.native
-    def jsonp(url: String, data: js.Any, options: HttpOptions): js.Thenable[HttpResponse] = js.native
-    def jsonp(url: String, data: Unit, options: HttpOptions): js.Thenable[HttpResponse] = js.native
-    def jsonp(url: String, options: HttpOptions): js.Thenable[HttpResponse] = js.native
+    def jsonp(url: String): js.Thenable[HttpResponse]
+    def jsonp(url: String, data: js.Any): js.Thenable[HttpResponse]
+    def jsonp(url: String, data: js.Any, options: HttpOptions): js.Thenable[HttpResponse]
+    def jsonp(url: String, data: Unit, options: HttpOptions): js.Thenable[HttpResponse]
+    def jsonp(url: String, options: HttpOptions): js.Thenable[HttpResponse]
     @JSName("jsonp")
-    var jsonp_Original: http = js.native
+    var jsonp_Original: http
     
-    var options: HttpOptionsrootstring = js.native
+    var options: HttpOptionsrootstring
     
-    def patch(url: String): js.Thenable[HttpResponse] = js.native
-    def patch(url: String, data: js.Any): js.Thenable[HttpResponse] = js.native
-    def patch(url: String, data: js.Any, options: HttpOptions): js.Thenable[HttpResponse] = js.native
-    def patch(url: String, data: Unit, options: HttpOptions): js.Thenable[HttpResponse] = js.native
-    def patch(url: String, options: HttpOptions): js.Thenable[HttpResponse] = js.native
+    def patch(url: String): js.Thenable[HttpResponse]
+    def patch(url: String, data: js.Any): js.Thenable[HttpResponse]
+    def patch(url: String, data: js.Any, options: HttpOptions): js.Thenable[HttpResponse]
+    def patch(url: String, data: Unit, options: HttpOptions): js.Thenable[HttpResponse]
+    def patch(url: String, options: HttpOptions): js.Thenable[HttpResponse]
     @JSName("patch")
-    var patch_Original: http = js.native
+    var patch_Original: http
     
-    def post(url: String): js.Thenable[HttpResponse] = js.native
-    def post(url: String, data: js.Any): js.Thenable[HttpResponse] = js.native
-    def post(url: String, data: js.Any, options: HttpOptions): js.Thenable[HttpResponse] = js.native
-    def post(url: String, data: Unit, options: HttpOptions): js.Thenable[HttpResponse] = js.native
-    def post(url: String, options: HttpOptions): js.Thenable[HttpResponse] = js.native
+    def post(url: String): js.Thenable[HttpResponse]
+    def post(url: String, data: js.Any): js.Thenable[HttpResponse]
+    def post(url: String, data: js.Any, options: HttpOptions): js.Thenable[HttpResponse]
+    def post(url: String, data: Unit, options: HttpOptions): js.Thenable[HttpResponse]
+    def post(url: String, options: HttpOptions): js.Thenable[HttpResponse]
     @JSName("post")
-    var post_Original: http = js.native
+    var post_Original: http
     
-    def put(url: String): js.Thenable[HttpResponse] = js.native
-    def put(url: String, data: js.Any): js.Thenable[HttpResponse] = js.native
-    def put(url: String, data: js.Any, options: HttpOptions): js.Thenable[HttpResponse] = js.native
-    def put(url: String, data: Unit, options: HttpOptions): js.Thenable[HttpResponse] = js.native
-    def put(url: String, options: HttpOptions): js.Thenable[HttpResponse] = js.native
+    def put(url: String): js.Thenable[HttpResponse]
+    def put(url: String, data: js.Any): js.Thenable[HttpResponse]
+    def put(url: String, data: js.Any, options: HttpOptions): js.Thenable[HttpResponse]
+    def put(url: String, data: Unit, options: HttpOptions): js.Thenable[HttpResponse]
+    def put(url: String, options: HttpOptions): js.Thenable[HttpResponse]
     @JSName("put")
-    var put_Original: http = js.native
+    var put_Original: http
   }
   object Http_ {
     
@@ -405,20 +399,19 @@ object vuejs {
     }
   }
   
-  @js.native
   trait ResourceActions extends StObject {
     
-    var delete: Method = js.native
+    var delete: Method
     
-    var get: Method = js.native
+    var get: Method
     
-    var query: Method = js.native
+    var query: Method
     
-    var remove: Method = js.native
+    var remove: Method
     
-    var save: Method = js.native
+    var save: Method
     
-    var update: Method = js.native
+    var update: Method
   }
   object ResourceActions {
     
@@ -470,110 +463,109 @@ object vuejs {
     def apply(success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
   }
   
-  @js.native
   trait ResourceMethods extends StObject {
     
-    def delete(): js.Thenable[HttpResponse] = js.native
-    def delete(params: js.Any): js.Thenable[HttpResponse] = js.native
-    def delete(params: js.Any, data: js.Any): js.Thenable[HttpResponse] = js.native
-    def delete(params: js.Any, data: js.Any, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def delete(params: js.Any, data: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def delete(params: js.Any, data: js.Any, success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def delete(params: js.Any, data: Unit, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def delete(params: js.Any, data: Unit, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def delete(params: js.Any, data: Unit, success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def delete(params: js.Any, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def delete(params: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def delete(success: js.Function): js.Thenable[HttpResponse] = js.native
-    def delete(success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def delete(success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
+    def delete(): js.Thenable[HttpResponse]
+    def delete(params: js.Any): js.Thenable[HttpResponse]
+    def delete(params: js.Any, data: js.Any): js.Thenable[HttpResponse]
+    def delete(params: js.Any, data: js.Any, success: js.Function): js.Thenable[HttpResponse]
+    def delete(params: js.Any, data: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def delete(params: js.Any, data: js.Any, success: Unit, error: js.Function): js.Thenable[HttpResponse]
+    def delete(params: js.Any, data: Unit, success: js.Function): js.Thenable[HttpResponse]
+    def delete(params: js.Any, data: Unit, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def delete(params: js.Any, data: Unit, success: Unit, error: js.Function): js.Thenable[HttpResponse]
+    def delete(params: js.Any, success: js.Function): js.Thenable[HttpResponse]
+    def delete(params: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def delete(success: js.Function): js.Thenable[HttpResponse]
+    def delete(success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def delete(success: Unit, error: js.Function): js.Thenable[HttpResponse]
     @JSName("delete")
-    var delete_Original: ResourceMethod = js.native
+    var delete_Original: ResourceMethod
     
-    def get(): js.Thenable[HttpResponse] = js.native
-    def get(params: js.Any): js.Thenable[HttpResponse] = js.native
-    def get(params: js.Any, data: js.Any): js.Thenable[HttpResponse] = js.native
-    def get(params: js.Any, data: js.Any, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def get(params: js.Any, data: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def get(params: js.Any, data: js.Any, success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def get(params: js.Any, data: Unit, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def get(params: js.Any, data: Unit, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def get(params: js.Any, data: Unit, success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def get(params: js.Any, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def get(params: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def get(success: js.Function): js.Thenable[HttpResponse] = js.native
-    def get(success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def get(success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
+    def get(): js.Thenable[HttpResponse]
+    def get(params: js.Any): js.Thenable[HttpResponse]
+    def get(params: js.Any, data: js.Any): js.Thenable[HttpResponse]
+    def get(params: js.Any, data: js.Any, success: js.Function): js.Thenable[HttpResponse]
+    def get(params: js.Any, data: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def get(params: js.Any, data: js.Any, success: Unit, error: js.Function): js.Thenable[HttpResponse]
+    def get(params: js.Any, data: Unit, success: js.Function): js.Thenable[HttpResponse]
+    def get(params: js.Any, data: Unit, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def get(params: js.Any, data: Unit, success: Unit, error: js.Function): js.Thenable[HttpResponse]
+    def get(params: js.Any, success: js.Function): js.Thenable[HttpResponse]
+    def get(params: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def get(success: js.Function): js.Thenable[HttpResponse]
+    def get(success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def get(success: Unit, error: js.Function): js.Thenable[HttpResponse]
     @JSName("get")
-    var get_Original: ResourceMethod = js.native
+    var get_Original: ResourceMethod
     
-    def query(): js.Thenable[HttpResponse] = js.native
-    def query(params: js.Any): js.Thenable[HttpResponse] = js.native
-    def query(params: js.Any, data: js.Any): js.Thenable[HttpResponse] = js.native
-    def query(params: js.Any, data: js.Any, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def query(params: js.Any, data: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def query(params: js.Any, data: js.Any, success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def query(params: js.Any, data: Unit, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def query(params: js.Any, data: Unit, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def query(params: js.Any, data: Unit, success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def query(params: js.Any, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def query(params: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def query(success: js.Function): js.Thenable[HttpResponse] = js.native
-    def query(success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def query(success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
+    def query(): js.Thenable[HttpResponse]
+    def query(params: js.Any): js.Thenable[HttpResponse]
+    def query(params: js.Any, data: js.Any): js.Thenable[HttpResponse]
+    def query(params: js.Any, data: js.Any, success: js.Function): js.Thenable[HttpResponse]
+    def query(params: js.Any, data: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def query(params: js.Any, data: js.Any, success: Unit, error: js.Function): js.Thenable[HttpResponse]
+    def query(params: js.Any, data: Unit, success: js.Function): js.Thenable[HttpResponse]
+    def query(params: js.Any, data: Unit, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def query(params: js.Any, data: Unit, success: Unit, error: js.Function): js.Thenable[HttpResponse]
+    def query(params: js.Any, success: js.Function): js.Thenable[HttpResponse]
+    def query(params: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def query(success: js.Function): js.Thenable[HttpResponse]
+    def query(success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def query(success: Unit, error: js.Function): js.Thenable[HttpResponse]
     @JSName("query")
-    var query_Original: ResourceMethod = js.native
+    var query_Original: ResourceMethod
     
-    def remove(): js.Thenable[HttpResponse] = js.native
-    def remove(params: js.Any): js.Thenable[HttpResponse] = js.native
-    def remove(params: js.Any, data: js.Any): js.Thenable[HttpResponse] = js.native
-    def remove(params: js.Any, data: js.Any, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def remove(params: js.Any, data: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def remove(params: js.Any, data: js.Any, success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def remove(params: js.Any, data: Unit, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def remove(params: js.Any, data: Unit, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def remove(params: js.Any, data: Unit, success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def remove(params: js.Any, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def remove(params: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def remove(success: js.Function): js.Thenable[HttpResponse] = js.native
-    def remove(success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def remove(success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
+    def remove(): js.Thenable[HttpResponse]
+    def remove(params: js.Any): js.Thenable[HttpResponse]
+    def remove(params: js.Any, data: js.Any): js.Thenable[HttpResponse]
+    def remove(params: js.Any, data: js.Any, success: js.Function): js.Thenable[HttpResponse]
+    def remove(params: js.Any, data: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def remove(params: js.Any, data: js.Any, success: Unit, error: js.Function): js.Thenable[HttpResponse]
+    def remove(params: js.Any, data: Unit, success: js.Function): js.Thenable[HttpResponse]
+    def remove(params: js.Any, data: Unit, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def remove(params: js.Any, data: Unit, success: Unit, error: js.Function): js.Thenable[HttpResponse]
+    def remove(params: js.Any, success: js.Function): js.Thenable[HttpResponse]
+    def remove(params: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def remove(success: js.Function): js.Thenable[HttpResponse]
+    def remove(success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def remove(success: Unit, error: js.Function): js.Thenable[HttpResponse]
     @JSName("remove")
-    var remove_Original: ResourceMethod = js.native
+    var remove_Original: ResourceMethod
     
-    def save(): js.Thenable[HttpResponse] = js.native
-    def save(params: js.Any): js.Thenable[HttpResponse] = js.native
-    def save(params: js.Any, data: js.Any): js.Thenable[HttpResponse] = js.native
-    def save(params: js.Any, data: js.Any, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def save(params: js.Any, data: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def save(params: js.Any, data: js.Any, success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def save(params: js.Any, data: Unit, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def save(params: js.Any, data: Unit, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def save(params: js.Any, data: Unit, success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def save(params: js.Any, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def save(params: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def save(success: js.Function): js.Thenable[HttpResponse] = js.native
-    def save(success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def save(success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
+    def save(): js.Thenable[HttpResponse]
+    def save(params: js.Any): js.Thenable[HttpResponse]
+    def save(params: js.Any, data: js.Any): js.Thenable[HttpResponse]
+    def save(params: js.Any, data: js.Any, success: js.Function): js.Thenable[HttpResponse]
+    def save(params: js.Any, data: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def save(params: js.Any, data: js.Any, success: Unit, error: js.Function): js.Thenable[HttpResponse]
+    def save(params: js.Any, data: Unit, success: js.Function): js.Thenable[HttpResponse]
+    def save(params: js.Any, data: Unit, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def save(params: js.Any, data: Unit, success: Unit, error: js.Function): js.Thenable[HttpResponse]
+    def save(params: js.Any, success: js.Function): js.Thenable[HttpResponse]
+    def save(params: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def save(success: js.Function): js.Thenable[HttpResponse]
+    def save(success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def save(success: Unit, error: js.Function): js.Thenable[HttpResponse]
     @JSName("save")
-    var save_Original: ResourceMethod = js.native
+    var save_Original: ResourceMethod
     
-    def update(): js.Thenable[HttpResponse] = js.native
-    def update(params: js.Any): js.Thenable[HttpResponse] = js.native
-    def update(params: js.Any, data: js.Any): js.Thenable[HttpResponse] = js.native
-    def update(params: js.Any, data: js.Any, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def update(params: js.Any, data: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def update(params: js.Any, data: js.Any, success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def update(params: js.Any, data: Unit, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def update(params: js.Any, data: Unit, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def update(params: js.Any, data: Unit, success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def update(params: js.Any, success: js.Function): js.Thenable[HttpResponse] = js.native
-    def update(params: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def update(success: js.Function): js.Thenable[HttpResponse] = js.native
-    def update(success: js.Function, error: js.Function): js.Thenable[HttpResponse] = js.native
-    def update(success: Unit, error: js.Function): js.Thenable[HttpResponse] = js.native
+    def update(): js.Thenable[HttpResponse]
+    def update(params: js.Any): js.Thenable[HttpResponse]
+    def update(params: js.Any, data: js.Any): js.Thenable[HttpResponse]
+    def update(params: js.Any, data: js.Any, success: js.Function): js.Thenable[HttpResponse]
+    def update(params: js.Any, data: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def update(params: js.Any, data: js.Any, success: Unit, error: js.Function): js.Thenable[HttpResponse]
+    def update(params: js.Any, data: Unit, success: js.Function): js.Thenable[HttpResponse]
+    def update(params: js.Any, data: Unit, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def update(params: js.Any, data: Unit, success: Unit, error: js.Function): js.Thenable[HttpResponse]
+    def update(params: js.Any, success: js.Function): js.Thenable[HttpResponse]
+    def update(params: js.Any, success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def update(success: js.Function): js.Thenable[HttpResponse]
+    def update(success: js.Function, error: js.Function): js.Thenable[HttpResponse]
+    def update(success: Unit, error: js.Function): js.Thenable[HttpResponse]
     @JSName("update")
-    var update_Original: ResourceMethod = js.native
+    var update_Original: ResourceMethod
   }
   object ResourceMethods {
     
@@ -619,32 +611,31 @@ object vuejs {
     var actions: ResourceActions = js.native
   }
   
-  @js.native
   trait Vue extends StObject {
     
     @JSName("$http")
-    def $http(options: HttpOptions): js.Thenable[HttpResponse] = js.native
+    def $http(options: HttpOptions): js.Thenable[HttpResponse]
     @JSName("$http")
-    var $http_Original: Call = js.native
+    var $http_Original: Call
     
     @JSName("$resource")
-    def $resource(url: String): ResourceMethods = js.native
+    def $resource(url: String): ResourceMethods
     @JSName("$resource")
-    def $resource(url: String, params: js.Object): ResourceMethods = js.native
+    def $resource(url: String, params: js.Object): ResourceMethods
     @JSName("$resource")
-    def $resource(url: String, params: js.Object, actions: js.Any): ResourceMethods = js.native
+    def $resource(url: String, params: js.Object, actions: js.Any): ResourceMethods
     @JSName("$resource")
-    def $resource(url: String, params: js.Object, actions: js.Any, options: HttpOptions): ResourceMethods = js.native
+    def $resource(url: String, params: js.Object, actions: js.Any, options: HttpOptions): ResourceMethods
     @JSName("$resource")
-    def $resource(url: String, params: js.Object, actions: Unit, options: HttpOptions): ResourceMethods = js.native
+    def $resource(url: String, params: js.Object, actions: Unit, options: HttpOptions): ResourceMethods
     @JSName("$resource")
-    def $resource(url: String, params: Unit, actions: js.Any): ResourceMethods = js.native
+    def $resource(url: String, params: Unit, actions: js.Any): ResourceMethods
     @JSName("$resource")
-    def $resource(url: String, params: Unit, actions: js.Any, options: HttpOptions): ResourceMethods = js.native
+    def $resource(url: String, params: Unit, actions: js.Any, options: HttpOptions): ResourceMethods
     @JSName("$resource")
-    def $resource(url: String, params: Unit, actions: Unit, options: HttpOptions): ResourceMethods = js.native
+    def $resource(url: String, params: Unit, actions: Unit, options: HttpOptions): ResourceMethods
     @JSName("$resource")
-    var $resource_Original: resource = js.native
+    var $resource_Original: resource
   }
   object Vue {
     
@@ -670,12 +661,11 @@ object vuejs {
     }
   }
   
-  @js.native
   trait VueStatic extends StObject {
     
-    var http: Http_ = js.native
+    var http: Http_
     
-    var resource: Resource_ = js.native
+    var resource: Resource_
   }
   object VueStatic {
     

--- a/tests/vue/check/v/vue-scrollto/build.sbt
+++ b/tests/vue/check/v/vue-scrollto/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "vue-scrollto"
-version := "2.7-2ad236"
+version := "2.7-25ec75"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-b9c231",
-  "org.scalablytyped" %%% "vue" % "2.5.13-c2fcf3")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-dcb159",
+  "org.scalablytyped" %%% "vue" % "2.5.13-ea809d")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/vue/check/v/vue-scrollto/src/main/scala/typings/vueScrollto/mod.scala
+++ b/tests/vue/check/v/vue-scrollto/src/main/scala/typings/vueScrollto/mod.scala
@@ -13,7 +13,30 @@ object mod {
   @js.native
   class ^ ()
     extends StObject
-       with VueScrollTo
+       with VueScrollTo {
+    
+    /* CompleteClass */
+    override def scrollTo(element: String): Unit = js.native
+    /* CompleteClass */
+    override def scrollTo(element: String, duration: Double): Unit = js.native
+    /* CompleteClass */
+    override def scrollTo(element: String, duration: Double, options: Options): Unit = js.native
+    /* CompleteClass */
+    override def scrollTo(element: String, options: Options): Unit = js.native
+    /* CompleteClass */
+    override def scrollTo(element: Element): Unit = js.native
+    /* CompleteClass */
+    override def scrollTo(element: Element, duration: Double): Unit = js.native
+    /* CompleteClass */
+    override def scrollTo(element: Element, duration: Double, options: Options): Unit = js.native
+    /* CompleteClass */
+    override def scrollTo(element: Element, options: Options): Unit = js.native
+    /* CompleteClass */
+    override def scrollTo(options: Options): Unit = js.native
+    /* CompleteClass */
+    @JSName("scrollTo")
+    var scrollTo_Original: VueStatic = js.native
+  }
   @JSImport("vue-scrollto", JSImport.Namespace)
   @js.native
   val ^ : js.Any = js.native
@@ -25,41 +48,40 @@ object mod {
   @scala.inline
   def install_=(x: PluginFunction[scala.Nothing]): Unit = ^.asInstanceOf[js.Dynamic].updateDynamic("install")(x.asInstanceOf[js.Any])
   
-  @js.native
   trait Options extends StObject {
     
     // Indicates if user can cancel the scroll or not. Default: true
-    var cancelable: js.UndefOr[Boolean] = js.native
+    var cancelable: js.UndefOr[Boolean] = js.undefined
     
     // The container that has to be scrolled. Default: body
-    var container: js.UndefOr[String | Element] = js.native
+    var container: js.UndefOr[String | Element] = js.undefined
     
     // The duration (in milliseconds) of the scrolling animation. Default: 500
-    var duration: js.UndefOr[Double] = js.native
+    var duration: js.UndefOr[Double] = js.undefined
     
     // The easing to be used when animating. Default: ease
-    var easing: js.UndefOr[String] = js.native
+    var easing: js.UndefOr[String] = js.undefined
     
     // The element you want to scroll to.
-    var el: js.UndefOr[String | Element] = js.native
+    var el: js.UndefOr[String | Element] = js.undefined
     
-    var element: js.UndefOr[String | Element] = js.native
+    var element: js.UndefOr[String | Element] = js.undefined
     
     // The offset that should be applied when scrolling. Default: 0
-    var offset: js.UndefOr[Double] = js.native
+    var offset: js.UndefOr[Double] = js.undefined
     
     // A callback function that should be called when scrolling has been aborted by the user (user scrolled, clicked
     // etc.). Default: noop
-    var onCancel: js.UndefOr[js.Function0[Unit] | `false`] = js.native
+    var onCancel: js.UndefOr[js.Function0[Unit] | `false`] = js.undefined
     
     // A callback function that should be called when scrolling has ended. Default: noop
-    var onDone: js.UndefOr[js.Function0[Unit] | `false`] = js.native
+    var onDone: js.UndefOr[js.Function0[Unit] | `false`] = js.undefined
     
     // Whether or not we want scrolling on the x axis. Default: true
-    var x: js.UndefOr[Boolean] = js.native
+    var x: js.UndefOr[Boolean] = js.undefined
     
     // Whether or not we want scrolling on the y axis. Default: true
-    var y: js.UndefOr[Boolean] = js.native
+    var y: js.UndefOr[Boolean] = js.undefined
   }
   object Options {
     
@@ -146,20 +168,19 @@ object mod {
     }
   }
   
-  @js.native
   trait VueScrollTo extends StObject {
     
-    def scrollTo(element: String): Unit = js.native
-    def scrollTo(element: String, duration: Double): Unit = js.native
-    def scrollTo(element: String, duration: Double, options: Options): Unit = js.native
-    def scrollTo(element: String, options: Options): Unit = js.native
-    def scrollTo(element: Element): Unit = js.native
-    def scrollTo(element: Element, duration: Double): Unit = js.native
-    def scrollTo(element: Element, duration: Double, options: Options): Unit = js.native
-    def scrollTo(element: Element, options: Options): Unit = js.native
-    def scrollTo(options: Options): Unit = js.native
+    def scrollTo(element: String): Unit
+    def scrollTo(element: String, duration: Double): Unit
+    def scrollTo(element: String, duration: Double, options: Options): Unit
+    def scrollTo(element: String, options: Options): Unit
+    def scrollTo(element: Element): Unit
+    def scrollTo(element: Element, duration: Double): Unit
+    def scrollTo(element: Element, duration: Double, options: Options): Unit
+    def scrollTo(element: Element, options: Options): Unit
+    def scrollTo(options: Options): Unit
     @JSName("scrollTo")
-    var scrollTo_Original: VueStatic = js.native
+    var scrollTo_Original: VueStatic
   }
   object VueScrollTo {
     
@@ -193,29 +214,28 @@ object mod {
   
   object vueTypesVueAugmentingMod {
     
-    @js.native
     trait Vue extends StObject {
       
       @JSName("$scrollTo")
-      def $scrollTo(element: String): Unit = js.native
+      def $scrollTo(element: String): Unit
       @JSName("$scrollTo")
-      def $scrollTo(element: String, duration: Double): Unit = js.native
+      def $scrollTo(element: String, duration: Double): Unit
       @JSName("$scrollTo")
-      def $scrollTo(element: String, duration: Double, options: Options): Unit = js.native
+      def $scrollTo(element: String, duration: Double, options: Options): Unit
       @JSName("$scrollTo")
-      def $scrollTo(element: String, options: Options): Unit = js.native
+      def $scrollTo(element: String, options: Options): Unit
       @JSName("$scrollTo")
-      def $scrollTo(element: Element): Unit = js.native
+      def $scrollTo(element: Element): Unit
       @JSName("$scrollTo")
-      def $scrollTo(element: Element, duration: Double): Unit = js.native
+      def $scrollTo(element: Element, duration: Double): Unit
       @JSName("$scrollTo")
-      def $scrollTo(element: Element, duration: Double, options: Options): Unit = js.native
+      def $scrollTo(element: Element, duration: Double, options: Options): Unit
       @JSName("$scrollTo")
-      def $scrollTo(element: Element, options: Options): Unit = js.native
+      def $scrollTo(element: Element, options: Options): Unit
       @JSName("$scrollTo")
-      def $scrollTo(options: Options): Unit = js.native
+      def $scrollTo(options: Options): Unit
       @JSName("$scrollTo")
-      var $scrollTo_Original: VueStatic = js.native
+      var $scrollTo_Original: VueStatic
     }
     object Vue {
       

--- a/tests/vue/check/v/vue/build.sbt
+++ b/tests/vue/check/v/vue/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "vue"
-version := "2.5.13-c2fcf3"
+version := "2.5.13-ea809d"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-b9c231")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-dcb159")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/vue/check/v/vue/src/main/scala/typings/vue/anon.scala
+++ b/tests/vue/check/v/vue/src/main/scala/typings/vue/anon.scala
@@ -10,12 +10,11 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Default extends StObject {
     
-    var default: js.UndefOr[js.Any] = js.native
+    var default: js.UndefOr[js.Any] = js.undefined
     
-    var from: js.UndefOr[InjectKey] = js.native
+    var from: js.UndefOr[InjectKey] = js.undefined
   }
   object Default {
     
@@ -42,12 +41,11 @@ object anon {
     }
   }
   
-  @js.native
   trait Event extends StObject {
     
-    var event: js.UndefOr[String] = js.native
+    var event: js.UndefOr[String] = js.undefined
     
-    var prop: js.UndefOr[String] = js.native
+    var prop: js.UndefOr[String] = js.undefined
   }
   object Event {
     
@@ -93,12 +91,11 @@ object anon {
     extends StObject
        with Instantiable1[/* args (repeated) */ js.Any, T & js.Object]
   
-  @js.native
   trait Render extends StObject {
     
-    var render: js.Function = js.native
+    var render: js.Function
     
-    var staticRenderFns: js.Array[js.Function] = js.native
+    var staticRenderFns: js.Array[js.Function]
   }
   object Render {
     
@@ -122,12 +119,11 @@ object anon {
     }
   }
   
-  @js.native
   trait StaticRenderFns extends StObject {
     
-    def render(createElement: CreateElement): VNode = js.native
+    def render(createElement: CreateElement): VNode
     
-    var staticRenderFns: js.Array[js.Function0[VNode]] = js.native
+    var staticRenderFns: js.Array[js.Function0[VNode]]
   }
   object StaticRenderFns {
     

--- a/tests/vue/check/v/vue/src/main/scala/typings/vue/optionsMod.scala
+++ b/tests/vue/check/v/vue/src/main/scala/typings/vue/optionsMod.scala
@@ -40,44 +40,43 @@ object optionsMod {
   
   type Component[Data, Methods, Computed, Props] = VueConstructor[Vue] | (FunctionalComponentOptions[Props, PropsDefinition[Props]]) | (ComponentOptions[Vue, Data, Methods, Computed, Props])
   
-  @js.native
   trait ComponentOptions[V /* <: Vue */, Data, Methods, Computed, PropsDef] extends StObject {
     
-    var activated: js.UndefOr[js.Function0[Unit]] = js.native
+    var activated: js.UndefOr[js.Function0[Unit]] = js.undefined
     
-    var beforeCreate: js.UndefOr[js.ThisFunction0[/* this */ V, Unit]] = js.native
+    var beforeCreate: js.UndefOr[js.ThisFunction0[/* this */ V, Unit]] = js.undefined
     
-    var beforeDestroy: js.UndefOr[js.Function0[Unit]] = js.native
+    var beforeDestroy: js.UndefOr[js.Function0[Unit]] = js.undefined
     
-    var beforeMount: js.UndefOr[js.Function0[Unit]] = js.native
+    var beforeMount: js.UndefOr[js.Function0[Unit]] = js.undefined
     
-    var beforeUpdate: js.UndefOr[js.Function0[Unit]] = js.native
+    var beforeUpdate: js.UndefOr[js.Function0[Unit]] = js.undefined
     
-    var comments: js.UndefOr[Boolean] = js.native
+    var comments: js.UndefOr[Boolean] = js.undefined
     
     var components: js.UndefOr[
         StringDictionary[
           (Component[js.Any, js.Any, js.Any, js.Any]) | (AsyncComponent[js.Any, js.Any, js.Any, js.Any])
         ]
-      ] = js.native
+      ] = js.undefined
     
-    var computed: js.UndefOr[Accessors[Computed]] = js.native
+    var computed: js.UndefOr[Accessors[Computed]] = js.undefined
     
-    var created: js.UndefOr[js.Function0[Unit]] = js.native
+    var created: js.UndefOr[js.Function0[Unit]] = js.undefined
     
-    var data: js.UndefOr[Data] = js.native
+    var data: js.UndefOr[Data] = js.undefined
     
-    var deactivated: js.UndefOr[js.Function0[Unit]] = js.native
+    var deactivated: js.UndefOr[js.Function0[Unit]] = js.undefined
     
-    var delimiters: js.UndefOr[js.Tuple2[String, String]] = js.native
+    var delimiters: js.UndefOr[js.Tuple2[String, String]] = js.undefined
     
-    var destroyed: js.UndefOr[js.Function0[Unit]] = js.native
+    var destroyed: js.UndefOr[js.Function0[Unit]] = js.undefined
     
-    var directives: js.UndefOr[StringDictionary[DirectiveFunction | DirectiveOptions]] = js.native
+    var directives: js.UndefOr[StringDictionary[DirectiveFunction | DirectiveOptions]] = js.undefined
     
-    var el: js.UndefOr[Element | String] = js.native
+    var el: js.UndefOr[Element | String] = js.undefined
     
-    var errorCaptured: js.UndefOr[js.Function0[Boolean | Unit]] = js.native
+    var errorCaptured: js.UndefOr[js.Function0[Boolean | Unit]] = js.undefined
     
     // TODO: support properly inferred 'extends'
     var `extends`: js.UndefOr[
@@ -88,15 +87,15 @@ object optionsMod {
           DefaultComputed, 
           PropsDefinition[DefaultProps]
         ]) | VueConstructor[Vue]
-      ] = js.native
+      ] = js.undefined
     
-    var filters: js.UndefOr[StringDictionary[js.Function]] = js.native
+    var filters: js.UndefOr[StringDictionary[js.Function]] = js.undefined
     
-    var inheritAttrs: js.UndefOr[Boolean] = js.native
+    var inheritAttrs: js.UndefOr[Boolean] = js.undefined
     
-    var inject: js.UndefOr[InjectOptions] = js.native
+    var inject: js.UndefOr[InjectOptions] = js.undefined
     
-    var methods: js.UndefOr[Methods] = js.native
+    var methods: js.UndefOr[Methods] = js.undefined
     
     var mixins: js.UndefOr[
         js.Array[
@@ -108,35 +107,35 @@ object optionsMod {
             PropsDefinition[DefaultProps]
           ]) | VueConstructor[Vue]
         ]
-      ] = js.native
+      ] = js.undefined
     
-    var model: js.UndefOr[Event] = js.native
+    var model: js.UndefOr[Event] = js.undefined
     
-    var mounted: js.UndefOr[js.Function0[Unit]] = js.native
+    var mounted: js.UndefOr[js.Function0[Unit]] = js.undefined
     
-    var name: js.UndefOr[String] = js.native
+    var name: js.UndefOr[String] = js.undefined
     
-    var parent: js.UndefOr[Vue] = js.native
+    var parent: js.UndefOr[Vue] = js.undefined
     
-    var props: js.UndefOr[PropsDef] = js.native
+    var props: js.UndefOr[PropsDef] = js.undefined
     
-    var propsData: js.UndefOr[js.Object] = js.native
+    var propsData: js.UndefOr[js.Object] = js.undefined
     
-    var provide: js.UndefOr[js.Object | js.Function0[js.Object]] = js.native
+    var provide: js.UndefOr[js.Object | js.Function0[js.Object]] = js.undefined
     
-    var render: js.UndefOr[js.Function1[/* createElement */ CreateElement, VNode]] = js.native
+    var render: js.UndefOr[js.Function1[/* createElement */ CreateElement, VNode]] = js.undefined
     
-    var renderError: js.UndefOr[js.Function2[/* h */ js.Function0[VNode], /* err */ Error, VNode]] = js.native
+    var renderError: js.UndefOr[js.Function2[/* h */ js.Function0[VNode], /* err */ Error, VNode]] = js.undefined
     
-    var staticRenderFns: js.UndefOr[js.Array[js.Function1[/* createElement */ CreateElement, VNode]]] = js.native
+    var staticRenderFns: js.UndefOr[js.Array[js.Function1[/* createElement */ CreateElement, VNode]]] = js.undefined
     
-    var template: js.UndefOr[String] = js.native
+    var template: js.UndefOr[String] = js.undefined
     
-    var transitions: js.UndefOr[StringDictionary[js.Object]] = js.native
+    var transitions: js.UndefOr[StringDictionary[js.Object]] = js.undefined
     
-    var updated: js.UndefOr[js.Function0[Unit]] = js.native
+    var updated: js.UndefOr[js.Function0[Unit]] = js.undefined
     
-    var watch: js.UndefOr[Record[String, WatchOptionsWithHandler[js.Any] | WatchHandler[js.Any] | String]] = js.native
+    var watch: js.UndefOr[Record[String, WatchOptionsWithHandler[js.Any] | WatchHandler[js.Any] | String]] = js.undefined
   }
   object ComponentOptions {
     
@@ -409,14 +408,13 @@ object optionsMod {
     }
   }
   
-  @js.native
   trait ComputedOptions[T] extends StObject {
     
-    var cache: js.UndefOr[Boolean] = js.native
+    var cache: js.UndefOr[Boolean] = js.undefined
     
-    var get: js.UndefOr[js.Function0[T]] = js.native
+    var get: js.UndefOr[js.Function0[T]] = js.undefined
     
-    var set: js.UndefOr[js.Function1[/* value */ T, Unit]] = js.native
+    var set: js.UndefOr[js.Function1[/* value */ T, Unit]] = js.undefined
   }
   object ComputedOptions {
     
@@ -470,18 +468,17 @@ object optionsMod {
     Unit
   ]
   
-  @js.native
   trait DirectiveOptions extends StObject {
     
-    var bind: js.UndefOr[DirectiveFunction] = js.native
+    var bind: js.UndefOr[DirectiveFunction] = js.undefined
     
-    var componentUpdated: js.UndefOr[DirectiveFunction] = js.native
+    var componentUpdated: js.UndefOr[DirectiveFunction] = js.undefined
     
-    var inserted: js.UndefOr[DirectiveFunction] = js.native
+    var inserted: js.UndefOr[DirectiveFunction] = js.undefined
     
-    var unbind: js.UndefOr[DirectiveFunction] = js.native
+    var unbind: js.UndefOr[DirectiveFunction] = js.undefined
     
-    var update: js.UndefOr[DirectiveFunction] = js.native
+    var update: js.UndefOr[DirectiveFunction] = js.undefined
   }
   object DirectiveOptions {
     
@@ -536,10 +533,9 @@ object optionsMod {
     }
   }
   
-  @js.native
   trait EsModuleComponent extends StObject {
     
-    var default: Component[DefaultData[Vue], DefaultMethods[Vue], DefaultComputed, DefaultProps] = js.native
+    var default: Component[DefaultData[Vue], DefaultMethods[Vue], DefaultComputed, DefaultProps]
   }
   object EsModuleComponent {
     
@@ -557,18 +553,17 @@ object optionsMod {
     }
   }
   
-  @js.native
   trait FunctionalComponentOptions[Props, PropDefs] extends StObject {
     
-    var functional: Boolean = js.native
+    var functional: Boolean
     
-    var inject: js.UndefOr[InjectOptions] = js.native
+    var inject: js.UndefOr[InjectOptions] = js.undefined
     
-    var name: js.UndefOr[String] = js.native
+    var name: js.UndefOr[String] = js.undefined
     
-    var props: js.UndefOr[PropDefs] = js.native
+    var props: js.UndefOr[PropDefs] = js.undefined
     
-    def render(createElement: CreateElement, context: RenderContext[Props]): VNode = js.native
+    def render(createElement: CreateElement, context: RenderContext[Props]): VNode
   }
   object FunctionalComponentOptions {
     
@@ -616,16 +611,15 @@ object optionsMod {
   
   type Prop[T] = js.Function0[T] | Instantiable[T]
   
-  @js.native
   trait PropOptions[T] extends StObject {
     
-    var default: js.UndefOr[T | Null | js.Function0[js.Object]] = js.native
+    var default: js.UndefOr[T | Null | js.Function0[js.Object]] = js.undefined
     
-    var required: js.UndefOr[Boolean] = js.native
+    var required: js.UndefOr[Boolean] = js.undefined
     
-    var `type`: js.UndefOr[Prop[T] | js.Array[Prop[T]]] = js.native
+    var `type`: js.UndefOr[Prop[T] | js.Array[Prop[T]]] = js.undefined
     
-    var validator: js.UndefOr[js.Function1[/* value */ T, Boolean]] = js.native
+    var validator: js.UndefOr[js.Function1[/* value */ T, Boolean]] = js.undefined
   }
   object PropOptions {
     
@@ -684,20 +678,19 @@ object optionsMod {
   {[ K in keyof T ]: vue.vue/types/options.PropValidator<T[K]>}
     */ typings.vue.vueStrings.RecordPropsDefinition & TopLevel[T]
   
-  @js.native
   trait RenderContext[Props] extends StObject {
     
-    var children: js.Array[VNode] = js.native
+    var children: js.Array[VNode]
     
-    var data: VNodeData = js.native
+    var data: VNodeData
     
-    var injections: js.Any = js.native
+    var injections: js.Any
     
-    var parent: Vue = js.native
+    var parent: Vue
     
-    var props: Props = js.native
+    var props: Props
     
-    def slots(): js.Any = js.native
+    def slots(): js.Any
   }
   object RenderContext {
     
@@ -741,8 +734,7 @@ object optionsMod {
   }
   
   /* import warning: RemoveDifficultInheritance.summarizeChanges 
-  - Dropped object */ @js.native
-  trait ThisTypedComponentOptionsWithArrayProps[V /* <: Vue */, Data, Methods, Computed, PropNames /* <: String */]
+  - Dropped object */ trait ThisTypedComponentOptionsWithArrayProps[V /* <: Vue */, Data, Methods, Computed, PropNames /* <: String */]
     extends StObject
        with ComponentOptions[
           V, 
@@ -762,8 +754,7 @@ object optionsMod {
   }
   
   /* import warning: RemoveDifficultInheritance.summarizeChanges 
-  - Dropped object */ @js.native
-  trait ThisTypedComponentOptionsWithRecordProps[V /* <: Vue */, Data, Methods, Computed, Props]
+  - Dropped object */ trait ThisTypedComponentOptionsWithRecordProps[V /* <: Vue */, Data, Methods, Computed, Props]
     extends StObject
        with ComponentOptions[
           V, 
@@ -784,12 +775,11 @@ object optionsMod {
   
   type WatchHandler[T] = js.Function2[/* val */ T, /* oldVal */ T, Unit]
   
-  @js.native
   trait WatchOptions extends StObject {
     
-    var deep: js.UndefOr[Boolean] = js.native
+    var deep: js.UndefOr[Boolean] = js.undefined
     
-    var immediate: js.UndefOr[Boolean] = js.native
+    var immediate: js.UndefOr[Boolean] = js.undefined
   }
   object WatchOptions {
     
@@ -816,14 +806,13 @@ object optionsMod {
     }
   }
   
-  @js.native
   trait WatchOptionsWithHandler[T]
     extends StObject
        with WatchOptions {
     
-    def handler(`val`: T, oldVal: T): Unit = js.native
+    def handler(`val`: T, oldVal: T): Unit
     @JSName("handler")
-    var handler_Original: WatchHandler[T] = js.native
+    var handler_Original: WatchHandler[T]
   }
   object WatchOptionsWithHandler {
     

--- a/tests/vue/check/v/vue/src/main/scala/typings/vue/pluginMod.scala
+++ b/tests/vue/check/v/vue/src/main/scala/typings/vue/pluginMod.scala
@@ -11,15 +11,14 @@ object pluginMod {
   
   type PluginFunction[T] = js.Function2[/* Vue */ VueConstructor[Vue], /* options */ js.UndefOr[T], Unit]
   
-  @js.native
   trait PluginObject[T]
     extends StObject
        with /* key */ StringDictionary[js.Any] {
     
-    def install(Vue: VueConstructor[Vue]): Unit = js.native
-    def install(Vue: VueConstructor[Vue], options: T): Unit = js.native
+    def install(Vue: VueConstructor[Vue]): Unit
+    def install(Vue: VueConstructor[Vue], options: T): Unit
     @JSName("install")
-    var install_Original: PluginFunction[T] = js.native
+    var install_Original: PluginFunction[T]
   }
   object PluginObject {
     

--- a/tests/vue/check/v/vue/src/main/scala/typings/vue/vnodeMod.scala
+++ b/tests/vue/check/v/vue/src/main/scala/typings/vue/vnodeMod.scala
@@ -14,38 +14,37 @@ object vnodeMod {
   
   type ScopedSlot = js.Function1[/* props */ js.Any, VNodeChildrenArrayContents | String]
   
-  @js.native
   trait VNode extends StObject {
     
-    var children: js.UndefOr[js.Array[VNode]] = js.native
+    var children: js.UndefOr[js.Array[VNode]] = js.undefined
     
-    var componentInstance: js.UndefOr[Vue] = js.native
+    var componentInstance: js.UndefOr[Vue] = js.undefined
     
-    var componentOptions: js.UndefOr[VNodeComponentOptions] = js.native
+    var componentOptions: js.UndefOr[VNodeComponentOptions] = js.undefined
     
-    var context: js.UndefOr[Vue] = js.native
+    var context: js.UndefOr[Vue] = js.undefined
     
-    var data: js.UndefOr[VNodeData] = js.native
+    var data: js.UndefOr[VNodeData] = js.undefined
     
-    var elm: js.UndefOr[Node] = js.native
+    var elm: js.UndefOr[Node] = js.undefined
     
-    var isComment: Boolean = js.native
+    var isComment: Boolean
     
-    var isRootInsert: Boolean = js.native
+    var isRootInsert: Boolean
     
-    var isStatic: js.UndefOr[Boolean] = js.native
+    var isStatic: js.UndefOr[Boolean] = js.undefined
     
-    var key: js.UndefOr[String | Double] = js.native
+    var key: js.UndefOr[String | Double] = js.undefined
     
-    var ns: js.UndefOr[String] = js.native
+    var ns: js.UndefOr[String] = js.undefined
     
-    var parent: js.UndefOr[VNode] = js.native
+    var parent: js.UndefOr[VNode] = js.undefined
     
-    var raw: js.UndefOr[Boolean] = js.native
+    var raw: js.UndefOr[Boolean] = js.undefined
     
-    var tag: js.UndefOr[String] = js.native
+    var tag: js.UndefOr[String] = js.undefined
     
-    var text: js.UndefOr[String] = js.native
+    var text: js.UndefOr[String] = js.undefined
   }
   object VNode {
     
@@ -149,7 +148,6 @@ object vnodeMod {
   
   type VNodeChildren = VNodeChildrenArrayContents | js.Array[ScopedSlot] | String
   
-  @js.native
   trait VNodeChildrenArrayContents
     extends StObject
        with /* x */ NumberDictionary[VNode | String | VNodeChildren]
@@ -162,18 +160,17 @@ object vnodeMod {
     }
   }
   
-  @js.native
   trait VNodeComponentOptions extends StObject {
     
-    var Ctor: VueConstructor[Vue] = js.native
+    var Ctor: VueConstructor[Vue]
     
-    var children: js.UndefOr[VNodeChildren] = js.native
+    var children: js.UndefOr[VNodeChildren] = js.undefined
     
-    var listeners: js.UndefOr[js.Object] = js.native
+    var listeners: js.UndefOr[js.Object] = js.undefined
     
-    var propsData: js.UndefOr[js.Object] = js.native
+    var propsData: js.UndefOr[js.Object] = js.undefined
     
-    var tag: js.UndefOr[String] = js.native
+    var tag: js.UndefOr[String] = js.undefined
   }
   object VNodeComponentOptions {
     
@@ -218,48 +215,47 @@ object vnodeMod {
     }
   }
   
-  @js.native
   trait VNodeData extends StObject {
     
-    var attrs: js.UndefOr[StringDictionary[js.Any]] = js.native
+    var attrs: js.UndefOr[StringDictionary[js.Any]] = js.undefined
     
-    var `class`: js.UndefOr[js.Any] = js.native
+    var `class`: js.UndefOr[js.Any] = js.undefined
     
-    var directives: js.UndefOr[js.Array[VNodeDirective]] = js.native
+    var directives: js.UndefOr[js.Array[VNodeDirective]] = js.undefined
     
-    var domProps: js.UndefOr[StringDictionary[js.Any]] = js.native
+    var domProps: js.UndefOr[StringDictionary[js.Any]] = js.undefined
     
-    var hook: js.UndefOr[StringDictionary[js.Function]] = js.native
+    var hook: js.UndefOr[StringDictionary[js.Function]] = js.undefined
     
-    var inlineTemplate: js.UndefOr[Render] = js.native
+    var inlineTemplate: js.UndefOr[Render] = js.undefined
     
-    var keepAlive: js.UndefOr[Boolean] = js.native
+    var keepAlive: js.UndefOr[Boolean] = js.undefined
     
-    var key: js.UndefOr[String | Double] = js.native
+    var key: js.UndefOr[String | Double] = js.undefined
     
-    var nativeOn: js.UndefOr[StringDictionary[js.Function | js.Array[js.Function]]] = js.native
+    var nativeOn: js.UndefOr[StringDictionary[js.Function | js.Array[js.Function]]] = js.undefined
     
-    var on: js.UndefOr[StringDictionary[js.Function | js.Array[js.Function]]] = js.native
+    var on: js.UndefOr[StringDictionary[js.Function | js.Array[js.Function]]] = js.undefined
     
-    var props: js.UndefOr[StringDictionary[js.Any]] = js.native
+    var props: js.UndefOr[StringDictionary[js.Any]] = js.undefined
     
-    var ref: js.UndefOr[String] = js.native
+    var ref: js.UndefOr[String] = js.undefined
     
-    var scopedSlots: js.UndefOr[StringDictionary[ScopedSlot]] = js.native
+    var scopedSlots: js.UndefOr[StringDictionary[ScopedSlot]] = js.undefined
     
-    var show: js.UndefOr[Boolean] = js.native
+    var show: js.UndefOr[Boolean] = js.undefined
     
-    var slot: js.UndefOr[String] = js.native
+    var slot: js.UndefOr[String] = js.undefined
     
-    var staticClass: js.UndefOr[String] = js.native
+    var staticClass: js.UndefOr[String] = js.undefined
     
-    var staticStyle: js.UndefOr[StringDictionary[js.Any]] = js.native
+    var staticStyle: js.UndefOr[StringDictionary[js.Any]] = js.undefined
     
-    var style: js.UndefOr[js.Array[js.Object] | js.Object] = js.native
+    var style: js.UndefOr[js.Array[js.Object] | js.Object] = js.undefined
     
-    var tag: js.UndefOr[String] = js.native
+    var tag: js.UndefOr[String] = js.undefined
     
-    var transition: js.UndefOr[js.Object] = js.native
+    var transition: js.UndefOr[js.Object] = js.undefined
   }
   object VNodeData {
     
@@ -400,20 +396,19 @@ object vnodeMod {
     }
   }
   
-  @js.native
   trait VNodeDirective extends StObject {
     
-    val arg: String = js.native
+    val arg: String
     
-    val expression: js.Any = js.native
+    val expression: js.Any
     
-    val modifiers: StringDictionary[Boolean] = js.native
+    val modifiers: StringDictionary[Boolean]
     
-    val name: String = js.native
+    val name: String
     
-    val oldValue: js.Any = js.native
+    val oldValue: js.Any
     
-    val value: js.Any = js.native
+    val value: js.Any
   }
   object VNodeDirective {
     

--- a/tests/vue/check/v/vue/src/main/scala/typings/vue/vueMod.scala
+++ b/tests/vue/check/v/vue/src/main/scala/typings/vue/vueMod.scala
@@ -372,26 +372,25 @@ object vueMod {
     (CombinedVueInstance[Instance, Data, Methods, Computed, Props]) & typings.vue.vueMod.Vue
   ]
   
-  @js.native
   trait VueConfiguration extends StObject {
     
-    var devtools: Boolean = js.native
+    var devtools: Boolean
     
-    def errorHandler(err: Error, vm: typings.vue.vueMod.Vue, info: String): Unit = js.native
+    def errorHandler(err: Error, vm: typings.vue.vueMod.Vue, info: String): Unit
     
-    var ignoredElements: js.Array[String | RegExp] = js.native
+    var ignoredElements: js.Array[String | RegExp]
     
-    var keyCodes: StringDictionary[Double | js.Array[Double]] = js.native
+    var keyCodes: StringDictionary[Double | js.Array[Double]]
     
-    var optionMergeStrategies: js.Any = js.native
+    var optionMergeStrategies: js.Any
     
-    var performance: Boolean = js.native
+    var performance: Boolean
     
-    var productionTip: Boolean = js.native
+    var productionTip: Boolean
     
-    var silent: Boolean = js.native
+    var silent: Boolean
     
-    def warnHandler(msg: String, vm: typings.vue.vueMod.Vue, trace: String): Unit = js.native
+    def warnHandler(msg: String, vm: typings.vue.vueMod.Vue, trace: String): Unit
   }
   object VueConfiguration {
     

--- a/tests/vue/check/w/webpack-env/build.sbt
+++ b/tests/vue/check/w/webpack-env/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "webpack-env"
-version := "1.13-b65c7d"
+version := "1.13-3b324f"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-b9c231")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-dcb159")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/vue/check/w/webpack-env/src/main/scala/typings/webpackEnv/WebpackModuleApi.scala
+++ b/tests/vue/check/w/webpack-env/src/main/scala/typings/webpackEnv/WebpackModuleApi.scala
@@ -9,18 +9,17 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object WebpackModuleApi {
   
-  @js.native
   trait AcceptOptions extends StObject {
     
     /**
       * Indicates that apply() is automatically called by check function
       */
-    var autoApply: js.UndefOr[Boolean] = js.native
+    var autoApply: js.UndefOr[Boolean] = js.undefined
     
     /**
       * If true the update process continues even if some modules are not accepted (and would bubble to the entry point).
       */
-    var ignoreUnaccepted: js.UndefOr[Boolean] = js.native
+    var ignoreUnaccepted: js.UndefOr[Boolean] = js.undefined
   }
   object AcceptOptions {
     
@@ -206,10 +205,9 @@ object WebpackModuleApi {
   /**
     * Inside env you can pass any variable
     */
-  @js.native
   trait NodeProcess extends StObject {
     
-    var env: js.UndefOr[js.Any] = js.native
+    var env: js.UndefOr[js.Any] = js.undefined
   }
   object NodeProcess {
     

--- a/tests/winston/check/w/winston/build.sbt
+++ b/tests/winston/check/w/winston/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "winston"
-version := "3.0.0-0537ec"
+version := "3.0.0-2138e2"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/winston/check/w/winston/src/main/scala/typings/winston/configMod.scala
+++ b/tests/winston/check/w/winston/src/main/scala/typings/winston/configMod.scala
@@ -15,10 +15,9 @@ object configMod extends Shortcut {
   
   type AbstractConfigSetLevels = StringDictionary[Double]
   
-  @js.native
   trait Config extends StObject {
     
-    var foo: bar = js.native
+    var foo: bar
   }
   object Config {
     

--- a/tests/winston/check/w/winston/src/main/scala/typings/winston/mod.scala
+++ b/tests/winston/check/w/winston/src/main/scala/typings/winston/mod.scala
@@ -12,10 +12,9 @@ object mod {
   @js.native
   val config: Config = js.native
   
-  @js.native
   trait LoggerOptions extends StObject {
     
-    var levels: js.UndefOr[AbstractConfigSetLevels] = js.native
+    var levels: js.UndefOr[AbstractConfigSetLevels] = js.undefined
   }
   object LoggerOptions {
     

--- a/tests/with-theme/check/r/react/build.sbt
+++ b/tests/with-theme/check/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-8151b5"
+version := "0.0-unknown-f0acae"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/with-theme/check/r/react/src/main/scala/typings/react/anon.scala
+++ b/tests/with-theme/check/r/react/src/main/scala/typings/react/anon.scala
@@ -6,10 +6,9 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object anon {
   
-  @js.native
   trait Html extends StObject {
     
-    var __html: String = js.native
+    var __html: String
   }
   object Html {
     

--- a/tests/with-theme/check/r/react/src/main/scala/typings/react/mod.scala
+++ b/tests/with-theme/check/r/react/src/main/scala/typings/react/mod.scala
@@ -8,14 +8,13 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object mod {
   
-  @js.native
   trait AllHTMLAttributes[T]
     extends StObject
        with HTMLAttributes[T] {
     
-    var accept: js.UndefOr[String] = js.native
+    var accept: js.UndefOr[String] = js.undefined
     
-    var acceptCharset: js.UndefOr[String] = js.native
+    var acceptCharset: js.UndefOr[String] = js.undefined
   }
   object AllHTMLAttributes {
     
@@ -42,18 +41,15 @@ object mod {
     }
   }
   
-  @js.native
   trait ComponentClass[P] extends StObject
   
-  @js.native
   trait ComponentType[P] extends StObject
   
-  @js.native
   trait DOMAttributes[T] extends StObject {
     
-    var children: js.UndefOr[ReactNode] = js.native
+    var children: js.UndefOr[ReactNode] = js.undefined
     
-    var dangerouslySetInnerHTML: js.UndefOr[Html] = js.native
+    var dangerouslySetInnerHTML: js.UndefOr[Html] = js.undefined
   }
   object DOMAttributes {
     
@@ -80,12 +76,11 @@ object mod {
     }
   }
   
-  @js.native
   trait HTMLAttributes[T]
     extends StObject
        with DOMAttributes[T] {
     
-    var defaultChecked: js.UndefOr[Boolean] = js.native
+    var defaultChecked: js.UndefOr[Boolean] = js.undefined
   }
   object HTMLAttributes {
     
@@ -106,18 +101,17 @@ object mod {
     }
   }
   
-  @js.native
   trait HTMLProps[T]
     extends StObject
        with AllHTMLAttributes[T] {
     
-    var defaultValue: foo = js.native
+    var defaultValue: foo
     
-    var onChange: foo = js.native
+    var onChange: foo
     
-    var `type`: foo = js.native
+    var `type`: foo
     
-    var value: foo = js.native
+    var value: foo
   }
   object HTMLProps {
     

--- a/tests/with-theme/check/s/std/build.sbt
+++ b/tests/with-theme/check/s/std/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-65c1a5"
+version := "0.0-unknown-3b1db7"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/with-theme/check/s/std/src/main/scala/typings/std/Foo.scala
+++ b/tests/with-theme/check/s/std/src/main/scala/typings/std/Foo.scala
@@ -4,10 +4,9 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait Foo extends StObject {
   
-  var f: js.UndefOr[js.Function1[/* n */ Double, String]] = js.native
+  var f: js.UndefOr[js.Function1[/* n */ Double, String]] = js.undefined
 }
 object Foo {
   

--- a/tests/with-theme/check/s/std/src/main/scala/typings/std/SomethingHasToBeHereApparently.scala
+++ b/tests/with-theme/check/s/std/src/main/scala/typings/std/SomethingHasToBeHereApparently.scala
@@ -4,5 +4,4 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
-@js.native
 trait SomethingHasToBeHereApparently extends StObject

--- a/tests/with-theme/check/w/with-theme/build.sbt
+++ b/tests/with-theme/check/w/with-theme/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "with-theme"
-version := "0.0-unknown-2865c9"
+version := "0.0-unknown-40faf1"
 scalaVersion := "3.0.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-8151b5",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-65c1a5")
+  "org.scalablytyped" %%% "react" % "0.0-unknown-f0acae",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-3b1db7")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/with-theme/check/w/with-theme/src/main/scala/typings/withTheme/mod.scala
+++ b/tests/with-theme/check/w/with-theme/src/main/scala/typings/withTheme/mod.scala
@@ -20,12 +20,11 @@ object mod {
   
   type ConsistentWith[T, U] = Pick[U, /* keyof T */ String]
   
-  @js.native
   trait WithTheme extends StObject {
     
-    var innerRef: js.UndefOr[Ref[js.Any] | RefObject[js.Any]] = js.native
+    var innerRef: js.UndefOr[Ref[js.Any] | RefObject[js.Any]] = js.undefined
     
-    var theme: String = js.native
+    var theme: String
   }
   object WithTheme {
     


### PR DESCRIPTION
Scala 3 seems to compile annotations so much faster it's feasible to enable `@ScalaJSDefined` by default now

Also Fix `@ScalaJSDefined` calculation by saying that types with unresolved parents have to be `@js.native`.