### PR TITLE
Fix a bug in `PreferTypeAlias`

### DIFF
--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-cbf8ba"
+version := "0.0-unknown-53f385"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-53a3df",
+  "org.scalablytyped" %%% "react" % "16.9.2-1d9012",
   "org.scalablytyped" %%% "std" % "0.0-unknown-e4bffc")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-bootstrap/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-8078c3"
+version := "0.32-d7bb2e"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-53a3df",
+  "org.scalablytyped" %%% "react" % "16.9.2-1d9012",
   "org.scalablytyped" %%% "std" % "0.0-unknown-e4bffc")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/libToggleButtonGroupMod.scala
+++ b/tests/react-integration-test/check-japgolly-3/r/react-bootstrap/src/main/scala/typingsJapgolly/reactBootstrap/libToggleButtonGroupMod.scala
@@ -116,5 +116,20 @@ object libToggleButtonGroupMod {
   
   type ToggleButtonGroup = japgolly.scalajs.react.facade.React.Component[ToggleButtonGroupProps & js.Object, js.Object]
   
+  /** 
+  NOTE: Rewritten from type alias:
+  {{{
+  type ToggleButtonGroupProps = react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.RadioProps & react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.BaseProps & react-bootstrap.react-bootstrap.Omit<react-bootstrap.react-bootstrap/lib/ButtonGroup.ButtonGroupProps, 'onChange'> & react-bootstrap.react-bootstrap.Omit<react.react.HTMLProps<react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.ToggleButtonGroup>, 'defaultValue' | 'type' | 'value' | 'onChange'> | react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.CheckboxProps & react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.BaseProps & react-bootstrap.react-bootstrap.Omit<react-bootstrap.react-bootstrap/lib/ButtonGroup.ButtonGroupProps, 'onChange'> & react-bootstrap.react-bootstrap.Omit<react.react.HTMLProps<react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.ToggleButtonGroup>, 'defaultValue' | 'type' | 'value' | 'onChange'>
+  }}}
+  to avoid circular code involving: 
+  - react-bootstrap.react-bootstrap.ToggleButtonGroup.ToggleButtonGroup
+  - react-bootstrap.react-bootstrap.ToggleButtonGroup.ToggleButtonGroupProps
+  - react-bootstrap.react-bootstrap.ToggleButtonGroupProps
+  - react-bootstrap.react-bootstrap/lib.ToggleButtonGroup.ToggleButtonGroup
+  - react-bootstrap.react-bootstrap/lib.ToggleButtonGroup.ToggleButtonGroupProps
+  - react-bootstrap.react-bootstrap/lib.ToggleButtonGroupProps
+  - react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.ToggleButtonGroup
+  - react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.ToggleButtonGroupProps
+  */
   type ToggleButtonGroupProps = (RadioProps & BaseProps & (Omit[ButtonGroupProps, onChange]) & (Omit[HTMLProps[Any], defaultValue | `type` | value | onChange])) | (CheckboxProps & BaseProps & (Omit[ButtonGroupProps, onChange]) & (Omit[HTMLProps[Any], defaultValue | `type` | value | onChange]))
 }

--- a/tests/react-integration-test/check-japgolly-3/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-contextmenu/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-cc5061"
+version := "2.13.0-03d5bf"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-53a3df",
+  "org.scalablytyped" %%% "react" % "16.9.2-1d9012",
   "org.scalablytyped" %%% "std" % "0.0-unknown-e4bffc")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-dropzone/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-fbeafa"
+version := "10.1.10-82ef46"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-53a3df",
+  "org.scalablytyped" %%% "react" % "16.9.2-1d9012",
   "org.scalablytyped" %%% "std" % "0.0-unknown-e4bffc")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/r/react-markdown/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-markdown/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-markdown"
-version := "0.0-unknown-08ad1f"
+version := "0.0-unknown-99c445"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-53a3df",
+  "org.scalablytyped" %%% "react" % "16.9.2-1d9012",
   "org.scalablytyped" %%% "std" % "0.0-unknown-e4bffc")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-select/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-46822a"
+version := "0.0-unknown-deda72"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-53a3df",
+  "org.scalablytyped" %%% "react" % "16.9.2-1d9012",
   "org.scalablytyped" %%% "std" % "0.0-unknown-e4bffc")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/r/react/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-53a3df"
