### PR TITLE
modules: named exports can also export default

### DIFF
--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-39f3a9"
+version := "0.0-unknown-c53eb1"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-8d196c",
+  "org.scalablytyped" %%% "react" % "16.9.2-43ffc0",
   "org.scalablytyped" %%% "std" % "0.0-unknown-f97ab0")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-bootstrap/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-8e5b08"
+version := "0.32-11e77c"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-8d196c",
+  "org.scalablytyped" %%% "react" % "16.9.2-43ffc0",
   "org.scalablytyped" %%% "std" % "0.0-unknown-f97ab0")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-contextmenu/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-11f9bc"
+version := "2.13.0-381358"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-8d196c",
+  "org.scalablytyped" %%% "react" % "16.9.2-43ffc0",
   "org.scalablytyped" %%% "std" % "0.0-unknown-f97ab0")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-dropzone/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-ffb43d"
+version := "10.1.10-3383ee"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-8d196c",
+  "org.scalablytyped" %%% "react" % "16.9.2-43ffc0",
   "org.scalablytyped" %%% "std" % "0.0-unknown-f97ab0")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/r/react-markdown/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-markdown/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-markdown"
-version := "0.0-unknown-18b4dd"
+version := "0.0-unknown-30c16f"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-8d196c",
+  "org.scalablytyped" %%% "react" % "16.9.2-43ffc0",
   "org.scalablytyped" %%% "std" % "0.0-unknown-f97ab0")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-select/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-6a72f3"
+version := "0.0-unknown-8f2c2a"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-8d196c",
+  "org.scalablytyped" %%% "react" % "16.9.2-43ffc0",
   "org.scalablytyped" %%% "std" % "0.0-unknown-f97ab0")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/r/react/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-8d196c"
+version := "16.9.2-43ffc0"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-japgolly-3/r/react/src/main/scala/typingsJapgolly/react/anon.scala
+++ b/tests/react-integration-test/check-japgolly-3/r/react/src/main/scala/typingsJapgolly/react/anon.scala
@@ -15,39 +15,39 @@ object anon {
   
   trait `0` extends StObject {
     
-    var defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any
+    var ref: js.UndefOr[Exclude[Any, String]] = js.undefined
   }
   object `0` {
     
-    inline def apply(
-      defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any
-    ): `0` = {
-      val __obj = js.Dynamic.literal(defaultProps = defaultProps.asInstanceOf[js.Any])
+    inline def apply(): `0` = {
+      val __obj = js.Dynamic.literal()
       __obj.asInstanceOf[`0`]
     }
     
     extension [Self <: `0`](x: Self) {
       
-      inline def setDefaultProps(value: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any): Self = StObject.set(x, "defaultProps", value.asInstanceOf[js.Any])
+      inline def setRef(value: Exclude[Any, String]): Self = StObject.set(x, "ref", value.asInstanceOf[js.Any])
+      
+      inline def setRefUndefined: Self = StObject.set(x, "ref", js.undefined)
     }
   }
   
   trait `1` extends StObject {
     
-    var ref: js.UndefOr[Exclude[Any, String]] = js.undefined
+    var defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any
   }
   object `1` {
     
-    inline def apply(): `1` = {
-      val __obj = js.Dynamic.literal()
+    inline def apply(
+      defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any
+    ): `1` = {
+      val __obj = js.Dynamic.literal(defaultProps = defaultProps.asInstanceOf[js.Any])
       __obj.asInstanceOf[`1`]
     }
     
     extension [Self <: `1`](x: Self) {
       
-      inline def setRef(value: Exclude[Any, String]): Self = StObject.set(x, "ref", value.asInstanceOf[js.Any])
-      
-      inline def setRefUndefined: Self = StObject.set(x, "ref", js.undefined)
+      inline def setDefaultProps(value: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any): Self = StObject.set(x, "defaultProps", value.asInstanceOf[js.Any])
     }
   }
   

--- a/tests/react-integration-test/check-japgolly-3/r/react/src/main/scala/typingsJapgolly/react/mod/package.scala
+++ b/tests/react-integration-test/check-japgolly-3/r/react/src/main/scala/typingsJapgolly/react/mod/package.scala
@@ -25,7 +25,7 @@ import org.scalajs.dom.EventTarget
 import org.scalajs.dom.HTMLElement
 import org.scalajs.dom.HTMLInputElement
 import org.scalajs.dom.SVGElement
-import typingsJapgolly.react.anon.`1`
+import typingsJapgolly.react.anon.`0`
 import typingsJapgolly.react.mod.^
 import typingsJapgolly.react.reactStrings.a_
 import typingsJapgolly.react.reactStrings.abbr
@@ -581,7 +581,7 @@ Unit]
 type PropsWithChildren[P] = P & typingsJapgolly.react.anon.Children
 
 /** Ensures that the props do not include string ref, which cannot be forwarded */
-type PropsWithRef[P] = P | (PropsWithoutRef[P] & `1`)
+type PropsWithRef[P] = P | (PropsWithoutRef[P] & `0`)
 
 /** Ensures that the props do not include ref at all */
 type PropsWithoutRef[P] = P | (Pick[P, Exclude[/* keyof P */ String, ref]])

--- a/tests/react-integration-test/check-japgolly-3/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/s/semantic-ui-react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-809265"
+version := "0.0-unknown-9fccd7"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-8d196c",
+  "org.scalablytyped" %%% "react" % "16.9.2-43ffc0",
   "org.scalablytyped" %%% "std" % "0.0-unknown-f97ab0")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-c3d4e0"
+version := "0.38.0-82774e"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-8d196c",
+  "org.scalablytyped" %%% "react" % "16.9.2-43ffc0",
   "org.scalablytyped" %%% "std" % "0.0-unknown-f97ab0")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-ref/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-ef4634"
