### PR TITLE
Fix ordering of Slinky SyntheticEvent type parameters

### DIFF
--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/SlinkyTypeConversions.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/SlinkyTypeConversions.scala
@@ -22,7 +22,7 @@ object SlinkyTypeConversions {
         CastConversion(reactNames.DOMElement, names.ReactElement),
         CastConversion(reactNames.ElementType, names.ReactElement),
         CastConversion(reactNames.BaseSyntheticEvent, names.SyntheticEvent, _2, _1),
-        CastConversion(reactNames.SyntheticEvent, names.SyntheticEvent, _2, _1),
+        CastConversion(reactNames.SyntheticEvent, names.SyntheticEvent, _1, _2),
       )
 
     val components: IArray[CastConversion] =

--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-bac773"
+version := "0.0-unknown-52406a"
 scalaVersion := "3.3.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/mod.scala
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/mod.scala
@@ -2,6 +2,7 @@ package typingsJapgolly.componentstest
 
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.CallbackTo
+import japgolly.scalajs.react.ReactEventFrom
 import japgolly.scalajs.react.ReactMouseEventFrom
 import org.scalajs.dom.Element
 import org.scalajs.dom.HTMLDivElement
@@ -160,6 +161,24 @@ object mod {
       inline def setPrefixCls(value: String): Self = StObject.set(x, "prefixCls", value.asInstanceOf[js.Any])
       
       inline def setPrefixClsUndefined: Self = StObject.set(x, "prefixCls", js.undefined)
+    }
+  }
+  
+  trait Events extends StObject {
+    
+    def onClick(event: ReactEventFrom[Any & Element]): Unit
+  }
+  object Events {
+    
+    inline def apply(onClick: ReactEventFrom[Any & Element] => Callback): Events = {
+      val __obj = js.Dynamic.literal(onClick = js.Any.fromFunction1((t0: ReactEventFrom[Any & Element]) => onClick(t0).runNow()))
+      __obj.asInstanceOf[Events]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: Events] (val x: Self) extends AnyVal {
+      
+      inline def setOnClick(value: ReactEventFrom[Any & Element] => Callback): Self = StObject.set(x, "onClick", js.Any.fromFunction1((t0: ReactEventFrom[Any & Element]) => value(t0).runNow()))
     }
   }
   

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-2f8b04"
+version := "0.0-unknown-367bbf"
 scalaVersion := "3.3.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-367bbf"
+version := "0.0-unknown-e027c7"
 scalaVersion := "3.3.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d793cd",
+  "org.scalablytyped" %%% "react" % "16.9.2-25cfad",
   "org.scalablytyped" %%% "std" % "0.0-unknown-7f073b")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/mod.scala
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/mod.scala
@@ -160,24 +160,24 @@ object mod {
   }
   
   trait Events extends StObject {
-
+    
     def onClick(event: SyntheticEvent[Any, Event]): Unit
   }
   object Events {
-
+    
     inline def apply(onClick: SyntheticEvent[Any, Event] => Unit): Events = {
       val __obj = js.Dynamic.literal(onClick = js.Any.fromFunction1(onClick))
       __obj.asInstanceOf[Events]
     }
-
+    
     @scala.inline
     implicit open class MutableBuilder[Self <: Events] (val x: Self) extends AnyVal {
-
+      
       inline def setOnClick(value: SyntheticEvent[Any, Event] => Unit): Self = StObject.set(x, "onClick", js.Any.fromFunction1(value))
     }
   }
-
-  /* Rewritten from type alias, can be one of:
+  
+  /* Rewritten from type alias, can be one of: 
     - typingsSlinky.componentstest.mod.A
     - typingsSlinky.componentstest.mod.B
   */

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/mod.scala
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/mod.scala
@@ -1,7 +1,9 @@
 package typingsSlinky.componentstest
 
+import org.scalajs.dom.Event
 import org.scalajs.dom.HTMLDivElement
 import slinky.core.ReactComponentClass
+import slinky.core.SyntheticEvent
 import slinky.web.SyntheticMouseEvent
 import typingsSlinky.componentstest.anon.Equals
 import typingsSlinky.react.mod.CSSProperties
@@ -157,7 +159,25 @@ object mod {
     }
   }
   
-  /* Rewritten from type alias, can be one of: 
+  trait Events extends StObject {
+
+    def onClick(event: SyntheticEvent[Any, Event]): Unit
+  }
+  object Events {
+
+    inline def apply(onClick: SyntheticEvent[Any, Event] => Unit): Events = {
+      val __obj = js.Dynamic.literal(onClick = js.Any.fromFunction1(onClick))
+      __obj.asInstanceOf[Events]
+    }
+
+    @scala.inline
+    implicit open class MutableBuilder[Self <: Events] (val x: Self) extends AnyVal {
+
+      inline def setOnClick(value: SyntheticEvent[Any, Event] => Unit): Self = StObject.set(x, "onClick", js.Any.fromFunction1(value))
+    }
+  }
+
+  /* Rewritten from type alias, can be one of:
     - typingsSlinky.componentstest.mod.A
     - typingsSlinky.componentstest.mod.B
   */

--- a/tests/react-integration-test/check-slinky-3/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-bootstrap/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-19d27a"
+version := "0.32-0b4f99"
 scalaVersion := "3.3.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d793cd",
+  "org.scalablytyped" %%% "react" % "16.9.2-25cfad",
   "org.scalablytyped" %%% "std" % "0.0-unknown-7f073b")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/components/ButtonGroup.scala