+version := "16.9.2-1d9012"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-japgolly-3/r/react/src/main/scala/typingsJapgolly/react/mod/ReactNodeArray.scala
+++ b/tests/react-integration-test/check-japgolly-3/r/react/src/main/scala/typingsJapgolly/react/mod/ReactNodeArray.scala
@@ -6,6 +6,19 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
+/** 
+NOTE: Rewritten from type alias:
+{{{
+type ReactNodeArray = std.Array<react.react.ReactNode>
+}}}
+to avoid circular code involving: 
+- react.<global>.React.ReactFragment
+- react.<global>.React.ReactNode
+- react.<global>.React.ReactNodeArray
+- react.react.ReactFragment
+- react.react.ReactNode
+- react.react.ReactNodeArray
+*/
 trait ReactNodeArray
   extends StObject
      with Array[Node]

--- a/tests/react-integration-test/check-japgolly-3/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/s/semantic-ui-react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-a8aec2"
+version := "0.0-unknown-4ec302"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-53a3df",
+  "org.scalablytyped" %%% "react" % "16.9.2-1d9012",
   "org.scalablytyped" %%% "std" % "0.0-unknown-e4bffc")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-eb5f19"
+version := "0.38.0-a84722"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-53a3df",
+  "org.scalablytyped" %%% "react" % "16.9.2-1d9012",
   "org.scalablytyped" %%% "std" % "0.0-unknown-e4bffc")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-ref/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-224208"
+version := "0.38.0-cd6008"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-53a3df",
+  "org.scalablytyped" %%% "react" % "16.9.2-1d9012",
   "org.scalablytyped" %%% "std" % "0.0-unknown-e4bffc")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-8079b2"
+version := "0.0-unknown-0ba9c5"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-09a2af",
+  "org.scalablytyped" %%% "react" % "16.9.2-175d61",
   "org.scalablytyped" %%% "std" % "0.0-unknown-24fca3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-bootstrap/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-f9d93c"
+version := "0.32-3a6785"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-09a2af",
+  "org.scalablytyped" %%% "react" % "16.9.2-175d61",
   "org.scalablytyped" %%% "std" % "0.0-unknown-24fca3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/libToggleButtonGroupMod.scala
+++ b/tests/react-integration-test/check-slinky-3/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/libToggleButtonGroupMod.scala
@@ -116,5 +116,20 @@ object libToggleButtonGroupMod {
   
   type ToggleButtonGroup = ReactComponentClass[ToggleButtonGroupProps]
   
+  /** 
+  NOTE: Rewritten from type alias:
+  {{{
+  type ToggleButtonGroupProps = react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.RadioProps & react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.BaseProps & react-bootstrap.react-bootstrap.Omit<react-bootstrap.react-bootstrap/lib/ButtonGroup.ButtonGroupProps, 'onChange'> & react-bootstrap.react-bootstrap.Omit<react.react.HTMLProps<react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.ToggleButtonGroup>, 'defaultValue' | 'type' | 'value' | 'onChange'> | react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.CheckboxProps & react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.BaseProps & react-bootstrap.react-bootstrap.Omit<react-bootstrap.react-bootstrap/lib/ButtonGroup.ButtonGroupProps, 'onChange'> & react-bootstrap.react-bootstrap.Omit<react.react.HTMLProps<react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.ToggleButtonGroup>, 'defaultValue' | 'type' | 'value' | 'onChange'>
+  }}}
+  to avoid circular code involving: 
+  - react-bootstrap.react-bootstrap.ToggleButtonGroup.ToggleButtonGroup
+  - react-bootstrap.react-bootstrap.ToggleButtonGroup.ToggleButtonGroupProps
+  - react-bootstrap.react-bootstrap.ToggleButtonGroupProps
+  - react-bootstrap.react-bootstrap/lib.ToggleButtonGroup.ToggleButtonGroup
+  - react-bootstrap.react-bootstrap/lib.ToggleButtonGroup.ToggleButtonGroupProps
+  - react-bootstrap.react-bootstrap/lib.ToggleButtonGroupProps
+  - react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.ToggleButtonGroup
+  - react-bootstrap.react-bootstrap/lib/ToggleButtonGroup.ToggleButtonGroupProps
+  */
   type ToggleButtonGroupProps = (RadioProps & BaseProps & (Omit[ButtonGroupProps, onChange]) & (Omit[HTMLProps[Any], defaultValue | `type` | value | onChange])) | (CheckboxProps & BaseProps & (Omit[ButtonGroupProps, onChange]) & (Omit[HTMLProps[Any], defaultValue | `type` | value | onChange]))
 }

