### PR TITLE
Include `npmDevDependencies` in `wantedLibs`

### DIFF
--- a/sbt-converter/src/main/scala/org/scalablytyped/converter/plugin/ScalablyTypedConverterGenSourcePlugin.scala
+++ b/sbt-converter/src/main/scala/org/scalablytyped/converter/plugin/ScalablyTypedConverterGenSourcePlugin.scala
@@ -91,7 +91,8 @@ object ScalablyTypedConverterGenSourcePlugin extends AutoPlugin {
         val cachedOutputs  = os.Path(streams.value.cacheDirectory / "output.json")
 
         val wantedLibs: SortedMap[TsIdentLibrary, String] = {
-          val allDeps = (Compile / npmDependencies).value ++ (Test / npmDependencies).value
+          val allDeps = (Compile / npmDependencies).value ++ (Compile / npmDevDependencies).value ++
+            (Test / npmDependencies).value ++ (Test / npmDevDependencies).value
           allDeps.map { case (name, version) => TsIdentLibrary(name) -> version }.toMap.toSorted
         }
 


### PR DESCRIPTION
This is convenient when you don't want downstreams to inherit the dependency to the type definitions. In fact, I would expect this is the case for nearly all facades.