+++ b/tests/react-integration-test/check-slinky-3/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/components/ButtonGroup.scala
@@ -369,7 +369,7 @@ object ButtonGroup {
     
     inline def nonce(value: String): this.type = set("nonce", value.asInstanceOf[js.Any])
     
-    inline def onAbort(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
+    inline def onAbort(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
     
     inline def onAnimationEnd(value: SyntheticAnimationEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onAnimationEnd", js.Any.fromFunction1(value))
     
@@ -383,9 +383,9 @@ object ButtonGroup {
     
     inline def onBlur(value: SyntheticFocusEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onBlur", js.Any.fromFunction1(value))
     
-    inline def onCanPlay(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
+    inline def onCanPlay(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
     
-    inline def onCanPlayThrough(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
+    inline def onCanPlayThrough(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
     
     inline def onChange(value: SyntheticEvent[EventTarget & ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onChange", js.Any.fromFunction1(value))
     
@@ -421,15 +421,15 @@ object ButtonGroup {
     
     inline def onDrop(value: DragEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onDrop", js.Any.fromFunction1(value))
     
-    inline def onDurationChange(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
+    inline def onDurationChange(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
     
-    inline def onEmptied(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
+    inline def onEmptied(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
     
-    inline def onEncrypted(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
+    inline def onEncrypted(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
     
-    inline def onEnded(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
+    inline def onEnded(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
     
-    inline def onError(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
+    inline def onError(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
     
     inline def onFocus(value: SyntheticFocusEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onFocus", js.Any.fromFunction1(value))
     
@@ -443,13 +443,13 @@ object ButtonGroup {
     
     inline def onKeyUp(value: SyntheticKeyboardEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onKeyUp", js.Any.fromFunction1(value))
     
-    inline def onLoad(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
+    inline def onLoad(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
     
-    inline def onLoadStart(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
+    inline def onLoadStart(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
     
-    inline def onLoadedData(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
+    inline def onLoadedData(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
     
-    inline def onLoadedMetadata(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
+    inline def onLoadedMetadata(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
     
     inline def onMouseDown(value: SyntheticMouseEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onMouseDown", js.Any.fromFunction1(value))
     
@@ -467,11 +467,11 @@ object ButtonGroup {
     
     inline def onPaste(value: SyntheticClipboardEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPaste", js.Any.fromFunction1(value))
     
-    inline def onPause(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
+    inline def onPause(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
     
-    inline def onPlay(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
+    inline def onPlay(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
     
-    inline def onPlaying(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
+    inline def onPlaying(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
     
     inline def onPointerCancel(value: SyntheticPointerEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPointerCancel", js.Any.fromFunction1(value))
     
@@ -489,27 +489,27 @@ object ButtonGroup {
     
     inline def onPointerUp(value: SyntheticPointerEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPointerUp", js.Any.fromFunction1(value))
     
-    inline def onProgress(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
+    inline def onProgress(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
     
-    inline def onRateChange(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
+    inline def onRateChange(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
     
     inline def onReset(value: SyntheticEvent[EventTarget & ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onReset", js.Any.fromFunction1(value))
     
     inline def onScroll(value: SyntheticUIEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onScroll", js.Any.fromFunction1(value))
     
-    inline def onSeeked(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
+    inline def onSeeked(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
     
-    inline def onSeeking(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
+    inline def onSeeking(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
     
-    inline def onSelect(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
+    inline def onSelect(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
     
-    inline def onStalled(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
+    inline def onStalled(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
     
     inline def onSubmit(value: SyntheticEvent[EventTarget & ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onSubmit", js.Any.fromFunction1(value))
     
-    inline def onSuspend(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
+    inline def onSuspend(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
     
-    inline def onTimeUpdate(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
+    inline def onTimeUpdate(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
     
     inline def onTouchCancel(value: SyntheticTouchEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onTouchCancel", js.Any.fromFunction1(value))
     
@@ -521,9 +521,9 @@ object ButtonGroup {
     
     inline def onTransitionEnd(value: SyntheticTransitionEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onTransitionEnd", js.Any.fromFunction1(value))
     
-    inline def onVolumeChange(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
+    inline def onVolumeChange(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
     
-    inline def onWaiting(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
+    inline def onWaiting(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
     
     inline def onWheel(value: SyntheticWheelEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onWheel", js.Any.fromFunction1(value))
     

--- a/tests/react-integration-test/check-slinky-3/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/components/ToggleButtonGroup.scala
+++ b/tests/react-integration-test/check-slinky-3/r/react-bootstrap/src/main/scala/typingsSlinky/reactBootstrap/components/ToggleButtonGroup.scala
@@ -379,7 +379,7 @@ object ToggleButtonGroup {
       
       inline def nonce(value: String): this.type = set("nonce", value.asInstanceOf[js.Any])
       
-      inline def onAbort(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
+      inline def onAbort(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
       
       inline def onAnimationEnd(value: SyntheticAnimationEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onAnimationEnd", js.Any.fromFunction1(value))
       
@@ -393,9 +393,9 @@ object ToggleButtonGroup {
       
       inline def onBlur(value: SyntheticFocusEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onBlur", js.Any.fromFunction1(value))
       
-      inline def onCanPlay(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
+      inline def onCanPlay(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
       
-      inline def onCanPlayThrough(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
+      inline def onCanPlayThrough(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
       
       inline def onChange(value: /* values */ js.Array[Any] => Unit): this.type = set("onChange", js.Any.fromFunction1(value))
       
@@ -431,15 +431,15 @@ object ToggleButtonGroup {
       
       inline def onDrop(value: DragEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onDrop", js.Any.fromFunction1(value))
       
-      inline def onDurationChange(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
+      inline def onDurationChange(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
       
-      inline def onEmptied(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
+      inline def onEmptied(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
       
-      inline def onEncrypted(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
+      inline def onEncrypted(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
       
-      inline def onEnded(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
+      inline def onEnded(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
       
-      inline def onError(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
+      inline def onError(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
       
       inline def onFocus(value: SyntheticFocusEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onFocus", js.Any.fromFunction1(value))
       
@@ -453,13 +453,13 @@ object ToggleButtonGroup {
       
       inline def onKeyUp(value: SyntheticKeyboardEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onKeyUp", js.Any.fromFunction1(value))
       
-      inline def onLoad(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
+      inline def onLoad(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
       
-      inline def onLoadStart(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
+      inline def onLoadStart(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
       
-      inline def onLoadedData(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
+      inline def onLoadedData(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
       
-      inline def onLoadedMetadata(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
+      inline def onLoadedMetadata(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
       
       inline def onMouseDown(value: SyntheticMouseEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onMouseDown", js.Any.fromFunction1(value))
       
@@ -477,11 +477,11 @@ object ToggleButtonGroup {
       
       inline def onPaste(value: SyntheticClipboardEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPaste", js.Any.fromFunction1(value))
       
-      inline def onPause(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
+      inline def onPause(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
       
-      inline def onPlay(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
+      inline def onPlay(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
       
-      inline def onPlaying(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
+      inline def onPlaying(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
       
       inline def onPointerCancel(value: SyntheticPointerEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPointerCancel", js.Any.fromFunction1(value))
       
@@ -499,27 +499,27 @@ object ToggleButtonGroup {
       
       inline def onPointerUp(value: SyntheticPointerEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPointerUp", js.Any.fromFunction1(value))
       
-      inline def onProgress(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
+      inline def onProgress(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
       
-      inline def onRateChange(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
+      inline def onRateChange(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
       
       inline def onReset(value: SyntheticEvent[EventTarget & ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onReset", js.Any.fromFunction1(value))
       
       inline def onScroll(value: SyntheticUIEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onScroll", js.Any.fromFunction1(value))
       
-      inline def onSeeked(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
+      inline def onSeeked(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
       
-      inline def onSeeking(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
+      inline def onSeeking(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
       
-      inline def onSelect(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
+      inline def onSelect(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
       
-      inline def onStalled(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
+      inline def onStalled(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
       
       inline def onSubmit(value: SyntheticEvent[EventTarget & ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onSubmit", js.Any.fromFunction1(value))
       
-      inline def onSuspend(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
+      inline def onSuspend(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
       
-      inline def onTimeUpdate(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
+      inline def onTimeUpdate(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
       
       inline def onTouchCancel(value: SyntheticTouchEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onTouchCancel", js.Any.fromFunction1(value))
       
@@ -531,9 +531,9 @@ object ToggleButtonGroup {
       
       inline def onTransitionEnd(value: SyntheticTransitionEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onTransitionEnd", js.Any.fromFunction1(value))
       
-      inline def onVolumeChange(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
+      inline def onVolumeChange(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
       
-      inline def onWaiting(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
+      inline def onWaiting(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
       
       inline def onWheel(value: SyntheticWheelEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onWheel", js.Any.fromFunction1(value))
       
@@ -960,7 +960,7 @@ object ToggleButtonGroup {
       
       inline def nonce(value: String): this.type = set("nonce", value.asInstanceOf[js.Any])
       
-      inline def onAbort(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
+      inline def onAbort(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
       
       inline def onAnimationEnd(value: SyntheticAnimationEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onAnimationEnd", js.Any.fromFunction1(value))
       
@@ -974,9 +974,9 @@ object ToggleButtonGroup {
       
       inline def onBlur(value: SyntheticFocusEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onBlur", js.Any.fromFunction1(value))
       
-      inline def onCanPlay(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
+      inline def onCanPlay(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
       
-      inline def onCanPlayThrough(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
+      inline def onCanPlayThrough(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
       
       inline def onChange(value: /* value */ Any => Unit): this.type = set("onChange", js.Any.fromFunction1(value))
       
@@ -1012,15 +1012,15 @@ object ToggleButtonGroup {
       
       inline def onDrop(value: DragEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onDrop", js.Any.fromFunction1(value))
       
-      inline def onDurationChange(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
+      inline def onDurationChange(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
       
-      inline def onEmptied(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
+      inline def onEmptied(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
       
-      inline def onEncrypted(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
+      inline def onEncrypted(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
       
-      inline def onEnded(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
+      inline def onEnded(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
       
-      inline def onError(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
+      inline def onError(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
       
       inline def onFocus(value: SyntheticFocusEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onFocus", js.Any.fromFunction1(value))
       
@@ -1034,13 +1034,13 @@ object ToggleButtonGroup {
       
       inline def onKeyUp(value: SyntheticKeyboardEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onKeyUp", js.Any.fromFunction1(value))
       
-      inline def onLoad(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
+      inline def onLoad(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
       
-      inline def onLoadStart(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
+      inline def onLoadStart(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
       
-      inline def onLoadedData(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
+      inline def onLoadedData(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
       
-      inline def onLoadedMetadata(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
+      inline def onLoadedMetadata(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
       
       inline def onMouseDown(value: SyntheticMouseEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onMouseDown", js.Any.fromFunction1(value))
       
@@ -1058,11 +1058,11 @@ object ToggleButtonGroup {
       
       inline def onPaste(value: SyntheticClipboardEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPaste", js.Any.fromFunction1(value))
       
-      inline def onPause(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
+      inline def onPause(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
       
-      inline def onPlay(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
+      inline def onPlay(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
       
-      inline def onPlaying(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
+      inline def onPlaying(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
       
       inline def onPointerCancel(value: SyntheticPointerEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPointerCancel", js.Any.fromFunction1(value))
       
@@ -1080,27 +1080,27 @@ object ToggleButtonGroup {
       
       inline def onPointerUp(value: SyntheticPointerEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onPointerUp", js.Any.fromFunction1(value))
       
-      inline def onProgress(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
+      inline def onProgress(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
       
-      inline def onRateChange(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
+      inline def onRateChange(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
       
       inline def onReset(value: SyntheticEvent[EventTarget & ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onReset", js.Any.fromFunction1(value))
       
       inline def onScroll(value: SyntheticUIEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onScroll", js.Any.fromFunction1(value))
       
-      inline def onSeeked(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
+      inline def onSeeked(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
       
-      inline def onSeeking(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
+      inline def onSeeking(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
       
-      inline def onSelect(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
+      inline def onSelect(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
       
-      inline def onStalled(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
+      inline def onStalled(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
       
       inline def onSubmit(value: SyntheticEvent[EventTarget & ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onSubmit", js.Any.fromFunction1(value))
       
-      inline def onSuspend(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
+      inline def onSuspend(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
       
-      inline def onTimeUpdate(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
+      inline def onTimeUpdate(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
       
       inline def onTouchCancel(value: SyntheticTouchEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onTouchCancel", js.Any.fromFunction1(value))
       
@@ -1112,9 +1112,9 @@ object ToggleButtonGroup {
       
       inline def onTransitionEnd(value: SyntheticTransitionEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onTransitionEnd", js.Any.fromFunction1(value))
       
-      inline def onVolumeChange(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
+      inline def onVolumeChange(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
       
-      inline def onWaiting(value: SyntheticEvent[Event, ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
+      inline def onWaiting(value: SyntheticEvent[ReactComponentClass[ButtonGroupProps], Event] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
       
       inline def onWheel(value: SyntheticWheelEvent[ReactComponentClass[ButtonGroupProps]] => Unit): this.type = set("onWheel", js.Any.fromFunction1(value))
       

--- a/tests/react-integration-test/check-slinky-3/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-contextmenu/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-d78f9d"
+version := "2.13.0-485ce0"
 scalaVersion := "3.3.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d793cd",
+  "org.scalablytyped" %%% "react" % "16.9.2-25cfad",
   "org.scalablytyped" %%% "std" % "0.0-unknown-7f073b")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-dropzone/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-62f1fc"
+version := "10.1.10-179355"
 scalaVersion := "3.3.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d793cd",
+  "org.scalablytyped" %%% "react" % "16.9.2-25cfad",
   "org.scalablytyped" %%% "std" % "0.0-unknown-7f073b")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react-markdown/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-markdown/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-markdown"
-version := "0.0-unknown-e636da"
+version := "0.0-unknown-87fc8b"
 scalaVersion := "3.3.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d793cd",
+  "org.scalablytyped" %%% "react" % "16.9.2-25cfad",
   "org.scalablytyped" %%% "std" % "0.0-unknown-7f073b")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-select/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-8dc02f"
+version := "0.0-unknown-90a136"
 scalaVersion := "3.3.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d793cd",
+  "org.scalablytyped" %%% "react" % "16.9.2-25cfad",
   "org.scalablytyped" %%% "std" % "0.0-unknown-7f073b")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/r/react/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-d793cd"
+version := "16.9.2-25cfad"
 scalaVersion := "3.3.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/components/SharedBuilder_DetailedHTMLProps_1670340210.scala
+++ b/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/components/SharedBuilder_DetailedHTMLProps_1670340210.scala
@@ -215,7 +215,7 @@ open class SharedBuilder_DetailedHTMLProps_1670340210[R <: js.Object] (val args:
   
   inline def lang(value: String): this.type = set("lang", value.asInstanceOf[js.Any])
   
-  inline def onAbort(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
+  inline def onAbort(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
   
   inline def onAnimationEnd(value: SyntheticAnimationEvent[HTMLElement] => Unit): this.type = set("onAnimationEnd", js.Any.fromFunction1(value))
   
@@ -229,9 +229,9 @@ open class SharedBuilder_DetailedHTMLProps_1670340210[R <: js.Object] (val args:
   
   inline def onBlur(value: SyntheticFocusEvent[HTMLElement] => Unit): this.type = set("onBlur", js.Any.fromFunction1(value))
   
-  inline def onCanPlay(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
+  inline def onCanPlay(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
   
-  inline def onCanPlayThrough(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
+  inline def onCanPlayThrough(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
   
   inline def onChange(value: SyntheticEvent[EventTarget & HTMLElement, Event] => Unit): this.type = set("onChange", js.Any.fromFunction1(value))
   
@@ -267,15 +267,15 @@ open class SharedBuilder_DetailedHTMLProps_1670340210[R <: js.Object] (val args:
   
   inline def onDrop(value: DragEvent[HTMLElement] => Unit): this.type = set("onDrop", js.Any.fromFunction1(value))
   
-  inline def onDurationChange(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
+  inline def onDurationChange(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
   
-  inline def onEmptied(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
+  inline def onEmptied(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
   
-  inline def onEncrypted(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
+  inline def onEncrypted(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
   
-  inline def onEnded(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
+  inline def onEnded(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
   
-  inline def onError(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
+  inline def onError(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
   
   inline def onFocus(value: SyntheticFocusEvent[HTMLElement] => Unit): this.type = set("onFocus", js.Any.fromFunction1(value))
   
@@ -289,13 +289,13 @@ open class SharedBuilder_DetailedHTMLProps_1670340210[R <: js.Object] (val args:
   
   inline def onKeyUp(value: SyntheticKeyboardEvent[HTMLElement] => Unit): this.type = set("onKeyUp", js.Any.fromFunction1(value))
   
-  inline def onLoad(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
+  inline def onLoad(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
   
-  inline def onLoadStart(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
+  inline def onLoadStart(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
   
-  inline def onLoadedData(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
+  inline def onLoadedData(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
   
-  inline def onLoadedMetadata(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
+  inline def onLoadedMetadata(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
   
   inline def onMouseDown(value: SyntheticMouseEvent[HTMLElement] => Unit): this.type = set("onMouseDown", js.Any.fromFunction1(value))
   
@@ -313,11 +313,11 @@ open class SharedBuilder_DetailedHTMLProps_1670340210[R <: js.Object] (val args:
   
   inline def onPaste(value: SyntheticClipboardEvent[HTMLElement] => Unit): this.type = set("onPaste", js.Any.fromFunction1(value))
   
-  inline def onPause(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
+  inline def onPause(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
   
-  inline def onPlay(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
+  inline def onPlay(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
   
-  inline def onPlaying(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
+  inline def onPlaying(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
   
   inline def onPointerCancel(value: SyntheticPointerEvent[HTMLElement] => Unit): this.type = set("onPointerCancel", js.Any.fromFunction1(value))
   
@@ -335,27 +335,27 @@ open class SharedBuilder_DetailedHTMLProps_1670340210[R <: js.Object] (val args:
   
   inline def onPointerUp(value: SyntheticPointerEvent[HTMLElement] => Unit): this.type = set("onPointerUp", js.Any.fromFunction1(value))
   
-  inline def onProgress(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
+  inline def onProgress(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
   
-  inline def onRateChange(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
+  inline def onRateChange(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
   
   inline def onReset(value: SyntheticEvent[EventTarget & HTMLElement, Event] => Unit): this.type = set("onReset", js.Any.fromFunction1(value))
   
   inline def onScroll(value: SyntheticUIEvent[HTMLElement] => Unit): this.type = set("onScroll", js.Any.fromFunction1(value))
   
-  inline def onSeeked(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
+  inline def onSeeked(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
   
-  inline def onSeeking(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
+  inline def onSeeking(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
   
-  inline def onSelect(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
+  inline def onSelect(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
   
-  inline def onStalled(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
+  inline def onStalled(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
   
   inline def onSubmit(value: SyntheticEvent[EventTarget & HTMLElement, Event] => Unit): this.type = set("onSubmit", js.Any.fromFunction1(value))
   
-  inline def onSuspend(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
+  inline def onSuspend(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
   
-  inline def onTimeUpdate(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
+  inline def onTimeUpdate(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
   
   inline def onTouchCancel(value: SyntheticTouchEvent[HTMLElement] => Unit): this.type = set("onTouchCancel", js.Any.fromFunction1(value))
   
@@ -367,9 +367,9 @@ open class SharedBuilder_DetailedHTMLProps_1670340210[R <: js.Object] (val args:
   
   inline def onTransitionEnd(value: SyntheticTransitionEvent[HTMLElement] => Unit): this.type = set("onTransitionEnd", js.Any.fromFunction1(value))
   
-  inline def onVolumeChange(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
+  inline def onVolumeChange(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
   
-  inline def onWaiting(value: SyntheticEvent[Event, HTMLElement] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
+  inline def onWaiting(value: SyntheticEvent[HTMLElement, Event] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
   
   inline def onWheel(value: SyntheticWheelEvent[HTMLElement] => Unit): this.type = set("onWheel", js.Any.fromFunction1(value))
   

--- a/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/components/a.scala
+++ b/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/components/a.scala
@@ -227,7 +227,7 @@ object a {
     
     inline def media(value: String): this.type = set("media", value.asInstanceOf[js.Any])
     
-    inline def onAbort(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
+    inline def onAbort(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
     
     inline def onAnimationEnd(value: SyntheticAnimationEvent[HTMLAnchorElement] => Unit): this.type = set("onAnimationEnd", js.Any.fromFunction1(value))
     
@@ -241,9 +241,9 @@ object a {
     
     inline def onBlur(value: SyntheticFocusEvent[HTMLAnchorElement] => Unit): this.type = set("onBlur", js.Any.fromFunction1(value))
     
-    inline def onCanPlay(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
+    inline def onCanPlay(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
     
-    inline def onCanPlayThrough(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
+    inline def onCanPlayThrough(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
     
     inline def onChange(value: SyntheticEvent[EventTarget & HTMLAnchorElement, Event] => Unit): this.type = set("onChange", js.Any.fromFunction1(value))
     
@@ -279,15 +279,15 @@ object a {
     
     inline def onDrop(value: DragEvent[HTMLAnchorElement] => Unit): this.type = set("onDrop", js.Any.fromFunction1(value))
     
-    inline def onDurationChange(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
+    inline def onDurationChange(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
     
-    inline def onEmptied(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
+    inline def onEmptied(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
     
-    inline def onEncrypted(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
+    inline def onEncrypted(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
     
-    inline def onEnded(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
+    inline def onEnded(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
     
-    inline def onError(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
+    inline def onError(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
     
     inline def onFocus(value: SyntheticFocusEvent[HTMLAnchorElement] => Unit): this.type = set("onFocus", js.Any.fromFunction1(value))
     
@@ -301,13 +301,13 @@ object a {
     
     inline def onKeyUp(value: SyntheticKeyboardEvent[HTMLAnchorElement] => Unit): this.type = set("onKeyUp", js.Any.fromFunction1(value))
     
-    inline def onLoad(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
+    inline def onLoad(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
     
-    inline def onLoadStart(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
+    inline def onLoadStart(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
     
-    inline def onLoadedData(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
+    inline def onLoadedData(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
     
-    inline def onLoadedMetadata(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
+    inline def onLoadedMetadata(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
     
     inline def onMouseDown(value: SyntheticMouseEvent[HTMLAnchorElement] => Unit): this.type = set("onMouseDown", js.Any.fromFunction1(value))
     
@@ -325,11 +325,11 @@ object a {
     
     inline def onPaste(value: SyntheticClipboardEvent[HTMLAnchorElement] => Unit): this.type = set("onPaste", js.Any.fromFunction1(value))
     
-    inline def onPause(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
+    inline def onPause(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
     
-    inline def onPlay(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
+    inline def onPlay(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
     
-    inline def onPlaying(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
+    inline def onPlaying(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
     
     inline def onPointerCancel(value: SyntheticPointerEvent[HTMLAnchorElement] => Unit): this.type = set("onPointerCancel", js.Any.fromFunction1(value))
     
@@ -347,27 +347,27 @@ object a {
     
     inline def onPointerUp(value: SyntheticPointerEvent[HTMLAnchorElement] => Unit): this.type = set("onPointerUp", js.Any.fromFunction1(value))
     
-    inline def onProgress(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
+    inline def onProgress(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
     
-    inline def onRateChange(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
+    inline def onRateChange(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
     
     inline def onReset(value: SyntheticEvent[EventTarget & HTMLAnchorElement, Event] => Unit): this.type = set("onReset", js.Any.fromFunction1(value))
     
     inline def onScroll(value: SyntheticUIEvent[HTMLAnchorElement] => Unit): this.type = set("onScroll", js.Any.fromFunction1(value))
     
-    inline def onSeeked(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
+    inline def onSeeked(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
     
-    inline def onSeeking(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
+    inline def onSeeking(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
     
-    inline def onSelect(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
+    inline def onSelect(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
     
-    inline def onStalled(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
+    inline def onStalled(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
     
     inline def onSubmit(value: SyntheticEvent[EventTarget & HTMLAnchorElement, Event] => Unit): this.type = set("onSubmit", js.Any.fromFunction1(value))
     
-    inline def onSuspend(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
+    inline def onSuspend(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
     
-    inline def onTimeUpdate(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
+    inline def onTimeUpdate(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
     
     inline def onTouchCancel(value: SyntheticTouchEvent[HTMLAnchorElement] => Unit): this.type = set("onTouchCancel", js.Any.fromFunction1(value))
     
@@ -379,9 +379,9 @@ object a {
     
     inline def onTransitionEnd(value: SyntheticTransitionEvent[HTMLAnchorElement] => Unit): this.type = set("onTransitionEnd", js.Any.fromFunction1(value))
     
-    inline def onVolumeChange(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
+    inline def onVolumeChange(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
     
-    inline def onWaiting(value: SyntheticEvent[Event, HTMLAnchorElement] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
+    inline def onWaiting(value: SyntheticEvent[HTMLAnchorElement, Event] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
     
     inline def onWheel(value: SyntheticWheelEvent[HTMLAnchorElement] => Unit): this.type = set("onWheel", js.Any.fromFunction1(value))
     

--- a/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/components/area.scala
+++ b/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/components/area.scala
@@ -231,7 +231,7 @@ object area {
     
     inline def media(value: String): this.type = set("media", value.asInstanceOf[js.Any])
     
-    inline def onAbort(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
+    inline def onAbort(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
     
     inline def onAnimationEnd(value: SyntheticAnimationEvent[HTMLAreaElement] => Unit): this.type = set("onAnimationEnd", js.Any.fromFunction1(value))
     
@@ -245,9 +245,9 @@ object area {
     
     inline def onBlur(value: SyntheticFocusEvent[HTMLAreaElement] => Unit): this.type = set("onBlur", js.Any.fromFunction1(value))
     
-    inline def onCanPlay(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
+    inline def onCanPlay(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
     
-    inline def onCanPlayThrough(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
+    inline def onCanPlayThrough(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
     
     inline def onChange(value: SyntheticEvent[EventTarget & HTMLAreaElement, Event] => Unit): this.type = set("onChange", js.Any.fromFunction1(value))
     
@@ -283,15 +283,15 @@ object area {
     
     inline def onDrop(value: DragEvent[HTMLAreaElement] => Unit): this.type = set("onDrop", js.Any.fromFunction1(value))
     
-    inline def onDurationChange(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
+    inline def onDurationChange(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
     
-    inline def onEmptied(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
+    inline def onEmptied(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
     
-    inline def onEncrypted(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
+    inline def onEncrypted(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
     
-    inline def onEnded(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
+    inline def onEnded(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
     
-    inline def onError(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
+    inline def onError(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
     
     inline def onFocus(value: SyntheticFocusEvent[HTMLAreaElement] => Unit): this.type = set("onFocus", js.Any.fromFunction1(value))
     
@@ -305,13 +305,13 @@ object area {
     
     inline def onKeyUp(value: SyntheticKeyboardEvent[HTMLAreaElement] => Unit): this.type = set("onKeyUp", js.Any.fromFunction1(value))
     
-    inline def onLoad(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
+    inline def onLoad(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
     
-    inline def onLoadStart(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
+    inline def onLoadStart(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
     
-    inline def onLoadedData(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
+    inline def onLoadedData(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
     
-    inline def onLoadedMetadata(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
+    inline def onLoadedMetadata(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
     
     inline def onMouseDown(value: SyntheticMouseEvent[HTMLAreaElement] => Unit): this.type = set("onMouseDown", js.Any.fromFunction1(value))
     
@@ -329,11 +329,11 @@ object area {
     
     inline def onPaste(value: SyntheticClipboardEvent[HTMLAreaElement] => Unit): this.type = set("onPaste", js.Any.fromFunction1(value))
     
-    inline def onPause(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
+    inline def onPause(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
     
-    inline def onPlay(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
+    inline def onPlay(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
     
-    inline def onPlaying(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
+    inline def onPlaying(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
     
     inline def onPointerCancel(value: SyntheticPointerEvent[HTMLAreaElement] => Unit): this.type = set("onPointerCancel", js.Any.fromFunction1(value))
     
@@ -351,27 +351,27 @@ object area {
     
     inline def onPointerUp(value: SyntheticPointerEvent[HTMLAreaElement] => Unit): this.type = set("onPointerUp", js.Any.fromFunction1(value))
     
-    inline def onProgress(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
+    inline def onProgress(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
     
-    inline def onRateChange(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
+    inline def onRateChange(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
     
     inline def onReset(value: SyntheticEvent[EventTarget & HTMLAreaElement, Event] => Unit): this.type = set("onReset", js.Any.fromFunction1(value))
     
     inline def onScroll(value: SyntheticUIEvent[HTMLAreaElement] => Unit): this.type = set("onScroll", js.Any.fromFunction1(value))
     
-    inline def onSeeked(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
+    inline def onSeeked(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
     
-    inline def onSeeking(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
+    inline def onSeeking(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
     
-    inline def onSelect(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
+    inline def onSelect(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
     
-    inline def onStalled(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
+    inline def onStalled(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
     
     inline def onSubmit(value: SyntheticEvent[EventTarget & HTMLAreaElement, Event] => Unit): this.type = set("onSubmit", js.Any.fromFunction1(value))
     
-    inline def onSuspend(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
+    inline def onSuspend(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
     
-    inline def onTimeUpdate(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
+    inline def onTimeUpdate(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
     
     inline def onTouchCancel(value: SyntheticTouchEvent[HTMLAreaElement] => Unit): this.type = set("onTouchCancel", js.Any.fromFunction1(value))
     
@@ -383,9 +383,9 @@ object area {
     
     inline def onTransitionEnd(value: SyntheticTransitionEvent[HTMLAreaElement] => Unit): this.type = set("onTransitionEnd", js.Any.fromFunction1(value))
     
-    inline def onVolumeChange(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
+    inline def onVolumeChange(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
     
-    inline def onWaiting(value: SyntheticEvent[Event, HTMLAreaElement] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
+    inline def onWaiting(value: SyntheticEvent[HTMLAreaElement, Event] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
     
     inline def onWheel(value: SyntheticWheelEvent[HTMLAreaElement] => Unit): this.type = set("onWheel", js.Any.fromFunction1(value))
     

--- a/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/components/audio.scala
+++ b/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/components/audio.scala
@@ -233,7 +233,7 @@ object audio {
     
     inline def muted(value: Boolean): this.type = set("muted", value.asInstanceOf[js.Any])
     
-    inline def onAbort(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
+    inline def onAbort(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
     
     inline def onAnimationEnd(value: SyntheticAnimationEvent[HTMLAudioElement] => Unit): this.type = set("onAnimationEnd", js.Any.fromFunction1(value))
     
@@ -247,9 +247,9 @@ object audio {
     
     inline def onBlur(value: SyntheticFocusEvent[HTMLAudioElement] => Unit): this.type = set("onBlur", js.Any.fromFunction1(value))
     
-    inline def onCanPlay(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
+    inline def onCanPlay(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
     
-    inline def onCanPlayThrough(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
+    inline def onCanPlayThrough(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
     
     inline def onChange(value: SyntheticEvent[EventTarget & HTMLAudioElement, Event] => Unit): this.type = set("onChange", js.Any.fromFunction1(value))
     
@@ -285,15 +285,15 @@ object audio {
     
     inline def onDrop(value: DragEvent[HTMLAudioElement] => Unit): this.type = set("onDrop", js.Any.fromFunction1(value))
     
-    inline def onDurationChange(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
+    inline def onDurationChange(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
     
-    inline def onEmptied(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
+    inline def onEmptied(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
     
-    inline def onEncrypted(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
+    inline def onEncrypted(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
     
-    inline def onEnded(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
+    inline def onEnded(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
     
-    inline def onError(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
+    inline def onError(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
     
     inline def onFocus(value: SyntheticFocusEvent[HTMLAudioElement] => Unit): this.type = set("onFocus", js.Any.fromFunction1(value))
     
@@ -307,13 +307,13 @@ object audio {
     
     inline def onKeyUp(value: SyntheticKeyboardEvent[HTMLAudioElement] => Unit): this.type = set("onKeyUp", js.Any.fromFunction1(value))
     
-    inline def onLoad(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
+    inline def onLoad(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
     
-    inline def onLoadStart(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
+    inline def onLoadStart(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
     
-    inline def onLoadedData(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
+    inline def onLoadedData(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
     
-    inline def onLoadedMetadata(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
+    inline def onLoadedMetadata(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
     
     inline def onMouseDown(value: SyntheticMouseEvent[HTMLAudioElement] => Unit): this.type = set("onMouseDown", js.Any.fromFunction1(value))
     
@@ -331,11 +331,11 @@ object audio {
     
     inline def onPaste(value: SyntheticClipboardEvent[HTMLAudioElement] => Unit): this.type = set("onPaste", js.Any.fromFunction1(value))
     
-    inline def onPause(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
+    inline def onPause(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
     
-    inline def onPlay(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
+    inline def onPlay(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
     
-    inline def onPlaying(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
+    inline def onPlaying(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
     
     inline def onPointerCancel(value: SyntheticPointerEvent[HTMLAudioElement] => Unit): this.type = set("onPointerCancel", js.Any.fromFunction1(value))
     
@@ -353,27 +353,27 @@ object audio {
     
     inline def onPointerUp(value: SyntheticPointerEvent[HTMLAudioElement] => Unit): this.type = set("onPointerUp", js.Any.fromFunction1(value))
     
-    inline def onProgress(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
+    inline def onProgress(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
     
-    inline def onRateChange(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
+    inline def onRateChange(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
     
     inline def onReset(value: SyntheticEvent[EventTarget & HTMLAudioElement, Event] => Unit): this.type = set("onReset", js.Any.fromFunction1(value))
     
     inline def onScroll(value: SyntheticUIEvent[HTMLAudioElement] => Unit): this.type = set("onScroll", js.Any.fromFunction1(value))
     
-    inline def onSeeked(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
+    inline def onSeeked(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
     
-    inline def onSeeking(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
+    inline def onSeeking(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
     
-    inline def onSelect(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
+    inline def onSelect(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
     
-    inline def onStalled(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
+    inline def onStalled(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
     
     inline def onSubmit(value: SyntheticEvent[EventTarget & HTMLAudioElement, Event] => Unit): this.type = set("onSubmit", js.Any.fromFunction1(value))
     
-    inline def onSuspend(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
+    inline def onSuspend(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
     
-    inline def onTimeUpdate(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
+    inline def onTimeUpdate(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
     
     inline def onTouchCancel(value: SyntheticTouchEvent[HTMLAudioElement] => Unit): this.type = set("onTouchCancel", js.Any.fromFunction1(value))
     
@@ -385,9 +385,9 @@ object audio {
     
     inline def onTransitionEnd(value: SyntheticTransitionEvent[HTMLAudioElement] => Unit): this.type = set("onTransitionEnd", js.Any.fromFunction1(value))
     
-    inline def onVolumeChange(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
+    inline def onVolumeChange(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
     
-    inline def onWaiting(value: SyntheticEvent[Event, HTMLAudioElement] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
+    inline def onWaiting(value: SyntheticEvent[HTMLAudioElement, Event] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
     
     inline def onWheel(value: SyntheticWheelEvent[HTMLAudioElement] => Unit): this.type = set("onWheel", js.Any.fromFunction1(value))
     

--- a/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/components/base.scala
+++ b/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/components/base.scala
@@ -221,7 +221,7 @@ object base {
     
     inline def lang(value: String): this.type = set("lang", value.asInstanceOf[js.Any])
     
-    inline def onAbort(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
+    inline def onAbort(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
     
     inline def onAnimationEnd(value: SyntheticAnimationEvent[HTMLBaseElement] => Unit): this.type = set("onAnimationEnd", js.Any.fromFunction1(value))
     
@@ -235,9 +235,9 @@ object base {
     
     inline def onBlur(value: SyntheticFocusEvent[HTMLBaseElement] => Unit): this.type = set("onBlur", js.Any.fromFunction1(value))
     
-    inline def onCanPlay(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
+    inline def onCanPlay(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
     
-    inline def onCanPlayThrough(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
+    inline def onCanPlayThrough(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
     
     inline def onChange(value: SyntheticEvent[EventTarget & HTMLBaseElement, Event] => Unit): this.type = set("onChange", js.Any.fromFunction1(value))
     
@@ -273,15 +273,15 @@ object base {
     
     inline def onDrop(value: DragEvent[HTMLBaseElement] => Unit): this.type = set("onDrop", js.Any.fromFunction1(value))
     
-    inline def onDurationChange(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
+    inline def onDurationChange(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
     
-    inline def onEmptied(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
+    inline def onEmptied(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
     
-    inline def onEncrypted(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
+    inline def onEncrypted(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
     
-    inline def onEnded(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
+    inline def onEnded(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
     
-    inline def onError(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
+    inline def onError(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
     
     inline def onFocus(value: SyntheticFocusEvent[HTMLBaseElement] => Unit): this.type = set("onFocus", js.Any.fromFunction1(value))
     
@@ -295,13 +295,13 @@ object base {
     
     inline def onKeyUp(value: SyntheticKeyboardEvent[HTMLBaseElement] => Unit): this.type = set("onKeyUp", js.Any.fromFunction1(value))
     
-    inline def onLoad(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
+    inline def onLoad(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
     
-    inline def onLoadStart(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
+    inline def onLoadStart(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
     
-    inline def onLoadedData(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
+    inline def onLoadedData(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
     
-    inline def onLoadedMetadata(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
+    inline def onLoadedMetadata(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
     
     inline def onMouseDown(value: SyntheticMouseEvent[HTMLBaseElement] => Unit): this.type = set("onMouseDown", js.Any.fromFunction1(value))
     
@@ -319,11 +319,11 @@ object base {
     
     inline def onPaste(value: SyntheticClipboardEvent[HTMLBaseElement] => Unit): this.type = set("onPaste", js.Any.fromFunction1(value))
     
-    inline def onPause(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
+    inline def onPause(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
     
-    inline def onPlay(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
+    inline def onPlay(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
     
-    inline def onPlaying(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
+    inline def onPlaying(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
     
     inline def onPointerCancel(value: SyntheticPointerEvent[HTMLBaseElement] => Unit): this.type = set("onPointerCancel", js.Any.fromFunction1(value))
     
@@ -341,27 +341,27 @@ object base {
     
     inline def onPointerUp(value: SyntheticPointerEvent[HTMLBaseElement] => Unit): this.type = set("onPointerUp", js.Any.fromFunction1(value))
     
-    inline def onProgress(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
+    inline def onProgress(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
     
-    inline def onRateChange(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
+    inline def onRateChange(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
     
     inline def onReset(value: SyntheticEvent[EventTarget & HTMLBaseElement, Event] => Unit): this.type = set("onReset", js.Any.fromFunction1(value))
     
     inline def onScroll(value: SyntheticUIEvent[HTMLBaseElement] => Unit): this.type = set("onScroll", js.Any.fromFunction1(value))
     
-    inline def onSeeked(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
+    inline def onSeeked(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
     
-    inline def onSeeking(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
+    inline def onSeeking(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
     
-    inline def onSelect(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
+    inline def onSelect(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
     
-    inline def onStalled(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
+    inline def onStalled(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
     
     inline def onSubmit(value: SyntheticEvent[EventTarget & HTMLBaseElement, Event] => Unit): this.type = set("onSubmit", js.Any.fromFunction1(value))
     
-    inline def onSuspend(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
+    inline def onSuspend(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
     
-    inline def onTimeUpdate(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
+    inline def onTimeUpdate(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
     
     inline def onTouchCancel(value: SyntheticTouchEvent[HTMLBaseElement] => Unit): this.type = set("onTouchCancel", js.Any.fromFunction1(value))
     
@@ -373,9 +373,9 @@ object base {
     
     inline def onTransitionEnd(value: SyntheticTransitionEvent[HTMLBaseElement] => Unit): this.type = set("onTransitionEnd", js.Any.fromFunction1(value))
     
-    inline def onVolumeChange(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
+    inline def onVolumeChange(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
     
-    inline def onWaiting(value: SyntheticEvent[Event, HTMLBaseElement] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
+    inline def onWaiting(value: SyntheticEvent[HTMLBaseElement, Event] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
     
     inline def onWheel(value: SyntheticWheelEvent[HTMLBaseElement] => Unit): this.type = set("onWheel", js.Any.fromFunction1(value))
     

--- a/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/components/view.scala
+++ b/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/components/view.scala
@@ -453,7 +453,7 @@ object view {
     
     inline def offset(value: Double | String): this.type = set("offset", value.asInstanceOf[js.Any])
     
-    inline def onAbort(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
+    inline def onAbort(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
     
     inline def onAnimationEnd(value: SyntheticAnimationEvent[SVGViewElement] => Unit): this.type = set("onAnimationEnd", js.Any.fromFunction1(value))
     
@@ -467,9 +467,9 @@ object view {
     
     inline def onBlur(value: SyntheticFocusEvent[SVGViewElement] => Unit): this.type = set("onBlur", js.Any.fromFunction1(value))
     
-    inline def onCanPlay(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
+    inline def onCanPlay(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
     
-    inline def onCanPlayThrough(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
+    inline def onCanPlayThrough(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
     
     inline def onChange(value: SyntheticEvent[EventTarget & SVGViewElement, Event] => Unit): this.type = set("onChange", js.Any.fromFunction1(value))
     
@@ -505,15 +505,15 @@ object view {
     
     inline def onDrop(value: DragEvent[SVGViewElement] => Unit): this.type = set("onDrop", js.Any.fromFunction1(value))
     
-    inline def onDurationChange(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
+    inline def onDurationChange(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
     
-    inline def onEmptied(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
+    inline def onEmptied(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
     
-    inline def onEncrypted(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
+    inline def onEncrypted(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
     
-    inline def onEnded(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
+    inline def onEnded(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
     
-    inline def onError(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
+    inline def onError(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
     
     inline def onFocus(value: SyntheticFocusEvent[SVGViewElement] => Unit): this.type = set("onFocus", js.Any.fromFunction1(value))
     
@@ -527,13 +527,13 @@ object view {
     
     inline def onKeyUp(value: SyntheticKeyboardEvent[SVGViewElement] => Unit): this.type = set("onKeyUp", js.Any.fromFunction1(value))
     
-    inline def onLoad(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
+    inline def onLoad(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
     
-    inline def onLoadStart(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
+    inline def onLoadStart(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
     
-    inline def onLoadedData(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
+    inline def onLoadedData(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
     
-    inline def onLoadedMetadata(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
+    inline def onLoadedMetadata(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
     
     inline def onMouseDown(value: SyntheticMouseEvent[SVGViewElement] => Unit): this.type = set("onMouseDown", js.Any.fromFunction1(value))
     
@@ -551,11 +551,11 @@ object view {
     
     inline def onPaste(value: SyntheticClipboardEvent[SVGViewElement] => Unit): this.type = set("onPaste", js.Any.fromFunction1(value))
     
-    inline def onPause(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
+    inline def onPause(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
     
-    inline def onPlay(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
+    inline def onPlay(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
     
-    inline def onPlaying(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
+    inline def onPlaying(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
     
     inline def onPointerCancel(value: SyntheticPointerEvent[SVGViewElement] => Unit): this.type = set("onPointerCancel", js.Any.fromFunction1(value))
     
@@ -573,27 +573,27 @@ object view {
     
     inline def onPointerUp(value: SyntheticPointerEvent[SVGViewElement] => Unit): this.type = set("onPointerUp", js.Any.fromFunction1(value))
     
-    inline def onProgress(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
+    inline def onProgress(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
     
-    inline def onRateChange(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
+    inline def onRateChange(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
     
     inline def onReset(value: SyntheticEvent[EventTarget & SVGViewElement, Event] => Unit): this.type = set("onReset", js.Any.fromFunction1(value))
     
     inline def onScroll(value: SyntheticUIEvent[SVGViewElement] => Unit): this.type = set("onScroll", js.Any.fromFunction1(value))
     
-    inline def onSeeked(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
+    inline def onSeeked(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
     
-    inline def onSeeking(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
+    inline def onSeeking(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
     
-    inline def onSelect(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
+    inline def onSelect(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
     
-    inline def onStalled(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
+    inline def onStalled(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
     
     inline def onSubmit(value: SyntheticEvent[EventTarget & SVGViewElement, Event] => Unit): this.type = set("onSubmit", js.Any.fromFunction1(value))
     
-    inline def onSuspend(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
+    inline def onSuspend(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
     
-    inline def onTimeUpdate(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
+    inline def onTimeUpdate(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
     
     inline def onTouchCancel(value: SyntheticTouchEvent[SVGViewElement] => Unit): this.type = set("onTouchCancel", js.Any.fromFunction1(value))
     
@@ -605,9 +605,9 @@ object view {
     
     inline def onTransitionEnd(value: SyntheticTransitionEvent[SVGViewElement] => Unit): this.type = set("onTransitionEnd", js.Any.fromFunction1(value))
     
-    inline def onVolumeChange(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
+    inline def onVolumeChange(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
     
-    inline def onWaiting(value: SyntheticEvent[Event, SVGViewElement] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
+    inline def onWaiting(value: SyntheticEvent[SVGViewElement, Event] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
     
     inline def onWheel(value: SyntheticWheelEvent[SVGViewElement] => Unit): this.type = set("onWheel", js.Any.fromFunction1(value))
     

--- a/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/mod/DOMAttributes.scala
+++ b/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/mod/DOMAttributes.scala
@@ -216,7 +216,7 @@ object DOMAttributes {
     
     inline def setDangerouslySetInnerHTMLUndefined: Self = StObject.set(x, "dangerouslySetInnerHTML", js.undefined)
     
-    inline def setOnAbort(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onAbort", js.Any.fromFunction1(value))
+    inline def setOnAbort(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onAbort", js.Any.fromFunction1(value))
     
     inline def setOnAbortUndefined: Self = StObject.set(x, "onAbort", js.undefined)
     
@@ -244,9 +244,9 @@ object DOMAttributes {
     
     inline def setOnBlurUndefined: Self = StObject.set(x, "onBlur", js.undefined)
     
-    inline def setOnCanPlay(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onCanPlay", js.Any.fromFunction1(value))
+    inline def setOnCanPlay(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onCanPlay", js.Any.fromFunction1(value))
     
-    inline def setOnCanPlayThrough(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onCanPlayThrough", js.Any.fromFunction1(value))
+    inline def setOnCanPlayThrough(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onCanPlayThrough", js.Any.fromFunction1(value))
     
     inline def setOnCanPlayThroughUndefined: Self = StObject.set(x, "onCanPlayThrough", js.undefined)
     
@@ -320,23 +320,23 @@ object DOMAttributes {
     
     inline def setOnDropUndefined: Self = StObject.set(x, "onDrop", js.undefined)
     
-    inline def setOnDurationChange(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onDurationChange", js.Any.fromFunction1(value))
+    inline def setOnDurationChange(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onDurationChange", js.Any.fromFunction1(value))
     
     inline def setOnDurationChangeUndefined: Self = StObject.set(x, "onDurationChange", js.undefined)
     
-    inline def setOnEmptied(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onEmptied", js.Any.fromFunction1(value))
+    inline def setOnEmptied(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onEmptied", js.Any.fromFunction1(value))
     
     inline def setOnEmptiedUndefined: Self = StObject.set(x, "onEmptied", js.undefined)
     
-    inline def setOnEncrypted(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onEncrypted", js.Any.fromFunction1(value))
+    inline def setOnEncrypted(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onEncrypted", js.Any.fromFunction1(value))
     
     inline def setOnEncryptedUndefined: Self = StObject.set(x, "onEncrypted", js.undefined)
     
-    inline def setOnEnded(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onEnded", js.Any.fromFunction1(value))
+    inline def setOnEnded(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onEnded", js.Any.fromFunction1(value))
     
     inline def setOnEndedUndefined: Self = StObject.set(x, "onEnded", js.undefined)
     
-    inline def setOnError(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onError", js.Any.fromFunction1(value))
+    inline def setOnError(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onError", js.Any.fromFunction1(value))
     
     inline def setOnErrorUndefined: Self = StObject.set(x, "onError", js.undefined)
     
@@ -364,19 +364,19 @@ object DOMAttributes {
     
     inline def setOnKeyUpUndefined: Self = StObject.set(x, "onKeyUp", js.undefined)
     
-    inline def setOnLoad(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onLoad", js.Any.fromFunction1(value))
+    inline def setOnLoad(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onLoad", js.Any.fromFunction1(value))
     
-    inline def setOnLoadStart(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onLoadStart", js.Any.fromFunction1(value))
+    inline def setOnLoadStart(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onLoadStart", js.Any.fromFunction1(value))
     
     inline def setOnLoadStartUndefined: Self = StObject.set(x, "onLoadStart", js.undefined)
     
     inline def setOnLoadUndefined: Self = StObject.set(x, "onLoad", js.undefined)
     
-    inline def setOnLoadedData(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onLoadedData", js.Any.fromFunction1(value))
+    inline def setOnLoadedData(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onLoadedData", js.Any.fromFunction1(value))
     
     inline def setOnLoadedDataUndefined: Self = StObject.set(x, "onLoadedData", js.undefined)
     
-    inline def setOnLoadedMetadata(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onLoadedMetadata", js.Any.fromFunction1(value))
+    inline def setOnLoadedMetadata(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onLoadedMetadata", js.Any.fromFunction1(value))
     
     inline def setOnLoadedMetadataUndefined: Self = StObject.set(x, "onLoadedMetadata", js.undefined)
     
@@ -412,15 +412,15 @@ object DOMAttributes {
     
     inline def setOnPasteUndefined: Self = StObject.set(x, "onPaste", js.undefined)
     
-    inline def setOnPause(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onPause", js.Any.fromFunction1(value))
+    inline def setOnPause(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onPause", js.Any.fromFunction1(value))
     
     inline def setOnPauseUndefined: Self = StObject.set(x, "onPause", js.undefined)
     
-    inline def setOnPlay(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onPlay", js.Any.fromFunction1(value))
+    inline def setOnPlay(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onPlay", js.Any.fromFunction1(value))
     
     inline def setOnPlayUndefined: Self = StObject.set(x, "onPlay", js.undefined)
     
-    inline def setOnPlaying(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onPlaying", js.Any.fromFunction1(value))
+    inline def setOnPlaying(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onPlaying", js.Any.fromFunction1(value))
     
     inline def setOnPlayingUndefined: Self = StObject.set(x, "onPlaying", js.undefined)
     
@@ -456,11 +456,11 @@ object DOMAttributes {
     
     inline def setOnPointerUpUndefined: Self = StObject.set(x, "onPointerUp", js.undefined)
     
-    inline def setOnProgress(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onProgress", js.Any.fromFunction1(value))
+    inline def setOnProgress(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onProgress", js.Any.fromFunction1(value))
     
     inline def setOnProgressUndefined: Self = StObject.set(x, "onProgress", js.undefined)
     
-    inline def setOnRateChange(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onRateChange", js.Any.fromFunction1(value))
+    inline def setOnRateChange(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onRateChange", js.Any.fromFunction1(value))
     
     inline def setOnRateChangeUndefined: Self = StObject.set(x, "onRateChange", js.undefined)
     
@@ -472,19 +472,19 @@ object DOMAttributes {
     
     inline def setOnScrollUndefined: Self = StObject.set(x, "onScroll", js.undefined)
     
-    inline def setOnSeeked(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onSeeked", js.Any.fromFunction1(value))
+    inline def setOnSeeked(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onSeeked", js.Any.fromFunction1(value))
     
     inline def setOnSeekedUndefined: Self = StObject.set(x, "onSeeked", js.undefined)
     
-    inline def setOnSeeking(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onSeeking", js.Any.fromFunction1(value))
+    inline def setOnSeeking(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onSeeking", js.Any.fromFunction1(value))
     
     inline def setOnSeekingUndefined: Self = StObject.set(x, "onSeeking", js.undefined)
     
-    inline def setOnSelect(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onSelect", js.Any.fromFunction1(value))
+    inline def setOnSelect(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onSelect", js.Any.fromFunction1(value))
     
     inline def setOnSelectUndefined: Self = StObject.set(x, "onSelect", js.undefined)
     
-    inline def setOnStalled(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onStalled", js.Any.fromFunction1(value))
+    inline def setOnStalled(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onStalled", js.Any.fromFunction1(value))
     
     inline def setOnStalledUndefined: Self = StObject.set(x, "onStalled", js.undefined)
     
@@ -492,11 +492,11 @@ object DOMAttributes {
     
     inline def setOnSubmitUndefined: Self = StObject.set(x, "onSubmit", js.undefined)
     
-    inline def setOnSuspend(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onSuspend", js.Any.fromFunction1(value))
+    inline def setOnSuspend(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onSuspend", js.Any.fromFunction1(value))
     
     inline def setOnSuspendUndefined: Self = StObject.set(x, "onSuspend", js.undefined)
     
-    inline def setOnTimeUpdate(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onTimeUpdate", js.Any.fromFunction1(value))
+    inline def setOnTimeUpdate(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onTimeUpdate", js.Any.fromFunction1(value))
     
     inline def setOnTimeUpdateUndefined: Self = StObject.set(x, "onTimeUpdate", js.undefined)
     
@@ -520,11 +520,11 @@ object DOMAttributes {
     
     inline def setOnTransitionEndUndefined: Self = StObject.set(x, "onTransitionEnd", js.undefined)
     
-    inline def setOnVolumeChange(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onVolumeChange", js.Any.fromFunction1(value))
+    inline def setOnVolumeChange(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onVolumeChange", js.Any.fromFunction1(value))
     
     inline def setOnVolumeChangeUndefined: Self = StObject.set(x, "onVolumeChange", js.undefined)
     
-    inline def setOnWaiting(value: slinky.core.SyntheticEvent[Event, T] => Unit): Self = StObject.set(x, "onWaiting", js.Any.fromFunction1(value))
+    inline def setOnWaiting(value: slinky.core.SyntheticEvent[T, Event] => Unit): Self = StObject.set(x, "onWaiting", js.Any.fromFunction1(value))
     
     inline def setOnWaitingUndefined: Self = StObject.set(x, "onWaiting", js.undefined)
     

--- a/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/mod/package.scala
+++ b/tests/react-integration-test/check-slinky-3/r/react/src/main/scala/typingsSlinky/react/mod/package.scala
@@ -509,7 +509,7 @@ type ElementType[P] = (/* import warning: importer.ImportType#apply Failed type 
 //
 // Event Handler Types
 // ----------------------------------------------------------------------
-type EventHandler[E /* <: slinky.core.SyntheticEvent[Event, Any] */] = js.Function1[/* event */ E, Unit]
+type EventHandler[E /* <: slinky.core.SyntheticEvent[Any, Event] */] = js.Function1[/* event */ E, Unit]
 
 type ExactlyAnyPropertyKeys[T] = /* import warning: importer.ImportType#apply Failed type conversion: {[ K in keyof T ]: react.react.IsExactlyAny<T[K]> extends true? K : never}[keyof T] */ js.Any
 
@@ -518,7 +518,7 @@ type FC[P] = ReactComponentClass[P]
 type FocusEventHandler[T] = EventHandler[SyntheticFocusEvent[T]]
 
 // tslint:disable-next-line:no-empty-interface
-type FormEvent[T] = slinky.core.SyntheticEvent[Event, T]
+type FormEvent[T] = slinky.core.SyntheticEvent[T, Event]
 
 type FormEventHandler[T] = EventHandler[slinky.core.SyntheticEvent[EventTarget & T, Event]]
 
@@ -644,7 +644,7 @@ type ReactChild = slinky.core.facade.ReactElement | ReactText
 
 type ReactComponentElement[T /* <: a_ | abbr | address | area | article | aside | audio | b | base | bdi | bdo | big | view | JSXElementConstructor[Any] */, P] = slinky.core.facade.ReactElement
 
-type ReactEventHandler[T] = EventHandler[slinky.core.SyntheticEvent[Event, T]]
+type ReactEventHandler[T] = EventHandler[slinky.core.SyntheticEvent[T, Event]]
 
 type ReactFragment = js.Object | ReactNodeArray
 

--- a/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-4a1319"
+version := "0.0-unknown-0bd288"
 scalaVersion := "3.3.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d793cd",
+  "org.scalablytyped" %%% "react" % "16.9.2-25cfad",
   "org.scalablytyped" %%% "std" % "0.0-unknown-7f073b")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/components/Button.scala
+++ b/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/components/Button.scala
@@ -363,7 +363,7 @@ object Button {
     
     inline def negative(value: Boolean): this.type = set("negative", value.asInstanceOf[js.Any])
     
-    inline def onAbort(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
+    inline def onAbort(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
     
     inline def onAnimationEnd(value: SyntheticAnimationEvent[HTMLButtonElement] => Unit): this.type = set("onAnimationEnd", js.Any.fromFunction1(value))
     
@@ -377,9 +377,9 @@ object Button {
     
     inline def onBlur(value: SyntheticFocusEvent[HTMLButtonElement] => Unit): this.type = set("onBlur", js.Any.fromFunction1(value))
     
-    inline def onCanPlay(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
+    inline def onCanPlay(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
     
-    inline def onCanPlayThrough(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
+    inline def onCanPlayThrough(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
     
     inline def onChange(value: SyntheticEvent[EventTarget & HTMLButtonElement, Event] => Unit): this.type = set("onChange", js.Any.fromFunction1(value))
     
@@ -415,15 +415,15 @@ object Button {
     
     inline def onDrop(value: DragEvent[HTMLButtonElement] => Unit): this.type = set("onDrop", js.Any.fromFunction1(value))
     
-    inline def onDurationChange(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
+    inline def onDurationChange(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
     
-    inline def onEmptied(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
+    inline def onEmptied(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
     
-    inline def onEncrypted(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
+    inline def onEncrypted(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
     
-    inline def onEnded(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
+    inline def onEnded(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
     
-    inline def onError(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
+    inline def onError(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
     
     inline def onFocus(value: SyntheticFocusEvent[HTMLButtonElement] => Unit): this.type = set("onFocus", js.Any.fromFunction1(value))
     
@@ -437,13 +437,13 @@ object Button {
     
     inline def onKeyUp(value: SyntheticKeyboardEvent[HTMLButtonElement] => Unit): this.type = set("onKeyUp", js.Any.fromFunction1(value))
     
-    inline def onLoad(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
+    inline def onLoad(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
     
-    inline def onLoadStart(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
+    inline def onLoadStart(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
     
-    inline def onLoadedData(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
+    inline def onLoadedData(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
     
-    inline def onLoadedMetadata(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
+    inline def onLoadedMetadata(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
     
     inline def onMouseDown(value: SyntheticMouseEvent[HTMLButtonElement] => Unit): this.type = set("onMouseDown", js.Any.fromFunction1(value))
     
@@ -461,11 +461,11 @@ object Button {
     
     inline def onPaste(value: SyntheticClipboardEvent[HTMLButtonElement] => Unit): this.type = set("onPaste", js.Any.fromFunction1(value))
     
-    inline def onPause(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
+    inline def onPause(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
     
-    inline def onPlay(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
+    inline def onPlay(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
     
-    inline def onPlaying(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
+    inline def onPlaying(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
     
     inline def onPointerCancel(value: SyntheticPointerEvent[HTMLButtonElement] => Unit): this.type = set("onPointerCancel", js.Any.fromFunction1(value))
     
@@ -483,27 +483,27 @@ object Button {
     
     inline def onPointerUp(value: SyntheticPointerEvent[HTMLButtonElement] => Unit): this.type = set("onPointerUp", js.Any.fromFunction1(value))
     
-    inline def onProgress(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
+    inline def onProgress(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
     
-    inline def onRateChange(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
+    inline def onRateChange(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
     
     inline def onReset(value: SyntheticEvent[EventTarget & HTMLButtonElement, Event] => Unit): this.type = set("onReset", js.Any.fromFunction1(value))
     
     inline def onScroll(value: SyntheticUIEvent[HTMLButtonElement] => Unit): this.type = set("onScroll", js.Any.fromFunction1(value))
     
-    inline def onSeeked(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
+    inline def onSeeked(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
     
-    inline def onSeeking(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
+    inline def onSeeking(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
     
-    inline def onSelect(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
+    inline def onSelect(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
     
-    inline def onStalled(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
+    inline def onStalled(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
     
     inline def onSubmit(value: SyntheticEvent[EventTarget & HTMLButtonElement, Event] => Unit): this.type = set("onSubmit", js.Any.fromFunction1(value))
     
-    inline def onSuspend(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
+    inline def onSuspend(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
     
-    inline def onTimeUpdate(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
+    inline def onTimeUpdate(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
     
     inline def onTouchCancel(value: SyntheticTouchEvent[HTMLButtonElement] => Unit): this.type = set("onTouchCancel", js.Any.fromFunction1(value))
     
@@ -515,9 +515,9 @@ object Button {
     
     inline def onTransitionEnd(value: SyntheticTransitionEvent[HTMLButtonElement] => Unit): this.type = set("onTransitionEnd", js.Any.fromFunction1(value))
     
-    inline def onVolumeChange(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
+    inline def onVolumeChange(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
     
-    inline def onWaiting(value: SyntheticEvent[Event, HTMLButtonElement] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
+    inline def onWaiting(value: SyntheticEvent[HTMLButtonElement, Event] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
     
     inline def onWheel(value: SyntheticWheelEvent[HTMLButtonElement] => Unit): this.type = set("onWheel", js.Any.fromFunction1(value))
     

--- a/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/components/Input.scala
+++ b/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/src/main/scala/typingsSlinky/semanticUiReact/components/Input.scala
@@ -335,7 +335,7 @@ object Input {
     
     inline def name(value: String): this.type = set("name", value.asInstanceOf[js.Any])
     
-    inline def onAbort(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
+    inline def onAbort(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onAbort", js.Any.fromFunction1(value))
     
     inline def onAnimationEnd(value: SyntheticAnimationEvent[HTMLInputElement] => Unit): this.type = set("onAnimationEnd", js.Any.fromFunction1(value))
     
@@ -349,9 +349,9 @@ object Input {
     
     inline def onBlur(value: SyntheticFocusEvent[HTMLInputElement] => Unit): this.type = set("onBlur", js.Any.fromFunction1(value))
     
-    inline def onCanPlay(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
+    inline def onCanPlay(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onCanPlay", js.Any.fromFunction1(value))
     
-    inline def onCanPlayThrough(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
+    inline def onCanPlayThrough(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onCanPlayThrough", js.Any.fromFunction1(value))
     
     inline def onChange(value: (/* event */ ChangeEvent[HTMLInputElement], /* data */ InputOnChangeData) => Unit): this.type = set("onChange", js.Any.fromFunction2(value))
     
@@ -387,15 +387,15 @@ object Input {
     
     inline def onDrop(value: DragEvent[HTMLInputElement] => Unit): this.type = set("onDrop", js.Any.fromFunction1(value))
     
-    inline def onDurationChange(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
+    inline def onDurationChange(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onDurationChange", js.Any.fromFunction1(value))
     
-    inline def onEmptied(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
+    inline def onEmptied(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onEmptied", js.Any.fromFunction1(value))
     
-    inline def onEncrypted(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
+    inline def onEncrypted(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onEncrypted", js.Any.fromFunction1(value))
     
-    inline def onEnded(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
+    inline def onEnded(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onEnded", js.Any.fromFunction1(value))
     
-    inline def onError(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
+    inline def onError(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onError", js.Any.fromFunction1(value))
     
     inline def onFocus(value: SyntheticFocusEvent[HTMLInputElement] => Unit): this.type = set("onFocus", js.Any.fromFunction1(value))
     
@@ -409,13 +409,13 @@ object Input {
     
     inline def onKeyUp(value: SyntheticKeyboardEvent[HTMLInputElement] => Unit): this.type = set("onKeyUp", js.Any.fromFunction1(value))
     
-    inline def onLoad(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
+    inline def onLoad(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onLoad", js.Any.fromFunction1(value))
     
-    inline def onLoadStart(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
+    inline def onLoadStart(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onLoadStart", js.Any.fromFunction1(value))
     
-    inline def onLoadedData(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
+    inline def onLoadedData(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onLoadedData", js.Any.fromFunction1(value))
     
-    inline def onLoadedMetadata(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
+    inline def onLoadedMetadata(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onLoadedMetadata", js.Any.fromFunction1(value))
     
     inline def onMouseDown(value: SyntheticMouseEvent[HTMLInputElement] => Unit): this.type = set("onMouseDown", js.Any.fromFunction1(value))
     
@@ -433,11 +433,11 @@ object Input {
     
     inline def onPaste(value: SyntheticClipboardEvent[HTMLInputElement] => Unit): this.type = set("onPaste", js.Any.fromFunction1(value))
     
-    inline def onPause(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
+    inline def onPause(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onPause", js.Any.fromFunction1(value))
     
-    inline def onPlay(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
+    inline def onPlay(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onPlay", js.Any.fromFunction1(value))
     
-    inline def onPlaying(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
+    inline def onPlaying(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onPlaying", js.Any.fromFunction1(value))
     
     inline def onPointerCancel(value: SyntheticPointerEvent[HTMLInputElement] => Unit): this.type = set("onPointerCancel", js.Any.fromFunction1(value))
     
@@ -455,27 +455,27 @@ object Input {
     
     inline def onPointerUp(value: SyntheticPointerEvent[HTMLInputElement] => Unit): this.type = set("onPointerUp", js.Any.fromFunction1(value))
     
-    inline def onProgress(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
+    inline def onProgress(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onProgress", js.Any.fromFunction1(value))
     
-    inline def onRateChange(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
+    inline def onRateChange(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onRateChange", js.Any.fromFunction1(value))
     
     inline def onReset(value: SyntheticEvent[EventTarget & HTMLInputElement, Event] => Unit): this.type = set("onReset", js.Any.fromFunction1(value))
     
     inline def onScroll(value: SyntheticUIEvent[HTMLInputElement] => Unit): this.type = set("onScroll", js.Any.fromFunction1(value))
     
-    inline def onSeeked(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
+    inline def onSeeked(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onSeeked", js.Any.fromFunction1(value))
     
-    inline def onSeeking(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
+    inline def onSeeking(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onSeeking", js.Any.fromFunction1(value))
     
-    inline def onSelect(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
+    inline def onSelect(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onSelect", js.Any.fromFunction1(value))
     
-    inline def onStalled(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
+    inline def onStalled(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onStalled", js.Any.fromFunction1(value))
     
     inline def onSubmit(value: SyntheticEvent[EventTarget & HTMLInputElement, Event] => Unit): this.type = set("onSubmit", js.Any.fromFunction1(value))
     
-    inline def onSuspend(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
+    inline def onSuspend(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onSuspend", js.Any.fromFunction1(value))
     
-    inline def onTimeUpdate(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
+    inline def onTimeUpdate(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onTimeUpdate", js.Any.fromFunction1(value))
     
     inline def onTouchCancel(value: SyntheticTouchEvent[HTMLInputElement] => Unit): this.type = set("onTouchCancel", js.Any.fromFunction1(value))
     
@@ -487,9 +487,9 @@ object Input {
     
     inline def onTransitionEnd(value: SyntheticTransitionEvent[HTMLInputElement] => Unit): this.type = set("onTransitionEnd", js.Any.fromFunction1(value))
     
-    inline def onVolumeChange(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
+    inline def onVolumeChange(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onVolumeChange", js.Any.fromFunction1(value))
     
-    inline def onWaiting(value: SyntheticEvent[Event, HTMLInputElement] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
+    inline def onWaiting(value: SyntheticEvent[HTMLInputElement, Event] => Unit): this.type = set("onWaiting", js.Any.fromFunction1(value))
     
     inline def onWheel(value: SyntheticWheelEvent[HTMLInputElement] => Unit): this.type = set("onWheel", js.Any.fromFunction1(value))
     

--- a/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-7ddea1"
+version := "0.38.0-ce06f1"
 scalaVersion := "3.3.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d793cd",
+  "org.scalablytyped" %%% "react" % "16.9.2-25cfad",
   "org.scalablytyped" %%% "std" % "0.0-unknown-7f073b")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-ref/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-a1d2ed"
+version := "0.38.0-3dff6f"
 scalaVersion := "3.3.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
   "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-d793cd",
+  "org.scalablytyped" %%% "react" % "16.9.2-25cfad",
   "org.scalablytyped" %%% "std" % "0.0-unknown-7f073b")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")

--- a/tests/react-integration-test/in/componentstest/index.d.ts
+++ b/tests/react-integration-test/in/componentstest/index.d.ts
@@ -38,3 +38,7 @@ export const ObjectNames: React.FC<{
 
 
 export const VeryExotic: React.MemoExoticComponent<React.ForwardRefExoticComponent<React.RefAttributes<HTMLDivElement>>>;
+
+export interface Events {
+    onClick: (event: React.SyntheticEvent<any>) => void;
+}


### PR DESCRIPTION
This fixes the bug in #596 where Slinky SyntheticEvent type parameters are around the wrong way.