### PR TITLE
Fixes #539: Support sbt 1.9.0 projects

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.0

--- a/sbt-converter/src/main/scala/org/scalablytyped/converter/plugin/ScalablyTypedPluginBase.scala
+++ b/sbt-converter/src/main/scala/org/scalablytyped/converter/plugin/ScalablyTypedPluginBase.scala
@@ -10,6 +10,8 @@ import org.scalablytyped.converter.internal.ts.TsIdentLibrary
 import sbt.Tags.Tag
 import sbt._
 import sbt.plugins.JvmPlugin
+import scala.util.matching.Regex
+import scala.util.Try
 
 import java.io.File
 import scala.collection.immutable.SortedSet
@@ -109,9 +111,12 @@ object ScalablyTypedPluginBase extends AutoPlugin {
   override lazy val globalSettings =
     Seq(
       Global / Keys.onLoad := (state => {
-        val old = (Global / Keys.onLoad).value
+        val old               = (Global / Keys.onLoad).value
+        val sbtVersionPattern = """^(\d+)\.(\d+)(\..*)?""".r
         Keys.sbtVersion.value match {
-          case valid if valid.startsWith("1.8") => old(state)
+          case sbtVersionPattern(major, minor, _)
+              if major == "1" && Try(minor.toInt).toOption.map(_ >= 8).getOrElse(false) =>
+            old(state)
           case invalid =>
             sys.error(
               s"This version of the ScalablyTyped plugin only supports 1.8.x. You're currently using $invalid",

--- a/sbt-converter/src/main/scala/org/scalablytyped/converter/plugin/ScalablyTypedPluginBase.scala
+++ b/sbt-converter/src/main/scala/org/scalablytyped/converter/plugin/ScalablyTypedPluginBase.scala
@@ -119,7 +119,7 @@ object ScalablyTypedPluginBase extends AutoPlugin {
             old(state)
           case invalid =>
             sys.error(
-              s"This version of the ScalablyTyped plugin only supports 1.8.x. You're currently using $invalid",
+              s"This version of the ScalablyTyped plugin only supports 1.8.x or later. You're currently using $invalid",
             )
         }
       }),

--- a/sbt-converter/src/sbt-test/react/external/project/build.properties
+++ b/sbt-converter/src/sbt-test/react/external/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.9.0


### PR DESCRIPTION
- Upgrade to sbt 1.9.0
- Fixed the version check to support sbt 1.8.0 or later
- Use sbt 1.9.0 in one of the sbt scripted test projects to check the behavior