+version := "0.38.0-4cb953"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-8d196c",
+  "org.scalablytyped" %%% "react" % "16.9.2-43ffc0",
   "org.scalablytyped" %%% "std" % "0.0-unknown-f97ab0")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-0911db"
+version := "0.0-unknown-2758d9"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-822543",
+  "org.scalablytyped" %%% "react" % "16.9.2-126b35",
   "org.scalablytyped" %%% "std" % "0.0-unknown-dc99ee")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-bootstrap/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-67c572"
+version := "0.32-daad1b"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-822543",
+  "org.scalablytyped" %%% "react" % "16.9.2-126b35",
   "org.scalablytyped" %%% "std" % "0.0-unknown-dc99ee")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-contextmenu/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-272fbc"
+version := "2.13.0-5fb46c"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-822543",
+  "org.scalablytyped" %%% "react" % "16.9.2-126b35",
   "org.scalablytyped" %%% "std" % "0.0-unknown-dc99ee")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-dropzone/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-e3d0de"
+version := "10.1.10-6c604f"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-822543",
+  "org.scalablytyped" %%% "react" % "16.9.2-126b35",
   "org.scalablytyped" %%% "std" % "0.0-unknown-dc99ee")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react-markdown/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-markdown/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-markdown"
-version := "0.0-unknown-f95880"
+version := "0.0-unknown-aab417"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-822543",
+  "org.scalablytyped" %%% "react" % "16.9.2-126b35",
   "org.scalablytyped" %%% "std" % "0.0-unknown-dc99ee")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-select/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-baf25e"
+version := "0.0-unknown-42082b"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-822543",
+  "org.scalablytyped" %%% "react" % "16.9.2-126b35",
   "org.scalablytyped" %%% "std" % "0.0-unknown-dc99ee")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-822543"
