### PR TITLE
Note which standard all members in std are from

### DIFF
--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/Phase1Res.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/Phase1Res.scala
@@ -23,9 +23,9 @@ object Phase1Res {
     def name: TsIdentLibrary = source.libName
   }
 
-  case class LibraryPart(file: FileAndInlinesRec, deps: SortedMap[Source, Phase1Res]) extends Phase1Res
+  case class LibTsFile(file: FileAndInlinesRec, deps: SortedMap[Source, Phase1Res]) extends Phase1Res
 
-  case class FileAndInlinesRec(file: TsParsedFile, toInline: SortedMap[Source, LibraryPart])
+  case class FileAndInlinesRec(file: TsParsedFile, toInline: SortedMap[Source, LibTsFile])
 
   case class FileAndInlinesFlat(file: TsParsedFile, toInline: SortedMap[Source, TsParsedFile])
 
@@ -55,7 +55,7 @@ object Phase1Res {
 
       def go(m: Map[Source, Phase1Res]): Unit =
         m.foreach {
-          case (s: TsHelperFile, libPart: LibraryPart) =>
+          case (s: TsHelperFile, libPart: LibTsFile) =>
             if (!libParts.contains(s)) {
               def flatten(os: Option[Source], _f: FileAndInlinesRec): SortedMap[Source, TsParsedFile] = {
                 val first: SortedMap[Source, TsParsedFile] =
@@ -65,7 +65,7 @@ object Phase1Res {
                   }
                 val rest: SortedMap[Source, TsParsedFile] =
                   _f.toInline.flatMap {
-                    case (s2, x: LibraryPart) =>
+                    case (s2, x: LibTsFile) =>
                       go(x.deps)
                       flatten(Some(s2), x.file)
                   }

--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/Phase2ToScalaJs.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/Phase2ToScalaJs.scala
@@ -3,7 +3,7 @@ package internal
 package importer
 
 import com.olvind.logging.Logger
-import org.scalablytyped.converter.internal.importer.Phase1Res.{LibTs, LibraryPart}
+import org.scalablytyped.converter.internal.importer.Phase1Res.{LibTs, LibTsFile}
 import org.scalablytyped.converter.internal.maps._
 import org.scalablytyped.converter.internal.phases.{GetDeps, IsCircular, Phase, PhaseRes}
 import org.scalablytyped.converter.internal.scalajs.CastConversion.TypeRewriterCast
@@ -43,7 +43,7 @@ class Phase2ToScalaJs(
       logger:     Logger[Unit],
   ): PhaseRes[Source, LibScalaJs] =
     current match {
-      case _: LibraryPart =>
+      case _: LibTsFile =>
         PhaseRes.Ignore()
 
       case lib: LibTs =>

--- a/ts/src/main/scala/org/scalablytyped/converter/internal/ts/transforms/AddComments.scala
+++ b/ts/src/main/scala/org/scalablytyped/converter/internal/ts/transforms/AddComments.scala
@@ -1,0 +1,15 @@
+package org.scalablytyped.converter.internal
+package ts
+package transforms
+
+case class AddComments(newComments: Comments) extends TreeTransformationUnit {
+  override def enterTsMember(t: Unit)(x: TsMember): TsMember =
+    x match {
+      case x: TsMemberCall       => x.copy(comments = x.comments ++ newComments)
+      case x: TsMemberCtor       => x.copy(comments = x.comments ++ newComments)
+      case x: TsMemberFunction   => x.copy(comments = x.comments ++ newComments)
+      case x: TsMemberIndex      => x.copy(comments = x.comments ++ newComments)
+      case x: TsMemberTypeMapped => x.copy(comments = x.comments ++ newComments)
+      case x: TsMemberProperty   => x.copy(comments = x.comments ++ newComments)
+    }
+}


### PR DESCRIPTION
May want to output this is annotations or something which can be queried at build-time, perhaps we can even determine which polyfills are needed.

This is an example diff from the Javascript `String` type:

```diff
Index: s/std/src/main/scala/typings/std/String.scala
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/s/std/src/main/scala/typings/std/String.scala b/s/std/src/main/scala/typings/std/String.scala
--- a/s/std/src/main/scala/typings/std/String.scala	(revision 8c5a423807f78facc80b5f7a8b05871bae377d40)
+++ b/s/std/src/main/scala/typings/std/String.scala	(date 1630492245197)
@@ -18,33 +18,40 @@
 @js.native
 trait String
   extends StObject
-     with /* index */ NumberDictionary[java.lang.String] {
+     with /* standard dom */
+/* index */ NumberDictionary[java.lang.String] {
   
   /**
     * Returns an `<a>` HTML anchor element and sets the name attribute to the text value
     * @param name
     */
+  /* standard es2015.core */
   def anchor(name: java.lang.String): java.lang.String = js.native
   
   /** Returns a `<big>` HTML element */
+  /* standard es2015.core */
   def big(): java.lang.String = js.native
   
   /** Returns a `<blink>` HTML element */
+  /* standard es2015.core */
   def blink(): java.lang.String = js.native
   
   /** Returns a `<b>` HTML element */
+  /* standard es2015.core */
   def bold(): java.lang.String = js.native
   
   /**
     * Returns the character at the specified index.
     * @param pos The zero-based index of the desired character.
     */
+  /* standard es5 */
   def charAt(pos: Double): java.lang.String = js.native
   
   /**
     * Returns the Unicode value of the character at the specified location.
     * @param index The zero-based index of the desired character. If there is no character at the specified index, NaN is returned.
     */
+  /* standard es5 */
   def charCodeAt(index: Double): Double = js.native
   
   /**
@@ -54,12 +61,14 @@
     * If there is no element at that position, the result is undefined.
     * If a valid UTF-16 surrogate pair does not begin at pos, the result is the code unit at pos.
     */
+  /* standard es2015.core */
   def codePointAt(pos: Double): js.UndefOr[Double] = js.native
   
   /**
     * Returns a string that contains the concatenation of two or more strings.
     * @param strings The strings to append to the end of the string.
     */
+  /* standard es5 */
   def concat(strings: java.lang.String*): java.lang.String = js.native
   
   /**
@@ -67,18 +76,23 @@
     * same as the corresponding elements of this object (converted to a String) starting at
     * endPosition – length(this). Otherwise returns false.
     */
+  /* standard es2015.core */
   def endsWith(searchString: java.lang.String): scala.Boolean = js.native
   def endsWith(searchString: java.lang.String, endPosition: Double): scala.Boolean = js.native
   
   /** Returns a `<tt>` HTML element */
+  /* standard es2015.core */
   def fixed(): java.lang.String = js.native
   
   /** Returns a `<font>` HTML element and sets the color attribute value */
+  /* standard es2015.core */
   def fontcolor(color: java.lang.String): java.lang.String = js.native
   
   /** Returns a `<font>` HTML element and sets the size attribute value */
+  /* standard es2015.core */
   def fontsize(size: java.lang.String): java.lang.String = js.native
   /** Returns a `<font>` HTML element and sets the size attribute value */
+  /* standard es2015.core */
   def fontsize(size: Double): java.lang.String = js.native
   
   /**
@@ -88,6 +102,7 @@
     * @param searchString search string
     * @param position If position is undefined, 0 is assumed, so as to search all of the String.
     */
+  /* standard es2015.core */
   def includes(searchString: java.lang.String): scala.Boolean = js.native
   def includes(searchString: java.lang.String, position: Double): scala.Boolean = js.native
   
@@ -96,13 +111,16 @@
     * @param searchString The substring to search for in the string
     * @param position The index at which to begin searching the String object. If omitted, search starts at the beginning of the string.
     */
+  /* standard es5 */
   def indexOf(searchString: java.lang.String): Double = js.native
   def indexOf(searchString: java.lang.String, position: Double): Double = js.native
   
   /** Returns an `<i>` HTML element */
+  /* standard es2015.core */
   def italics(): java.lang.String = js.native
   
   /** Iterator */
+  /* standard es2015.iterable */
   @JSName(js.Symbol.iterator)
   var iterator: js.Function0[IterableIterator[java.lang.String]] = js.native
   
@@ -111,19 +129,23 @@
     * @param searchString The substring to search for.
     * @param position The index at which to begin searching. If omitted, the search begins at the end of the string.
     */
+  /* standard es5 */
   def lastIndexOf(searchString: java.lang.String): Double = js.native
   def lastIndexOf(searchString: java.lang.String, position: Double): Double = js.native
   
   /** Returns the length of a String object. */
+  /* standard es5 */
   val length: Double = js.native
   
   /** Returns an `<a>` HTML element and sets the href attribute value */
+  /* standard es2015.core */
   def link(url: java.lang.String): java.lang.String = js.native
   
   /**
     * Determines whether two strings are equivalent in the current locale.
     * @param that String to compare to target string
     */
+  /* standard es5 */
   def localeCompare(that: java.lang.String): Double = js.native
   def localeCompare(that: java.lang.String, locales: java.lang.String): Double = js.native
   def localeCompare(that: java.lang.String, locales: java.lang.String, options: CollatorOptions): Double = js.native
@@ -136,11 +158,13 @@
     * containing the results of that search, or null if no matches are found.
     * @param matcher An object that supports being matched against.
     */
+  /* standard es2015.symbol.wellknown */
   def `match`(matcher: Match): RegExpMatchArray | Null = js.native
   /**
     * Matches a string with a regular expression, and returns an array containing the results of that search.
     * @param regexp A variable name or string literal containing the regular expression pattern and flags.
     */
+  /* standard es5 */
   def `match`(regexp: java.lang.String): RegExpMatchArray | Null = js.native
   def `match`(regexp: RegExp): RegExpMatchArray | Null = js.native
   
@@ -149,6 +173,7 @@
     * containing the results of that search.
     * @param regexp A variable name or string literal containing the regular expression pattern and flags.
     */
+  /* standard es2020.string */
   def matchAll(regexp: RegExp): IterableIterator[RegExpMatchArray] = js.native
   
   /**
@@ -157,6 +182,7 @@
     * @param form Applicable values: "NFC", "NFD", "NFKC", or "NFKD", If not specified default
     * is "NFC"
     */
+  /* standard es2015.core */
   def normalize(): java.lang.String = js.native
   /**
     * Returns the String value result of normalizing the string into the normalization form
@@ -164,6 +190,7 @@
     * @param form Applicable values: "NFC", "NFD", "NFKC", or "NFKD", If not specified default
     * is "NFC"
     */
+  /* standard es2015.core */
   def normalize(form: NFC | NFD | NFKC | NFKD): java.lang.String = js.native
   def normalize(form: java.lang.String): java.lang.String = js.native
   
@@ -178,6 +205,7 @@
     *        If this string is too long, it will be truncated and the left-most part will be applied.
     *        The default value for this parameter is " " (U+0020).
     */
+  /* standard es2017.string */
   def padEnd(maxLength: Double): java.lang.String = js.native
   def padEnd(maxLength: Double, fillString: java.lang.String): java.lang.String = js.native
   
@@ -192,6 +220,7 @@
     *        If this string is too long, it will be truncated and the left-most part will be applied.
     *        The default value for this parameter is " " (U+0020).
     */
+  /* standard es2017.string */
   def padStart(maxLength: Double): java.lang.String = js.native
   def padStart(maxLength: Double, fillString: java.lang.String): java.lang.String = js.native
   
@@ -200,6 +229,7 @@
     * the empty string is returned.
     * @param count number of copies to append
     */
+  /* standard es2015.core */
   def repeat(count: Double): java.lang.String = js.native
   
   /**
@@ -207,12 +237,14 @@
     * @param searchValue A string to search for.
     * @param replaceValue A string containing the text to replace for every successful match of searchValue in this string.
     */
+  /* standard es5 */
   def replace(searchValue: java.lang.String, replaceValue: java.lang.String): java.lang.String = js.native
   /**
     * Replaces text in a string, using a regular expression or search string.
     * @param searchValue A string to search for.
     * @param replacer A function that returns the replacement text.
     */
+  /* standard es5 */
   def replace(
     searchValue: java.lang.String,
     replacer: js.Function2[/* substring */ java.lang.String, /* repeated */ js.Any, java.lang.String]
@@ -227,12 +259,14 @@
     * @param searchValue A string or RegExp search value.
     * @param replaceValue A string containing the text to replace for match.
     */
+  /* standard es2015.symbol.wellknown */
   def replace(searchValue: Replace, replaceValue: java.lang.String): java.lang.String = js.native
   /**
     * Replaces text in a string, using an object that supports replacement within a string.
     * @param searchValue A object can search for and replace matches within a string.
     * @param replacer A function that returns the replacement text.
     */
+  /* standard es2015.symbol.wellknown */
   def replace(
     searchValue: `0`,
     replacer: js.Function2[/* substring */ java.lang.String, /* repeated */ js.Any, java.lang.String]
@@ -243,12 +277,14 @@
     * @param searchValue A string to search for.
     * @param replaceValue A string containing the text to replace for every successful match of searchValue in this string.
     */
+  /* standard es2021.string */
   def replaceAll(searchValue: java.lang.String, replaceValue: java.lang.String): java.lang.String = js.native
   /**
     * Replace all instances of a substring in a string, using a regular expression or search string.
     * @param searchValue A string to search for.
     * @param replacer A function that returns the replacement text.
     */
+  /* standard es2021.string */
   def replaceAll(
     searchValue: java.lang.String,
     replacer: js.Function2[/* substring */ java.lang.String, /* repeated */ js.Any, java.lang.String]
@@ -263,12 +299,14 @@
     * Finds the first substring match in a regular expression search.
     * @param regexp The regular expression pattern and applicable flags.
     */
+  /* standard es5 */
   def search(regexp: java.lang.String): Double = js.native
   def search(regexp: RegExp): Double = js.native
   /**
     * Finds the first substring match in a regular expression search.
     * @param searcher An object which supports searching within a string.
     */
+  /* standard es2015.symbol.wellknown */
   def search(searcher: Search): Double = js.native
   
   /**
@@ -277,12 +315,14 @@
     * @param end The index to the end of the specified portion of stringObj. The substring includes the characters up to, but not including, the character indicated by end.
     * If this value is not specified, the substring continues to the end of stringObj.
     */
+  /* standard es5 */
   def slice(): java.lang.String = js.native
   def slice(start: Double): java.lang.String = js.native
   def slice(start: Double, end: Double): java.lang.String = js.native
   def slice(start: Unit, end: Double): java.lang.String = js.native
   
   /** Returns a `<small>` HTML element */
+  /* standard es2015.core */
   def small(): java.lang.String = js.native
   
   /**
@@ -290,6 +330,7 @@
     * @param separator A string that identifies character or characters to use in separating the string. If omitted, a single-element array containing the entire string is returned.
     * @param limit A value used to limit the number of elements returned in the array.
     */
+  /* standard es5 */
   def split(separator: java.lang.String): js.Array[java.lang.String] = js.native
   def split(separator: java.lang.String, limit: Double): js.Array[java.lang.String] = js.native
   def split(separator: RegExp): js.Array[java.lang.String] = js.native
@@ -299,6 +340,7 @@
     * @param splitter An object that can split a string.
     * @param limit A value used to limit the number of elements returned in the array.
     */
+  /* standard es2015.symbol.wellknown */
   def split(splitter: Split): js.Array[java.lang.String] = js.native
   def split(splitter: Split, limit: Double): js.Array[java.lang.String] = js.native
   
@@ -307,13 +349,16 @@
     * same as the corresponding elements of this object (converted to a String) starting at
     * position. Otherwise returns false.
     */
+  /* standard es2015.core */
   def startsWith(searchString: java.lang.String): scala.Boolean = js.native
   def startsWith(searchString: java.lang.String, position: Double): scala.Boolean = js.native
   
   /** Returns a `<strike>` HTML element */
+  /* standard es2015.core */
   def strike(): java.lang.String = js.native
   
   /** Returns a `<sub>` HTML element */
+  /* standard es2015.core */
   def sub(): java.lang.String = js.native
   
   // IE extensions
@@ -322,6 +367,7 @@
     * @param from The starting position of the desired substring. The index of the first character in the string is zero.
     * @param length The number of characters to include in the returned substring.
     */
+  /* standard es5 */
   def substr(from: Double): java.lang.String = js.native
   def substr(from: Double, length: Double): java.lang.String = js.native
   
@@ -331,40 +377,51 @@
     * @param end Zero-based index number indicating the end of the substring. The substring includes the characters up to, but not including, the character indicated by end.
     * If end is omitted, the characters from start through the end of the original string are returned.
     */
+  /* standard es5 */
   def substring(start: Double): java.lang.String = js.native
   def substring(start: Double, end: Double): java.lang.String = js.native
   
   /** Returns a `<sup>` HTML element */
+  /* standard es2015.core */
   def sup(): java.lang.String = js.native
   
   /** Converts all alphabetic characters to lowercase, taking into account the host environment's current locale. */
+  /* standard es5 */
   def toLocaleLowerCase(): java.lang.String = js.native
   def toLocaleLowerCase(locales: java.lang.String): java.lang.String = js.native
   def toLocaleLowerCase(locales: js.Array[java.lang.String]): java.lang.String = js.native
   
   /** Returns a string where all alphabetic characters have been converted to uppercase, taking into account the host environment's current locale. */
+  /* standard es5 */
   def toLocaleUpperCase(): java.lang.String = js.native
   def toLocaleUpperCase(locales: java.lang.String): java.lang.String = js.native
   def toLocaleUpperCase(locales: js.Array[java.lang.String]): java.lang.String = js.native
   
   /** Converts all the alphabetic characters in a string to lowercase. */
+  /* standard es5 */
   def toLowerCase(): java.lang.String = js.native
   
   /** Converts all the alphabetic characters in a string to uppercase. */
+  /* standard es5 */
   def toUpperCase(): java.lang.String = js.native
   
   /** Removes the leading and trailing white space and line terminator characters from a string. */
+  /* standard es5 */
   def trim(): java.lang.String = js.native
   
   /** Removes the trailing white space and line terminator characters from a string. */
+  /* standard es2019.string */
   def trimEnd(): java.lang.String = js.native
   
   /** Removes the leading white space and line terminator characters from a string. */
+  /* standard es2019.string */
   def trimLeft(): java.lang.String = js.native
   
   /** Removes the trailing white space and line terminator characters from a string. */
+  /* standard es2019.string */
   def trimRight(): java.lang.String = js.native
   
   /** Removes the leading white space and line terminator characters from a string. */
+  /* standard es2019.string */
   def trimStart(): java.lang.String = js.native
 }
```