--- a/tests/react-integration-test/check-slinky-3/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-contextmenu/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-717d4e"
+version := "2.13.0-119c26"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-09a2af",
+  "org.scalablytyped" %%% "react" % "16.9.2-175d61",
   "org.scalablytyped" %%% "std" % "0.0-unknown-24fca3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-dropzone/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-dd5a75"
+version := "10.1.10-8f7eee"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-09a2af",
+  "org.scalablytyped" %%% "react" % "16.9.2-175d61",
   "org.scalablytyped" %%% "std" % "0.0-unknown-24fca3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react-markdown/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-markdown/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-markdown"
-version := "0.0-unknown-cfc72f"
+version := "0.0-unknown-c6e45f"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-09a2af",
+  "org.scalablytyped" %%% "react" % "16.9.2-175d61",
   "org.scalablytyped" %%% "std" % "0.0-unknown-24fca3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-select/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-df941e"
+version := "0.0-unknown-b26e52"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-09a2af",
+  "org.scalablytyped" %%% "react" % "16.9.2-175d61",
   "org.scalablytyped" %%% "std" % "0.0-unknown-24fca3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-09a2af"
+version := "16.9.2-175d61"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/mod/ReactNodeArray.scala
+++ b/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/mod/ReactNodeArray.scala
@@ -5,6 +5,19 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
+/** 
+NOTE: Rewritten from type alias:
+{{{
+type ReactNodeArray = std.Array<react.react.ReactNode>
+}}}
+to avoid circular code involving: 
+- react.<global>.React.ReactFragment
+- react.<global>.React.ReactNode
+- react.<global>.React.ReactNodeArray
+- react.react.ReactFragment
+- react.react.ReactNode
+- react.react.ReactNodeArray
+*/
 trait ReactNodeArray
   extends StObject
      with Array[slinky.core.facade.ReactElement]

--- a/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-6fabb9"
+version := "0.0-unknown-414cc0"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-09a2af",
+  "org.scalablytyped" %%% "react" % "16.9.2-175d61",
   "org.scalablytyped" %%% "std" % "0.0-unknown-24fca3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-4ef9da"
+version := "0.38.0-847058"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-09a2af",
+  "org.scalablytyped" %%% "react" % "16.9.2-175d61",
   "org.scalablytyped" %%% "std" % "0.0-unknown-24fca3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-ref/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-20c03f"
+version := "0.38.0-d74fd7"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-09a2af",
+  "org.scalablytyped" %%% "react" % "16.9.2-175d61",
   "org.scalablytyped" %%% "std" % "0.0-unknown-24fca3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/stylis/check-3/s/stylis/build.sbt