+version := "16.9.2-126b35"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/anon.scala
+++ b/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/anon.scala
@@ -10,39 +10,39 @@ object anon {
   
   trait `0` extends StObject {
     
-    var defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any
+    var ref: js.UndefOr[Exclude[Any, String]] = js.undefined
   }
   object `0` {
     
-    inline def apply(
-      defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any
-    ): `0` = {
-      val __obj = js.Dynamic.literal(defaultProps = defaultProps.asInstanceOf[js.Any])
+    inline def apply(): `0` = {
+      val __obj = js.Dynamic.literal()
       __obj.asInstanceOf[`0`]
     }
     
     extension [Self <: `0`](x: Self) {
       
-      inline def setDefaultProps(value: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any): Self = StObject.set(x, "defaultProps", value.asInstanceOf[js.Any])
+      inline def setRef(value: Exclude[Any, String]): Self = StObject.set(x, "ref", value.asInstanceOf[js.Any])
+      
+      inline def setRefUndefined: Self = StObject.set(x, "ref", js.undefined)
     }
   }
   
   trait `1` extends StObject {
     
-    var ref: js.UndefOr[Exclude[Any, String]] = js.undefined
+    var defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any
   }
   object `1` {
     
-    inline def apply(): `1` = {
-      val __obj = js.Dynamic.literal()
+    inline def apply(
+      defaultProps: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any
+    ): `1` = {
+      val __obj = js.Dynamic.literal(defaultProps = defaultProps.asInstanceOf[js.Any])
       __obj.asInstanceOf[`1`]
     }
     
     extension [Self <: `1`](x: Self) {
       
-      inline def setRef(value: Exclude[Any, String]): Self = StObject.set(x, "ref", value.asInstanceOf[js.Any])
-      
-      inline def setRefUndefined: Self = StObject.set(x, "ref", js.undefined)
+      inline def setDefaultProps(value: /* import warning: importer.ImportType#apply Failed type conversion: infer D */ js.Any): Self = StObject.set(x, "defaultProps", value.asInstanceOf[js.Any])
     }
   }
   

--- a/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/mod/package.scala
+++ b/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/mod/package.scala
@@ -22,7 +22,7 @@ import slinky.web.SyntheticTouchEvent
 import slinky.web.SyntheticTransitionEvent
 import slinky.web.SyntheticUIEvent
 import slinky.web.SyntheticWheelEvent
-import typingsSlinky.react.anon.`1`
+import typingsSlinky.react.anon.`0`
 import typingsSlinky.react.mod.^
 import typingsSlinky.react.reactStrings.a_
 import typingsSlinky.react.reactStrings.abbr
@@ -595,7 +595,7 @@ Unit]
 type PropsWithChildren[P] = P & typingsSlinky.react.anon.Children
 
 /** Ensures that the props do not include string ref, which cannot be forwarded */
-type PropsWithRef[P] = P | (PropsWithoutRef[P] & `1`)
+type PropsWithRef[P] = P | (PropsWithoutRef[P] & `0`)
 
 /** Ensures that the props do not include ref at all */
 type PropsWithoutRef[P] = P | (Pick[P, Exclude[/* keyof P */ String, ref]])

--- a/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-7db6d8"
+version := "0.0-unknown-79496e"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-822543",
+  "org.scalablytyped" %%% "react" % "16.9.2-126b35",
   "org.scalablytyped" %%% "std" % "0.0-unknown-dc99ee")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-865c9f"
+version := "0.38.0-d9c115"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-822543",
+  "org.scalablytyped" %%% "react" % "16.9.2-126b35",
   "org.scalablytyped" %%% "std" % "0.0-unknown-dc99ee")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-ref/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-cffa37"
+version := "0.38.0-fb2cbc"
 scalaVersion := "3.1.2"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-822543",
+  "org.scalablytyped" %%% "react" % "16.9.2-126b35",
   "org.scalablytyped" %%% "std" % "0.0-unknown-dc99ee")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/ts/src/main/scala/org/scalablytyped/converter/internal/ts/modules/Exports.scala
+++ b/ts/src/main/scala/org/scalablytyped/converter/internal/ts/modules/Exports.scala
@@ -93,9 +93,8 @@ object Exports {
               if (scope.stack contains mod) mod
               else CachedReplaceExports(newScope, loopDetector, mod)
 
-            resolvedModule.nameds.flatMap {
-              case n if n.name === TsIdent.default => Empty
-              case n                               => export(codePath, jsLocation, newScope, exportType, n, None, loopDetector)
+            resolvedModule.nameds.flatMap { n =>
+              export(codePath, jsLocation, newScope, exportType, n, None, loopDetector)
             }
           case _ =>
             scope.fatalMaybe(s"Couldn't find expected module $from")


### PR DESCRIPTION
- improve shadowing logic to not combine re-exported `default` exports from multiple modules.
- note: changes ordering post-module resolution, so anon names will change