### PR TITLE
Fix parsing error when parsing interface with `const` modifier in type parameter

### DIFF
--- a/importer/src/test/scala/org/scalablytyped/converter/internal/ts/parser/ParserTests.scala
+++ b/importer/src/test/scala/org/scalablytyped/converter/internal/ts/parser/ParserTests.scala
@@ -160,14 +160,23 @@ final class ParserTests extends AnyFunSuite {
     shouldParseAs(content, TsParser.tsDeclInterface)(expected)
   }
 
-  test("interface with const modifier for type parameters ") {
+  test("interface with const modifier for type parameters") {
     val content: String =
-      """      interface TFunctionStrict {
-         |           < const Key extends string>(key: Key): void;
-         |       }
-         |      """.stripMargin
+      """interface TFunctionStrict {
+        |  <const Key extends string>(key: Key): void;
+        |}
+        |""".stripMargin
 
     parseAs(content, TsParser.tsDeclInterface)
+
+    // Also test multiple const type parameters
+    val content2: String =
+      """interface MultiConst {
+        |  <const T, const U extends string, V>(t: T, u: U, v: V): void;
+        |}
+        |""".stripMargin
+
+    parseAs(content2, TsParser.tsDeclInterface)
   }
 
   test("class") {

--- a/importer/src/test/scala/org/scalablytyped/converter/internal/ts/parser/ParserTests.scala
+++ b/importer/src/test/scala/org/scalablytyped/converter/internal/ts/parser/ParserTests.scala
@@ -160,6 +160,16 @@ final class ParserTests extends AnyFunSuite {
     shouldParseAs(content, TsParser.tsDeclInterface)(expected)
   }
 
+  test("interface with const modifier for type parameters ") {
+    val content: String =
+      """      interface TFunctionStrict {
+         |           < const Key extends string>(key: Key): void;
+         |       }
+         |      """.stripMargin
+
+    parseAs(content, TsParser.tsDeclInterface)
+  }
+
   test("class") {
     val content: String =
       """    class Base {

--- a/ts/src/main/scala/org/scalablytyped/converter/internal/ts/parser/TsParser.scala
+++ b/ts/src/main/scala/org/scalablytyped/converter/internal/ts/parser/TsParser.scala
@@ -379,7 +379,9 @@ class TsParser(path: Option[(os.Path, Int)]) extends StdTokenParsers with Parser
     "keyof" ~>! baseTypeDesc ^^ TsTypeKeyOf
 
   lazy val typeParam: Parser[TsTypeParam] =
-    comments ~ tsIdent ~ ("extends" ~>! perhapsParens(tsType)).? ~ ("=" ~>! tsType).? ^^ TsTypeParam.apply
+    comments ~ "const".? ~ tsIdent ~ ("extends" ~>! perhapsParens(tsType)).? ~ ("=" ~>! tsType).? ^^ {
+      case comments ~ _ ~ name ~ upperBound ~ default => TsTypeParam(comments, name, upperBound, default)
+    }
 
   lazy val tsTypeParams: Parser[IArray[TsTypeParam]] =
     "<" ~>! repsep_(typeParam, ",") <~! ",".? <~ comments.? <~! ">" | success(Empty)


### PR DESCRIPTION
Converter fails to parse this code snippet:
```typescript
            interface TFunctionStrict {
                 < const Key extends string>(key: Key): void;
            }
```
- `const` modifier in type parameters was introduced in [Typescript 5.0 release](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#const-type-parameters)