### PR TITLE
Fix #438: Instantiable23 type not found

### DIFF
--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/ImportType.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/ImportType.scala
@@ -326,11 +326,16 @@ class ImportType(stdNames: QualifiedName.StdNames) {
     val ret: TypeRef =
       orAny(scope, importName)(sig.resultType)
 
-    TypeRef(
-      QualifiedName.Instantiable(sig.params.length),
-      params :+ ret,
-      comments,
-    )
+    if (sig.params.length > 22)
+      TypeRef.Any.withComments(
+        Comments(s"/* untranslatable newable function with more than 22 parameters: ${TsTypeFormatter.sig(_sig)} */"),
+      )
+    else
+      TypeRef(
+        QualifiedName.Instantiable(sig.params.length),
+        params :+ ret,
+        comments,
+      )
   }
 
   private def funParam(scope: TsTreeScope, importName: AdaptiveNamingImport)(param: TsFunParam): TypeRef =


### PR DESCRIPTION
I finally tested your suggestion. It works as expected (to not get that compilation error at code generation time https://github.com/ScalablyTyped/Converter/issues/438)

@oyvindberg Thank you. 
Would be great to have this included in the next release!