+++ b/tests/stylis/check-3/s/stylis/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "stylis"
-version := "0.0-unknown-d378d1"
+version := "0.0-unknown-26a40d"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/stylis/check-3/s/stylis/src/main/scala/typings/stylis/stylisMod.scala
+++ b/tests/stylis/check-3/s/stylis/src/main/scala/typings/stylis/stylisMod.scala
@@ -150,6 +150,14 @@ object stylisMod extends Shortcut {
   
   type Selectors = js.Array[String]
   
+  /** 
+  NOTE: Rewritten from type alias:
+  {{{
+  type Set = (options : stylis.stylis/stylis.Options | undefined): stylis.stylis/stylis.Set
+  }}}
+  to avoid circular code involving: 
+  - stylis.stylis/stylis.Set
+  */
   @js.native
   trait Set extends StObject {
     
@@ -177,6 +185,14 @@ object stylisMod extends Shortcut {
     var use_Original: Use = js.native
   }
   
+  /** 
+  NOTE: Rewritten from type alias:
+  {{{
+  type Use = (plugin : std.Array<stylis.stylis/stylis.Plugin> | stylis.stylis/stylis.Plugin | null | undefined): stylis.stylis/stylis.Use
+  }}}
+  to avoid circular code involving: 
+  - stylis.stylis/stylis.Use
+  */
   @js.native
   trait Use extends StObject {
     

--- a/tests/vfile/check-3/v/vfile/build.sbt
+++ b/tests/vfile/check-3/v/vfile/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "vfile"
-version := "0.0-unknown-d37623"
+version := "0.0-unknown-0ed86e"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/vfile/check-3/v/vfile/src/main/scala/typings/vfile/VFile.scala
+++ b/tests/vfile/check-3/v/vfile/src/main/scala/typings/vfile/VFile.scala
@@ -4,6 +4,14 @@ import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
+/** 
+NOTE: Rewritten from type alias:
+{{{
+type VFile = <F extends vfile.VFile>(input : vfile.VFileContents | F | vfile.VFileOptions | undefined): F
+}}}
+to avoid circular code involving: 
+- vfile.VFile
+*/
 @js.native
 trait VFile extends StObject {
   

--- a/tests/vue/check-3/s/storybook__vue/build.sbt
+++ b/tests/vue/check-3/s/storybook__vue/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "storybook__vue"
-version := "3.3-06ee93"
+version := "3.3-90f8e2"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "org.scalablytyped" %%% "std" % "0.0-unknown-8a4826",
-  "org.scalablytyped" %%% "vue" % "2.5.13-e59104",
+  "org.scalablytyped" %%% "vue" % "2.5.13-1628b0",
   "org.scalablytyped" %%% "webpack-env" % "1.13-eeea5a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/vue/check-3/v/vue-scrollto/build.sbt
+++ b/tests/vue/check-3/v/vue-scrollto/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "vue-scrollto"
-version := "2.7-7ec576"
+version := "2.7-ff8ad5"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "org.scalablytyped" %%% "std" % "0.0-unknown-8a4826",
-  "org.scalablytyped" %%% "vue" % "2.5.13-e59104")
+  "org.scalablytyped" %%% "vue" % "2.5.13-1628b0")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/vue/check-3/v/vue/build.sbt
+++ b/tests/vue/check-3/v/vue/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "vue"
-version := "2.5.13-e59104"
+version := "2.5.13-1628b0"
 scalaVersion := "3.2.0"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/vue/check-3/v/vue/src/main/scala/typings/vue/typesVnodeMod.scala
+++ b/tests/vue/check-3/v/vue/src/main/scala/typings/vue/typesVnodeMod.scala
@@ -12,6 +12,18 @@ import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, J
 
 object typesVnodeMod {
   
+  /** 
+  NOTE: Rewritten from type alias:
+  {{{
+  type ScopedSlot = (props : any): vue.vue/types/vnode.VNodeChildrenArrayContents | string
+  }}}
+  to avoid circular code involving: 
+  - vue.vue.VNodeChildren
+  - vue.vue.VNodeChildrenArrayContents
+  - vue.vue/types/vnode.ScopedSlot
+  - vue.vue/types/vnode.VNodeChildren
+  - vue.vue/types/vnode.VNodeChildrenArrayContents
+  */
   @js.native
   trait ScopedSlot extends StObject {
     
@@ -121,6 +133,16 @@ object typesVnodeMod {
   
   type VNodeChildren = VNodeChildrenArrayContents | js.Array[ScopedSlot] | String
   
+  /** 
+  NOTE: Rewritten from type alias:
+  {{{
+  type VNodeChildrenArrayContents = {[x: number] : vue.vue/types/vnode.VNode | string | vue.vue/types/vnode.VNodeChildren}
+  }}}
+  to avoid circular code involving: 
+  - vue.vue.VNodeChildren
+  - vue.vue/types/vnode.VNodeChildren
+  - vue.vue/types/vnode.VNodeChildrenArrayContents
+  */
   trait VNodeChildrenArrayContents
     extends StObject
        with /* x */ NumberDictionary[VNode | String | VNodeChildren]


### PR DESCRIPTION
- follow `FollowAliases` before deciding branch
- this was one of the reasons why we sometimes end up with for instance union types in inheritance hierarchies
- generate a comment describing the rewrite and possible lack of precision