### PR TITLE
Add option to disable wrapping scalajs-react props in Callback

### DIFF
--- a/cli/src/main/scala/org/scalablytyped/converter/cli/Main.scala
+++ b/cli/src/main/scala/org/scalablytyped/converter/cli/Main.scala
@@ -43,6 +43,7 @@ object Main {
     organization             = "org.scalablytyped",
     enableReactTreeShaking   = Selection.None,
     enableLongApplyMethod    = false,
+    disableCallbackWrapping  = false,
     privateWithin            = None,
     useDeprecatedModuleNames = false,
   )
@@ -167,6 +168,9 @@ object Main {
       opt[Boolean]("enableLongApplyMethod")
         .action((x, c) => c.mapConversion(_.copy(enableLongApplyMethod = x)))
         .text(s"Enables long apply methods, instead of implicit ops builders"),
+      opt[Boolean]("disableCallbackWrapping")
+        .action((x, c) => c.mapConversion(_.copy(disableCallbackWrapping = x)))
+        .text(s"Disable wrapping of native js function props in scalajs-react Callback"),
       opt[Boolean]("shortModuleNames")
         .action((x, c) => c.mapConversion(_.copy(useDeprecatedModuleNames = x)))
         .text(

--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/ConversionOptions.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/ConversionOptions.scala
@@ -21,6 +21,7 @@ case class ConversionOptions(
     organization:             String,
     enableReactTreeShaking:   Selection[Name],
     enableLongApplyMethod:    Boolean,
+    disableCallbackWrapping:  Boolean,
     privateWithin:            Option[Name],
     useDeprecatedModuleNames: Boolean,
 ) {
@@ -39,7 +40,7 @@ case class ConversionOptions(
       case Flavour.SlinkyNative =>
         SlinkyNativeFlavour(outputPackage, enableLongApplyMethod, versions, enableReactTreeShaking)
       case Flavour.ScalajsReact =>
-        JapgollyFlavour(outputPackage, enableLongApplyMethod, versions, enableReactTreeShaking)
+        JapgollyFlavour(outputPackage, enableLongApplyMethod, disableCallbackWrapping, versions, enableReactTreeShaking)
     }
 
 }

--- a/importer/src/main/scala/org/scalablytyped/converter/internal/importer/Ci.scala
+++ b/importer/src/main/scala/org/scalablytyped/converter/internal/importer/Ci.scala
@@ -116,6 +116,7 @@ object Ci {
                 organization             = organization,
                 enableReactTreeShaking   = Selection.None,
                 enableLongApplyMethod    = false,
+                disableCallbackWrapping  = false,
                 privateWithin            = None,
                 useDeprecatedModuleNames = false,
               ),

--- a/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterTest.scala
+++ b/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterTest.scala
@@ -20,8 +20,8 @@ class ImporterTest3 extends ImporterTest {
 trait ImporterTest extends AnyFunSuite with ImporterHarness with ParallelTestExecution {
 
   val Slinky       = SlinkyFlavour(Name("typingsSlinky"), enableLongApplyMethod     = false, version, Selection.None)
-  val Japgolly     = JapgollyFlavour(Name("typingsJapgolly"), enableLongApplyMethod = false, version, Selection.All)
-  val JapgollyLong = JapgollyFlavour(Name("typingsJapgolly"), enableLongApplyMethod = true, version, Selection.All)
+  val Japgolly     = JapgollyFlavour(Name("typingsJapgolly"), enableLongApplyMethod = false, disableCallbackWrapping = false, version, Selection.All)
+  val JapgollyLong = JapgollyFlavour(Name("typingsJapgolly"), enableLongApplyMethod = true, disableCallbackWrapping = false, version, Selection.All)
 
   test("pixi.js")(assertImportsOk("pixi.js", pedantic                               = false))
   test("augment-module")(assertImportsOk("augment-module", pedantic                 = false))

--- a/sbt-converter/src/main/scala/org/scalablytyped/converter/internal/ImportTypingsGenSources.scala
+++ b/sbt-converter/src/main/scala/org/scalablytyped/converter/internal/ImportTypingsGenSources.scala
@@ -186,6 +186,7 @@ object ImportTypingsGenSources {
       organization             = "org.scalablytyped",
       enableReactTreeShaking   = Selection.None,
       enableLongApplyMethod    = false,
+      disableCallbackWrapping  = false,
       privateWithin            = None,
       useDeprecatedModuleNames = false,
     )

--- a/sbt-converter/src/main/scala/org/scalablytyped/converter/plugin/ScalablyTypedPluginBase.scala
+++ b/sbt-converter/src/main/scala/org/scalablytyped/converter/plugin/ScalablyTypedPluginBase.scala
@@ -48,6 +48,7 @@ object ScalablyTypedPluginBase extends AutoPlugin {
       "If a given library is enabled, the react flavour will pick *longest* module names instead of shortest.",
     )
     val stEnableLongApplyMethod = settingKey[Boolean]("long apply methods instead of implicit ops builders")
+    val stDisableCallbackWrapping = settingKey[Boolean]("disable wrapping of native js function props in scalajs-react Callback")
     val stShortModuleNames = settingKey[Boolean](
       "Enables short module names. This used to be the default, and is now deprecated since it's so difficult to navigate",
     )
@@ -101,6 +102,7 @@ object ScalablyTypedPluginBase extends AutoPlugin {
           organization             = organization,
           enableReactTreeShaking   = stReactEnableTreeShaking.value.map(name => ImportName(TsIdentLibrary(name))),
           enableLongApplyMethod    = stEnableLongApplyMethod.value,
+          disableCallbackWrapping  = stDisableCallbackWrapping.value,
           privateWithin            = stPrivateWithin.value.map(Name.apply),
           useDeprecatedModuleNames = stShortModuleNames.value,
         )

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/JapgollyFlavour.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/JapgollyFlavour.scala
@@ -6,14 +6,15 @@ import org.scalablytyped.converter.Selection
 import org.scalablytyped.converter.internal.scalajs.transforms.{Adapter, CleanIllegalNames}
 
 case class JapgollyFlavour(
-    outputPkg:              Name,
-    enableLongApplyMethod:  Boolean,
-    versions:               Versions,
-    enableReactTreeShaking: Selection[Name],
+    outputPkg:               Name,
+    enableLongApplyMethod:   Boolean,
+    disableCallbackWrapping: Boolean,
+    versions:                Versions,
+    enableReactTreeShaking:  Selection[Name],
 ) extends FlavourImplReact {
   override val rewrites      = JapgollyTypeConversions(reactNames, scalaJsDomNames, scalaJsLibNames)
   override val dependencies  = Set(versions.runtime, versions.scalajsReact)
-  val memberToPro            = new JapgollyMemberToProp(reactNamesProxy, rewrites)
+  val memberToPro            = new JapgollyMemberToProp(reactNamesProxy, rewrites, disableCallbackWrapping)
   val findProps              = new FindProps(new CleanIllegalNames(outputPkg), memberToPro, parentsResolver)
   val genStBuildingComponent = new JapgollyGenStBuildingComponent(outputPkg, versions.scala)
   val genComponents =

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/JapgollyMemberToProp.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/JapgollyMemberToProp.scala
@@ -4,7 +4,11 @@ package flavours
 
 import org.scalablytyped.converter.internal.scalajs.ExprTree._
 
-class JapgollyMemberToProp(reactNames: ReactNamesProxy, rewrites: IArray[CastConversion]) extends MemberToProp {
+class JapgollyMemberToProp(
+    reactNames: ReactNamesProxy,
+    rewrites: IArray[CastConversion],
+    disableCallbackWrapping: Boolean,
+) extends MemberToProp {
   val default = new MemberToProp.Default(rewrites)
 
   override def apply(scope: TreeScope, x: MemberTree, isInherited: Boolean): Option[Prop] =
@@ -27,10 +31,10 @@ class JapgollyMemberToProp(reactNames: ReactNamesProxy, rewrites: IArray[CastCon
 
   def toScalaJsReact(variant: Prop.Variant): Prop.Variant =
     variant.tpe match {
-      case TypeRef.ScalaFunction(Empty, retType) =>
+      case TypeRef.ScalaFunction(Empty, retType) if !disableCallbackWrapping =>
         Prop.Variant(CallbackTo(retType), ref => Select(ref, Name("toJsFn")), isRewritten = true, extendsAnyVal = true)
 
-      case TypeRef.ScalaFunction(paramTypes, TypeRef.Unit) =>
+      case TypeRef.ScalaFunction(paramTypes, TypeRef.Unit) if !disableCallbackWrapping =>
         def fn(ref: ExprTree): ExprTree = {
           val params = paramTypes.zipWithIndex.map {
             case (tpe, i) =>


### PR DESCRIPTION
Scalajs-react added a feature, called [Effect Agnosticism](https://github.com/japgolly/scalajs-react/blob/master/doc/FX_AGNOSTICISM.md), to support arbitrary effects instead of its own `Callback` and `CallbackTo` types. For example, you can use Cats Effect or ZIO. 

Unfortunately, when scalajs-react is imported in this mode, the Callback classes are not in the same package so the code generated by the Converter doesn't compile. Even if it did, re-wrapping the effect type that you actually use in Callback is even worse than having to unwrap it into an impure function.

Ideally the Converter would support effect-agnostic scalajs-react as a new flavor, but doing so requires outputting higher-kinded type parameters in various places so it's a bit of an undertaking.

As a more immediate solution this PR just adds an option to disable the wrapping of callback-style props in the `Callback` type so the user could manually unwrap their effect type into impure functions but keep using all the other facilities of the ScalajsReact flavor.