### PR TITLE
Disable automatic snapshot publishing

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -3,8 +3,10 @@
 # that's why we don't trigger on tag
 name: Release snapshot
 on:
-  push:
-    branches: [ 'master', 'mui5-support' ]
+  # Temporarily disabled - can be re-enabled later
+  workflow_dispatch:
+  # push:
+  #   branches: [ 'master', 'mui5-support' ]
 
 jobs:
   release-snapshot:


### PR DESCRIPTION
Changed the workflow trigger from push to workflow_dispatch, so snapshots will only be published when manually triggered. This can be re-enabled later when needed.