### PR TITLE
Add support for `exports`

### DIFF
--- a/.run/CI Demoset.run.xml
+++ b/.run/CI Demoset.run.xml
@@ -3,7 +3,7 @@
     <option name="ALTERNATIVE_JRE_PATH" value="/usr/lib/jvm/java-8-openjdk-amd64/jre" />
     <option name="MAIN_CLASS_NAME" value="org.scalablytyped.converter.Main" />
     <module name="importer" />
-    <option name="PROGRAM_PARAMETERS" value="-softWrites -nextVersions2 -enableParseCache -offline -dontCleanProject -forceCommit -demoSet" />
+    <option name="PROGRAM_PARAMETERS" value="-softWrites -nextVersions2 -enableParseCache -offline -dontCleanProject -forceCommit -demoSet2 semantic-ui-react" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="org.scalablytyped.converter.*" />
@@ -12,7 +12,6 @@
     </extension>
     <method v="2">
       <option name="Make" enabled="true" />
-      <option name="BSP.BeforeRunTask" enabled="true" />
     </method>
   </configuration>
 </component>

--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/LibraryResolver.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/LibraryResolver.scala
@@ -13,11 +13,11 @@ class LibraryResolver(
   private val byName: Map[TsIdentLibrary, LibTsSource] =
     allSources.groupBy(_.libName).mapValues(_.head).updated(TsIdent.std, stdLib)
 
-  def module(current: LibTsSource, folder: InFolder, value: String): Option[ResolvedModule] =
+  def module(source: LibTsSource, folder: InFolder, value: String): Option[ResolvedModule] =
     value match {
       case LocalPath(localPath) =>
         file(folder, localPath).map { inFile =>
-          ResolvedModule.Local(inFile, LibraryResolver.moduleNameFor(current, inFile).head)
+          ResolvedModule.Local(inFile, LibraryResolver.moduleNameFor(source, inFile).head)
         }
       case globalRef =>
         val modName = ModuleNameParser(globalRef.split("/").to[List], keepIndexFragment = true)

--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/ProxyModule.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/ProxyModule.scala
@@ -1,0 +1,90 @@
+package org.scalablytyped.converter.internal
+package importer
+
+import com.olvind.logging.Logger
+import org.scalablytyped.converter.internal.ts._
+
+case class ProxyModule(
+    comments:   Comments,
+    libName:    TsIdentLibrary,
+    fromModule: TsIdentModule,
+    toModule:   TsIdentModule,
+) {
+  val asModule = TsDeclModule(
+    comments = comments,
+    declared = false,
+    name     = toModule,
+    members = IArray(
+      TsExport(
+        comments = NoComments,
+        typeOnly = false,
+        tpe      = ExportType.Named,
+        exported = TsExportee.Star(None, fromModule),
+      ),
+    ),
+    codePath   = CodePath.HasPath(libName, TsQIdent(IArray(toModule))),
+    jsLocation = JsLocation.Zero,
+  )
+}
+
+object ProxyModule {
+  val FromExports = Comments("/* from `exports` in `package.json` */\n")
+
+  def fromExports(
+      source:   LibTsSource,
+      logger:   Logger[_],
+      resolve:  LibraryResolver,
+      existing: TsIdent => Boolean,
+      exports:  Map[String, String],
+  ): Iterable[ProxyModule] = {
+    val expandedGlobs = exports.flatMap {
+      case tuple @ (exportedName, exportedTypesRelPath) =>
+        exportedTypesRelPath.split('*') match {
+          case Array(_) => Some(tuple)
+          case Array(pre, post) =>
+            val splitPrePath = pre.split('/').filterNot(_ == ".")
+
+            // last part of `pre` may not be a full path fragment, so drop it and consider it below
+            val (folderPrePart, preFileNameStart) =
+              if (pre.endsWith("/")) (splitPrePath, "")
+              else (splitPrePath.dropRight(1), splitPrePath.lastOption.getOrElse(""))
+
+            val lookIn = folderPrePart.foldLeft(source.folder.path)(_ / _)
+
+            // need to take whatever the glob expanded to and expand it into both `name` and `types`
+            val expandedFragments = os.walk(lookIn).flatMap { path =>
+              val relPathString = path.relativeTo(lookIn).toString()
+
+              if (relPathString.startsWith(preFileNameStart) && relPathString.endsWith(post))
+                Some(relPathString.drop(preFileNameStart.length).dropRight(post.length))
+              else None
+            }
+
+            val expanded =
+              expandedFragments.map(m => (exportedName.replace("*", m), exportedTypesRelPath.replace("*", m)))
+            expanded
+
+          case _ => logger.fatal(s"need to add support for more than one '*' in glob pattern $exportedTypesRelPath")
+        }
+    }
+
+    val libModule = TsIdentModule.fromLibrary(source.libName)
+
+    expandedGlobs.flatMap {
+      case tuple @ (name, types) =>
+        val fromModule = resolve.module(source, source.folder, types) match {
+          case Some(resolvedModule) => resolvedModule.moduleName
+          case None                 => logger.fatal(s"couldn't resolve $tuple")
+        }
+
+        val toModule =
+          libModule.copy(fragments = libModule.fragments ++ name.split("/").toList.filterNot(_ == "."))
+
+        if (existing(toModule)) None
+        else {
+          logger.info(s"exposing module ${toModule.value} from ${fromModule.value}")
+          Some(ProxyModule(FromExports, source.libName, fromModule, toModule))
+        }
+    }
+  }
+}

--- a/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ExportsJsonTest.scala
+++ b/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ExportsJsonTest.scala
@@ -1,0 +1,106 @@
+package org.scalablytyped.converter.internal.importer
+
+import org.scalablytyped.converter.internal.Json
+import org.scalablytyped.converter.internal.ts.PackageJson
+import org.scalatest.funsuite.AnyFunSuite
+
+class ExportsJsonTest extends AnyFunSuite {
+  test("no - 1") {
+    val content =
+      """{"exports": [
+        |        {
+        |          "default": "./index.js"
+        |        },
+        |        "./index.js"
+        |      ]
+        |}""".stripMargin
+    val actual = Json.force[PackageJson](content).parsedExported
+
+    assert(actual === None)
+  }
+
+  test("no - 2") {
+    val content =
+      """{"exports": {
+        |        "import": "./build/lib/index.js",
+        |        "require": "./build/index.cjs"
+        |      }
+        |}""".stripMargin
+    val actual = Json.force[PackageJson](content).parsedExported
+
+    assert(actual === None)
+  }
+  test("no - 3") {
+    val content =
+      """{"exports": {
+        |        ".": [
+        |          {
+        |            "import": "./build/lib/index.js",
+        |            "require": "./build/index.cjs"
+        |          },
+        |          "./build/index.cjs"
+        |        ]
+        |      }
+        |}""".stripMargin
+    val actual = Json.force[PackageJson](content).parsedExported
+
+    assert(actual === None)
+  }
+  test("no - 4") {
+    val content =
+      """{"exports": {
+        |        ".": [
+        |          {
+        |            "import": "./build/lib/index.js",
+        |            "require": "./build/index.cjs"
+        |          },
+        |          "./build/index.cjs"
+        |        ],
+        |        "./browser": [
+        |          "./browser.js"
+        |        ]
+        |      }}""".stripMargin
+    val actual = Json.force[PackageJson](content).parsedExported
+
+    assert(actual === None)
+  }
+
+  test("no - 5") {
+    val content =
+      """{"exports": "picocolors.js"}""".stripMargin
+    val actual = Json.force[PackageJson](content).parsedExported
+
+    assert(actual === None)
+  }
+
+  test("yes - 5") {
+    val content =
+      """{"exports": {
+        |    "./analytics": {
+        |      "types": "./analytics/dist/analytics/index.d.ts",
+        |      "node": {
+        |        "require": "./analytics/dist/index.cjs.js",
+        |        "import": "./analytics/dist/index.mjs"
+        |      },
+        |      "default": "./analytics/dist/index.esm.js"
+        |    },
+        |    "./app": {
+        |      "types": "./app/dist/app/index.d.ts",
+        |      "node": {
+        |        "require": "./app/dist/index.cjs.js",
+        |        "import": "./app/dist/index.mjs"
+        |      },
+        |      "default": "./app/dist/index.esm.js"
+        |    },
+        |    "./package.json": "./package.json"
+        |  }}""".stripMargin
+    val actual = Json.force[PackageJson](content).parsedExported
+    val expected = Some(
+      Map(
+        "./analytics" -> "./analytics/dist/analytics/index.d.ts",
+        "./app" -> "./app/dist/app/index.d.ts",
+      ),
+    )
+    assert(actual === expected)
+  }
+}

--- a/tests/pixi.js/check-3/p/pixi_dot_js/build.sbt
+++ b/tests/pixi.js/check-3/p/pixi_dot_js/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "pixi_dot_js"
-version := "0.0-unknown-ba15ed"
+version := "0.0-unknown-ba7eae"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/pixi.js/check-3/p/pixi_dot_js/src/main/scala/typings/pixiJs/mod.scala
+++ b/tests/pixi.js/check-3/p/pixi_dot_js/src/main/scala/typings/pixiJs/mod.scala
@@ -16,12 +16,26 @@ object mod {
       extends typings.pixiUtils.mod.EventEmitter[EventTypes]
     object EventEmitter extends Shortcut {
       
+      /* This class was inferred from a value with a constructor. In rare cases (like HTMLElement in the DOM) it might not work as you expect. */
+      @JSImport("pixi.js", "utils.EventEmitter")
+      @js.native
+      open class ^[EventTypes] ()
+        extends StObject
+           with typings.eventemitter3.mod.EventEmitter[EventTypes]
+      
       @JSImport("pixi.js", "utils.EventEmitter")
       @js.native
       val ^ : js.Object & EventEmitterStatic = js.native
       @JSImport("pixi.js", "utils.EventEmitter.EventEmitter")
       @js.native
       val EventEmitter: EventEmitterStatic = js.native
+      
+      /* This class was inferred from a value with a constructor, it was renamed because a distinct type already exists with the same name. */
+      @JSImport("pixi.js", "utils.EventEmitter.EventEmitter")
+      @js.native
+      open class EventEmitterCls[EventTypes] ()
+        extends StObject
+           with typings.eventemitter3.mod.EventEmitter[EventTypes]
       
       type _To = js.Object & EventEmitterStatic
       


### PR DESCRIPTION
- Dependent upon #366 

Solves the problem by injecting fake modules into the AST with `export import from '...'` taken from `exports` in `package.json`

The predictable module names will be split out into a separate PR

<img width="990" alt="Screenshot 2022-09-19 at 02 59 38" src="https://user-images.githubusercontent.com/247937/190935809-a8323186-a334-41e5-8ce0-97128f386d70.png">