### PR TITLE
Bump versions and update scala definitions

### DIFF
--- a/core/src/main/scala/org/scalablytyped/converter/internal/Json.scala
+++ b/core/src/main/scala/org/scalablytyped/converter/internal/Json.scala
@@ -134,9 +134,9 @@ object Json {
   def opt[T: Decoder](path: Path): Option[T] =
     if (Files.exists(path)) Some(force(path)) else None
 
-  def persist[V: Encoder](file: os.Path)(value: V): Synced =
-    persist(file.toNIO)(value)
+  def persist[V: Encoder](file: os.Path)(value: V, printer: Printer = Printer.noSpaces): Synced =
+    persist(file.toNIO)(value, printer)
 
-  def persist[V: Encoder](file: Path)(value: V): Synced =
-    files.softWrite(file)(_.append(value.asJson.noSpaces))
+  def persist[V: Encoder](file: Path)(value: V, printer: Printer): Synced =
+    files.softWrite(file)(_.append(printer.print(value.asJson)))
 }

--- a/import-scalajs-definitions/src/main/scala/org/scalablytyped/converter/internal/scalajs/ImportScalaDefinitions.scala
+++ b/import-scalajs-definitions/src/main/scala/org/scalablytyped/converter/internal/scalajs/ImportScalaDefinitions.scala
@@ -1,8 +1,6 @@
 package org.scalablytyped.converter.internal
 package scalajs
 
-import java.util.regex.Pattern
-
 import ammonite.ops._
 import bloop.io.AbsolutePath
 import com.olvind.logging
@@ -10,9 +8,8 @@ import org.scalablytyped.converter.internal.importer.build.BloopCompiler
 import org.scalablytyped.converter.internal.maps._
 import org.scalablytyped.converter.internal.scalajs.transforms.Sorter
 
-import scala.concurrent.Await
+import java.util.regex.Pattern
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.Duration
 import scala.reflect.NameTransformer
 import scala.tools.scalap.scalax.rules.scalasig._
 
@@ -174,7 +171,7 @@ object ImportScalaDefinitions extends App {
     all.mapNotNone(isJs)
   }
 
-  Json.persist[IArray[Tree]](dumpJsonTo)(flatten(allJs))
+  Json.persist[IArray[Tree]](dumpJsonTo)(flatten(allJs).sortBy(_.codePath.parts), io.circe.Printer.spaces2)
 
   {
     val inContainers: IArray[Tree] =

--- a/import-scalajs-definitions/src/test/resources/imported/japgolly.scala
+++ b/import-scalajs-definitions/src/test/resources/imported/japgolly.scala
@@ -288,7 +288,7 @@ object japgolly {
           }
           
           @js.native
-          abstract class Component[P, S] protected () extends StObject {
+          class Component[P, S] protected () extends StObject {
             def this(ctorProps: P) = this()
             
             type Props = P with PropsWithChildren

--- a/import-scalajs-definitions/src/test/resources/imported/org.scala
+++ b/import-scalajs-definitions/src/test/resources/imported/org.scala
@@ -140,7 +140,7 @@ object org {
       }
       
       @js.native
-      abstract class AbstractRange () extends StObject {
+      class AbstractRange () extends StObject {
         
         def collapsed(): Boolean = js.native
         
@@ -336,6 +336,13 @@ object org {
         def specified(): Boolean = js.native
         
         var value: String = js.native
+      }
+      
+      @js.native
+      class Audio ()
+        extends StObject
+           with HTMLAudioElement {
+        def this(url: String) = this()
       }
       
       @js.native
@@ -622,10 +629,29 @@ object org {
         def text(): js.Promise[String] = js.native
       }
       
+      @js.native
+      class BroadcastChannel protected ()
+        extends StObject
+           with EventTarget {
+        def this(channelName: String) = this()
+        
+        val channelName: String = js.native
+        
+        def close(): Unit = js.native
+        
+        def name(): String = js.native
+        
+        var onmessage: js.Function1[MessageEvent, _] = js.native
+        
+        var onmessageerror: js.Function1[MessageEvent, _] = js.native
+        
+        def postMessage(message: Any): Unit = js.native
+      }
+      
       type BufferSource = js.typedarray.ArrayBufferView | js.typedarray.ArrayBuffer
       
       @js.native
-      abstract class CDATASection ()
+      class CDATASection ()
         extends StObject
            with Text
       
@@ -1230,7 +1256,7 @@ object org {
       }
       
       @js.native
-      abstract class Cache () extends StObject {
+      class Cache () extends StObject {
         
         def add(request: RequestInfo): js.Promise[Unit] = js.native
         
@@ -1274,6 +1300,11 @@ object org {
       }
       
       @js.native
+      sealed trait CanvasFillRule
+        extends StObject
+           with js.Any
+      
+      @js.native
       class CanvasGradient () extends StObject {
         
         def addColorStop(offset: Double, color: String): Unit = js.native
@@ -1294,7 +1325,14 @@ object org {
       class CanvasRenderingContext2D () extends StObject {
         
         def arc(x: Double, y: Double, radius: Double, startAngle: Double, endAngle: Double): Unit = js.native
-        def arc(x: Double, y: Double, radius: Double, startAngle: Double, endAngle: Double, anticlockwise: Boolean): Unit = js.native
+        def arc(
+          x: Double,
+          y: Double,
+          radius: Double,
+          startAngle: Double,
+          endAngle: Double,
+          counterclockwise: Boolean
+        ): Unit = js.native
         
         def arcTo(x1: Double, y1: Double, x2: Double, y2: Double, radius: Double): Unit = js.native
         
@@ -1306,7 +1344,9 @@ object org {
         
         def clearRect(x: Double, y: Double, w: Double, h: Double): Unit = js.native
         
-        def clip(fillRule: String): Unit = js.native
+        def clip(fillRule: CanvasFillRule): Unit = js.native
+        def clip(path: Path2D): Unit = js.native
+        def clip(path: Path2D, fillRule: CanvasFillRule): Unit = js.native
         
         def closePath(): Unit = js.native
         
@@ -1338,16 +1378,20 @@ object org {
           rotation: Double,
           startAngle: Double,
           endAngle: Double,
-          anticlockwise: Boolean
+          counterclockwise: Boolean
         ): Unit = js.native
         
-        def fill(): Unit = js.native
+        def fill(fillRule: CanvasFillRule): Unit = js.native
+        def fill(path: Path2D): Unit = js.native
+        def fill(path: Path2D, fillRule: CanvasFillRule): Unit = js.native
         
         def fillRect(x: Double, y: Double, w: Double, h: Double): Unit = js.native
         
         var fillStyle: js.Any = js.native
         
         def fillText(text: String, x: Double, y: Double, maxWidth: Double): Unit = js.native
+        
+        var filter: String = js.native
         
         var font: String = js.native
         
@@ -1361,8 +1405,9 @@ object org {
         
         var imageSmoothingEnabled: Boolean = js.native
         
-        def isPointInPath(x: Double, y: Double): Boolean = js.native
-        def isPointInPath(x: Double, y: Double, fillRule: String): Boolean = js.native
+        def isPointInPath(path: Path2D, x: Double, y: Double): Boolean = js.native
+        def isPointInPath(path: Path2D, x: Double, y: Double, fillRule: CanvasFillRule): Boolean = js.native
+        def isPointInPath(x: Double, y: Double, fillRule: CanvasFillRule): Boolean = js.native
         
         var lineCap: String = js.native
         
@@ -1415,6 +1460,7 @@ object org {
         var shadowOffsetY: Double = js.native
         
         def stroke(): Unit = js.native
+        def stroke(path: Path2D): Unit = js.native
         
         def strokeRect(x: Double, y: Double, w: Double, h: Double): Unit = js.native
         
@@ -1444,7 +1490,7 @@ object org {
            with AudioNode
       
       @js.native
-      abstract class CharacterData ()
+      class CharacterData ()
         extends StObject
            with Node
            with NonDocumentTypeChildNode {
@@ -1518,11 +1564,11 @@ object org {
         extends StObject
            with EventTarget {
         
-        def read(): js.Promise[DataTransfer] = js.native
+        def read(): js.Promise[js.Array[ClipboardItem]] = js.native
         
         def readText(): js.Promise[String] = js.native
         
-        def write(data: DataTransfer): js.Promise[Unit] = js.native
+        def write(data: js.Array[ClipboardItem]): js.Promise[Unit] = js.native
         
         def writeText(newClipText: String): js.Promise[Unit] = js.native
       }
@@ -1548,6 +1594,29 @@ object org {
         var data: js.UndefOr[String] = js.native
         
         var dataType: js.UndefOr[String] = js.native
+      }
+      
+      @js.native
+      class ClipboardItem protected () extends StObject {
+        def this(items: js.Dictionary[ClipboardItemData], options: ClipboardItemOptions) = this()
+        
+        def getType(`type`: String): js.Promise[Blob] = js.native
+        
+        val items: js.Dictionary[ClipboardItemData] = js.native
+        
+        val options: ClipboardItemOptions = js.native
+        
+        def presentationStyle(): PresentationStyle = js.native
+        
+        def types(): FrozenArray[String] = js.native
+      }
+      
+      type ClipboardItemData = js.Promise[String | Blob]
+      
+      @js.native
+      trait ClipboardItemOptions extends StObject {
+        
+        def presentationStyle(): js.UndefOr[PresentationStyle] = js.native
       }
       
       @js.native
@@ -1593,6 +1662,22 @@ object org {
         var data: js.UndefOr[String] = js.native
         
         var locale: js.UndefOr[String] = js.native
+      }
+      
+      @js.native
+      sealed trait CompressionFormat
+        extends StObject
+           with js.Any
+      
+      @js.native
+      class CompressionStream protected () extends StObject {
+        def this(format: CompressionFormat) = this()
+        
+        val format: CompressionFormat = js.native
+        
+        def readable(): ReadableStream[js.typedarray.Uint8Array] = js.native
+        
+        def writable(): WriteableStream[js.typedarray.Uint8Array] = js.native
       }
       
       @js.native
@@ -1739,7 +1824,7 @@ object org {
       }
       
       @js.native
-      abstract class CustomElementRegistry () extends StObject {
+      class CustomElementRegistry () extends StObject {
         
         def define(name: String, constructor: js.Dynamic, options: ElementDefinitionOptions): Unit = js.native
       }
@@ -1868,6 +1953,18 @@ object org {
       }
       
       @js.native
+      trait DOMRectInit extends StObject {
+        
+        var height: js.UndefOr[Double] = js.native
+        
+        var width: js.UndefOr[Double] = js.native
+        
+        var x: js.UndefOr[Double] = js.native
+        
+        var y: js.UndefOr[Double] = js.native
+      }
+      
+      @js.native
       class DOMRectList ()
         extends StObject
            with DOMList[DOMRect]
@@ -1932,19 +2029,69 @@ object org {
         
         def clearData(format: String): Unit = js.native
         
-        var dropEffect: String = js.native
+        var dropEffect: DataTransferDropEffectKind = js.native
         
-        var effectAllowed: String = js.native
+        var effectAllowed: DataTransferEffectAllowedKind = js.native
         
         def files(): FileList = js.native
         
         def getData(format: String): String = js.native
         
+        def items(): DataTransferItemList = js.native
+        
         def setData(format: String, data: String): Unit = js.native
         
         def setDragImage(image: Element, x: Double, y: Double): Unit = js.native
         
-        def types(): js.Array[String] = js.native
+        def types(): FrozenArray[String] = js.native
+      }
+      
+      @js.native
+      sealed trait DataTransferDropEffectKind
+        extends StObject
+           with js.Any
+      
+      @js.native
+      sealed trait DataTransferEffectAllowedKind
+        extends StObject
+           with js.Any
+      
+      @js.native
+      class DataTransferItem private () extends StObject {
+        
+        def getAsFile(): File = js.native
+        
+        def getAsString(callback: js.Function1[String, Unit]): Unit = js.native
+        
+        def kind(): DragDataItemKind = js.native
+        
+        def `type`(): String = js.native
+      }
+      
+      @js.native
+      class DataTransferItemList private () extends StObject {
+        
+        def add(data: String, `type`: String): DataTransferItem = js.native
+        def add(data: File): DataTransferItem = js.native
+        
+        def apply(index: Int): DataTransferItem = js.native
+        
+        def clear(): Unit = js.native
+        
+        def length(): Int = js.native
+        
+        def remove(index: Int): Unit = js.native
+      }
+      
+      @js.native
+      class DecompressionStream protected () extends StObject {
+        def this(format: CompressionFormat) = this()
+        
+        val format: CompressionFormat = js.native
+        
+        def readable(): ReadableStream[js.typedarray.Uint8Array] = js.native
+        
+        def writable(): WriteableStream[js.typedarray.Uint8Array] = js.native
       }
       
       @js.native
@@ -2126,7 +2273,7 @@ object org {
       }
       
       @js.native
-      abstract class Document ()
+      class Document ()
         extends StObject
            with Node
            with NodeSelector
@@ -2149,8 +2296,12 @@ object org {
         def createDocumentFragment(): DocumentFragment = js.native
         
         def createElement(tagName: String): Element = js.native
+        def createElement(tagName: String, options: String): Element = js.native
+        def createElement(tagName: String, options: ElementCreationOptions): Element = js.native
         
         def createElementNS(namespaceURI: String, qualifiedName: String): Element = js.native
+        def createElementNS(namespaceURI: String, qualifiedName: String, options: String): Element = js.native
+        def createElementNS(namespaceURI: String, qualifiedName: String, options: ElementCreationOptions): Element = js.native
         
         def createNSResolver(node: Node): XPathNSResolver = js.native
         
@@ -2233,7 +2384,7 @@ object org {
       }
       
       @js.native
-      abstract class DocumentFragment ()
+      class DocumentFragment ()
         extends StObject
            with Node
            with NodeSelector
@@ -2244,7 +2395,7 @@ object org {
            with js.Any
       
       @js.native
-      abstract class DocumentType ()
+      class DocumentType ()
         extends StObject
            with Node {
         
@@ -2254,6 +2405,11 @@ object org {
         
         def systemId(): String = js.native
       }
+      
+      @js.native
+      sealed trait DragDataItemKind
+        extends StObject
+           with js.Any
       
       @js.native
       trait DragEvent
@@ -2323,7 +2479,7 @@ object org {
       }
       
       @js.native
-      abstract class Element ()
+      class Element ()
         extends StObject
            with Node
            with NodeSelector
@@ -2338,6 +2494,8 @@ object org {
         
         def attachShadow(init: ShadowRootInit): ShadowRoot = js.native
         
+        def attributes(): NamedNodeMap = js.native
+        
         def before(nodes: Node | String): Unit = js.native
         
         var classList: DOMTokenList = js.native
@@ -2349,6 +2507,8 @@ object org {
         def clientTop(): Int = js.native
         
         def clientWidth(): Int = js.native
+        
+        def closest(selector: String): Element = js.native
         
         def getAttribute(name: String): String = js.native
         
@@ -2372,6 +2532,10 @@ object org {
         
         def hasAttributeNS(namespaceURI: String, localName: String): Boolean = js.native
         
+        def hasAttributes(): Boolean = js.native
+        
+        def hasPointerCapture(pointerId: Double): Boolean = js.native
+        
         var id: String = js.native
         
         var innerHTML: String = js.native
@@ -2381,6 +2545,12 @@ object org {
         def insertAdjacentHTML(where: String, html: String): Unit = js.native
         
         def matches(selector: String): Boolean = js.native
+        
+        var oncompositionend: js.Function1[CompositionEvent, _] = js.native
+        
+        var oncompositionstart: js.Function1[CompositionEvent, _] = js.native
+        
+        var oncompositionupdate: js.Function1[CompositionEvent, _] = js.native
         
         var oncopy: js.Function1[ClipboardEvent, _] = js.native
         
@@ -2397,6 +2567,8 @@ object org {
         def prefix(): String = js.native
         
         def prepend(nodes: Node | String): Unit = js.native
+        
+        def releasePointerCapture(pointerId: Double): Unit = js.native
         
         def remove(): Unit = js.native
         
@@ -2430,9 +2602,17 @@ object org {
         
         def setAttributeNodeNS(newAttr: Attr): Attr = js.native
         
+        def setPointerCapture(pointerId: Double): Unit = js.native
+        
         def shadowRoot(): ShadowRoot = js.native
         
         def tagName(): String = js.native
+      }
+      
+      @js.native
+      trait ElementCreationOptions extends StObject {
+        
+        var is: js.UndefOr[String] = js.native
       }
       
       @js.native
@@ -2474,6 +2654,8 @@ object org {
         def cancelBubble(): Boolean = js.native
         
         def cancelable(): Boolean = js.native
+        
+        def composed(): Boolean = js.native
         
         def currentTarget(): EventTarget = js.native
         
@@ -2558,7 +2740,7 @@ object org {
         
         def close(): Unit = js.native
         
-        var onerror: js.Function1[ErrorEvent, _] = js.native
+        var onerror: js.Function1[Event, _] = js.native
         
         var onmessage: js.Function1[MessageEvent, _] = js.native
         
@@ -2807,18 +2989,57 @@ object org {
       }
       
       @js.native
-      class FormData protected () extends StObject {
+      trait FocusOptions extends StObject {
+        
+        var focusVisible: js.UndefOr[Boolean] = js.native
+        
+        var preventScroll: js.UndefOr[Boolean] = js.native
+      }
+      
+      @js.native
+      class FormData ()
+        extends StObject
+           with js.Iterable[js.Tuple2[String, String | Blob]] {
         def this(form: HTMLFormElement) = this()
+        def this(form: HTMLFormElement, submitter: HTMLElement) = this()
         
-        def append(name: js.Any, value: js.Any, blobName: String): Unit = js.native
+        def append(name: String, value: String): Unit = js.native
+        def append(name: String, value: Blob, blobName: String): Unit = js.native
         
-        val form: HTMLFormElement = js.native
+        def delete(name: String): Unit = js.native
+        
+        def entries(): js.Iterator[js.Tuple2[String, String | Blob]] = js.native
+        
+        def get(name: String): String | Blob = js.native
+        
+        def getAll(name: String): js.Array[String | Blob] = js.native
+        
+        def has(name: String): Boolean = js.native
+        
+        override def jsIterator(): js.Iterator[js.Tuple2[String, String | Blob]] = js.native
+        
+        def keys(): js.Iterator[String] = js.native
+        
+        def set(name: String, value: String): Unit = js.native
+        def set(name: String, value: Blob, blobName: String): Unit = js.native
+        
+        def values(): js.Iterator[String | Blob] = js.native
       }
       
       @js.native
       sealed trait FrameType
         extends StObject
            with js.Any
+      
+      @js.native
+      trait FrozenArray[T]
+        extends StObject
+           with js.Iterable[T] {
+        
+        def apply(index: Int): T = js.native
+        
+        val length: Int = js.native
+      }
       
       @js.native
       trait FullscreenOptions extends StObject {
@@ -2923,11 +3144,13 @@ object org {
       }
       
       @js.native
-      abstract class HTMLAnchorElement ()
+      class HTMLAnchorElement ()
         extends StObject
            with HTMLElement {
         
         var charset: String = js.native
+        
+        var download: String = js.native
         
         var hash: String = js.native
         
@@ -2959,7 +3182,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLAreaElement ()
+      class HTMLAreaElement ()
         extends StObject
            with HTMLElement {
         
@@ -2989,17 +3212,17 @@ object org {
       }
       
       @js.native
-      abstract class HTMLAudioElement ()
+      class HTMLAudioElement ()
         extends StObject
            with HTMLMediaElement
       
       @js.native
-      abstract class HTMLBRElement ()
+      class HTMLBRElement ()
         extends StObject
            with HTMLElement
       
       @js.native
-      abstract class HTMLBaseElement ()
+      class HTMLBaseElement ()
         extends StObject
            with HTMLElement {
         
@@ -3009,7 +3232,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLBodyElement ()
+      class HTMLBodyElement ()
         extends StObject
            with HTMLElement {
         
@@ -3043,7 +3266,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLButtonElement ()
+      class HTMLButtonElement ()
         extends StObject
            with HTMLElement {
         
@@ -3085,7 +3308,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLCanvasElement ()
+      class HTMLCanvasElement ()
         extends StObject
            with HTMLElement {
         
@@ -3099,7 +3322,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLCollection[E] ()
+      class HTMLCollection[E] ()
         extends StObject
            with DOMList[E] {
         
@@ -3109,12 +3332,12 @@ object org {
       }
       
       @js.native
-      abstract class HTMLDListElement ()
+      class HTMLDListElement ()
         extends StObject
            with HTMLElement
       
       @js.native
-      abstract class HTMLDataListElement ()
+      class HTMLDataListElement ()
         extends StObject
            with HTMLElement {
         
@@ -3122,7 +3345,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLDialogElement ()
+      class HTMLDialogElement ()
         extends StObject
            with HTMLElement {
         
@@ -3138,12 +3361,12 @@ object org {
       }
       
       @js.native
-      abstract class HTMLDivElement ()
+      class HTMLDivElement ()
         extends StObject
            with HTMLElement
       
       @js.native
-      abstract class HTMLDocument ()
+      class HTMLDocument ()
         extends StObject
            with Document {
         
@@ -3371,7 +3594,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLElement ()
+      class HTMLElement ()
         extends StObject
            with Element {
         
@@ -3394,6 +3617,7 @@ object org {
         var filters: Object = js.native
         
         def focus(): Unit = js.native
+        def focus(options: FocusOptions): Unit = js.native
         
         var gotpointercapture: js.Function1[PointerEvent, _] = js.native
         
@@ -3577,7 +3801,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLEmbedElement ()
+      class HTMLEmbedElement ()
         extends StObject
            with HTMLElement
            with GetSVGDocument {
@@ -3590,7 +3814,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLFieldSetElement ()
+      class HTMLFieldSetElement ()
         extends StObject
            with HTMLElement {
         
@@ -3617,7 +3841,7 @@ object org {
            with HTMLCollection[RadioNodeList | Element]
       
       @js.native
-      abstract class HTMLFormElement ()
+      class HTMLFormElement ()
         extends StObject
            with HTMLElement {
         
@@ -3661,27 +3885,27 @@ object org {
       }
       
       @js.native
-      abstract class HTMLHRElement ()
+      class HTMLHRElement ()
         extends StObject
            with HTMLElement
       
       @js.native
-      abstract class HTMLHeadElement ()
+      class HTMLHeadElement ()
         extends StObject
            with HTMLElement
       
       @js.native
-      abstract class HTMLHeadingElement ()
+      class HTMLHeadingElement ()
         extends StObject
            with HTMLElement
       
       @js.native
-      abstract class HTMLHtmlElement ()
+      class HTMLHtmlElement ()
         extends StObject
            with HTMLElement
       
       @js.native
-      abstract class HTMLIFrameElement ()
+      class HTMLIFrameElement ()
         extends StObject
            with HTMLElement
            with GetSVGDocument {
@@ -3708,7 +3932,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLImageElement ()
+      class HTMLImageElement ()
         extends StObject
            with HTMLElement {
         
@@ -3716,11 +3940,15 @@ object org {
         
         def complete(): Boolean = js.native
         
+        def currentSrc(): String = js.native
+        
         var height: Int = js.native
         
         var href: String = js.native
         
         var isMap: Boolean = js.native
+        
+        var loading: LazyLoadingState = js.native
         
         var naturalHeight: Int = js.native
         
@@ -3728,15 +3956,23 @@ object org {
         
         var onload: js.Function1[Event, _] = js.native
         
+        var sizes: String = js.native
+        
         var src: String = js.native
+        
+        var srcset: String = js.native
         
         var useMap: String = js.native
         
         var width: Int = js.native
+        
+        def x(): Int = js.native
+        
+        def y(): Int = js.native
       }
       
       @js.native
-      abstract class HTMLInputElement ()
+      class HTMLInputElement ()
         extends StObject
            with HTMLElement {
         
@@ -3836,7 +4072,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLLIElement ()
+      class HTMLLIElement ()
         extends StObject
            with HTMLElement {
         
@@ -3844,7 +4080,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLLabelElement ()
+      class HTMLLabelElement ()
         extends StObject
            with HTMLElement {
         
@@ -3854,7 +4090,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLLegendElement ()
+      class HTMLLegendElement ()
         extends StObject
            with HTMLElement {
         
@@ -3864,7 +4100,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLLinkElement ()
+      class HTMLLinkElement ()
         extends StObject
            with HTMLElement
            with LinkStyle {
@@ -3885,7 +4121,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLMapElement ()
+      class HTMLMapElement ()
         extends StObject
            with HTMLElement {
         
@@ -3893,7 +4129,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLMediaElement ()
+      class HTMLMediaElement ()
         extends StObject
            with HTMLElement {
         
@@ -3976,7 +4212,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLMenuElement ()
+      class HTMLMenuElement ()
         extends StObject
            with HTMLElement {
         
@@ -3984,7 +4220,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLMetaElement ()
+      class HTMLMetaElement ()
         extends StObject
            with HTMLElement {
         
@@ -4000,7 +4236,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLModElement ()
+      class HTMLModElement ()
         extends StObject
            with HTMLElement {
         
@@ -4010,7 +4246,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLOListElement ()
+      class HTMLOListElement ()
         extends StObject
            with HTMLElement {
         
@@ -4018,7 +4254,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLObjectElement ()
+      class HTMLObjectElement ()
         extends StObject
            with HTMLElement
            with GetSVGDocument {
@@ -4063,7 +4299,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLOptGroupElement ()
+      class HTMLOptGroupElement ()
         extends StObject
            with HTMLElement {
         
@@ -4073,7 +4309,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLOptionElement ()
+      class HTMLOptionElement ()
         extends StObject
            with HTMLElement {
         
@@ -4102,12 +4338,12 @@ object org {
            with HTMLCollection[HTMLOptionElement]
       
       @js.native
-      abstract class HTMLParagraphElement ()
+      class HTMLParagraphElement ()
         extends StObject
            with HTMLElement
       
       @js.native
-      abstract class HTMLParamElement ()
+      class HTMLParamElement ()
         extends StObject
            with HTMLElement {
         
@@ -4117,12 +4353,12 @@ object org {
       }
       
       @js.native
-      abstract class HTMLPreElement ()
+      class HTMLPreElement ()
         extends StObject
            with HTMLElement
       
       @js.native
-      abstract class HTMLProgressElement ()
+      class HTMLProgressElement ()
         extends StObject
            with HTMLElement {
         
@@ -4136,7 +4372,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLQuoteElement ()
+      class HTMLQuoteElement ()
         extends StObject
            with HTMLElement {
         
@@ -4146,7 +4382,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLScriptElement ()
+      class HTMLScriptElement ()
         extends StObject
            with HTMLElement {
         
@@ -4168,7 +4404,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLSelectElement ()
+      class HTMLSelectElement ()
         extends StObject
            with HTMLElement {
         
@@ -4222,7 +4458,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLSourceElement ()
+      class HTMLSourceElement ()
         extends StObject
            with HTMLElement {
         
@@ -4234,12 +4470,12 @@ object org {
       }
       
       @js.native
-      abstract class HTMLSpanElement ()
+      class HTMLSpanElement ()
         extends StObject
            with HTMLElement
       
       @js.native
-      abstract class HTMLStyleElement ()
+      class HTMLStyleElement ()
         extends StObject
            with HTMLElement
            with LinkStyle {
@@ -4253,12 +4489,12 @@ object org {
       trait HTMLTableAlignment extends StObject
       
       @js.native
-      abstract class HTMLTableCaptionElement ()
+      class HTMLTableCaptionElement ()
         extends StObject
            with HTMLElement
       
       @js.native
-      abstract class HTMLTableCellElement ()
+      class HTMLTableCellElement ()
         extends StObject
            with HTMLElement
            with HTMLTableAlignment {
@@ -4273,7 +4509,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLTableColElement ()
+      class HTMLTableColElement ()
         extends StObject
            with HTMLElement
            with HTMLTableAlignment {
@@ -4282,7 +4518,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLTableElement ()
+      class HTMLTableElement ()
         extends StObject
            with HTMLElement {
         
@@ -4318,7 +4554,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLTableRowElement ()
+      class HTMLTableRowElement ()
         extends StObject
            with HTMLElement
            with HTMLTableAlignment {
@@ -4343,7 +4579,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLTableSectionElement ()
+      class HTMLTableSectionElement ()
         extends StObject
            with HTMLElement
            with HTMLTableAlignment {
@@ -4358,7 +4594,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLTemplateElement ()
+      class HTMLTemplateElement ()
         extends StObject
            with HTMLElement {
         
@@ -4366,7 +4602,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLTextAreaElement ()
+      class HTMLTextAreaElement ()
         extends StObject
            with HTMLElement {
         
@@ -4422,7 +4658,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLTitleElement ()
+      class HTMLTitleElement ()
         extends StObject
            with HTMLElement {
         
@@ -4430,7 +4666,7 @@ object org {
       }
       
       @js.native
-      abstract class HTMLTrackElement ()
+      class HTMLTrackElement ()
         extends StObject
            with HTMLElement {
         
@@ -4446,17 +4682,17 @@ object org {
       }
       
       @js.native
-      abstract class HTMLUListElement ()
+      class HTMLUListElement ()
         extends StObject
            with HTMLElement
       
       @js.native
-      abstract class HTMLUnknownElement ()
+      class HTMLUnknownElement ()
         extends StObject
            with HTMLElement
       
       @js.native
-      abstract class HTMLVideoElement ()
+      class HTMLVideoElement ()
         extends StObject
            with HTMLMediaElement {
         
@@ -4897,6 +5133,18 @@ object org {
       }
       
       @js.native
+      class Image ()
+        extends StObject
+           with HTMLImageElement {
+        def this(width: Int) = this()
+        def this(width: Int, height: Int) = this()
+        
+        val height: Int = js.native
+        
+        val width: Int = js.native
+      }
+      
+      @js.native
       trait ImageBitmap extends StObject {
         
         def close(): Unit = js.native
@@ -4921,12 +5169,23 @@ object org {
       
       @js.native
       class ImageData () extends StObject {
+        def this(data: js.typedarray.Uint8ClampedArray, width: Int) = this()
+        def this(width: Int, height: Int) = this()
+        def this(data: js.typedarray.Uint8ClampedArray, width: Int, height: Int) = this()
+        def this(width: Int, height: Int, settings: ImageDataSettings) = this()
+        def this(data: js.typedarray.Uint8ClampedArray, width: Int, height: Int, settings: ImageDataSettings) = this()
         
-        def data(): js.Array[Int] = js.native
+        def data(): js.typedarray.Uint8ClampedArray = js.native
         
         def height(): Int = js.native
         
         def width(): Int = js.native
+      }
+      
+      @js.native
+      trait ImageDataSettings extends StObject {
+        
+        var colorSpace: js.UndefOr[PredefinedColorSpace] = js.native
       }
       
       @js.native
@@ -4967,6 +5226,81 @@ object org {
       sealed trait InputType
         extends StObject
            with js.Any
+      
+      @js.native
+      class IntersectionObserver protected () extends StObject {
+        def this(
+          callback: js.Function2[js.Array[IntersectionObserverEntry], IntersectionObserver, Unit],
+          options: IntersectionObserverInit
+        ) = this()
+        
+        val callback: js.Function2[js.Array[IntersectionObserverEntry], IntersectionObserver, Unit] = js.native
+        
+        def disconnect(): Unit = js.native
+        
+        def observe(target: Element): Unit = js.native
+        
+        val options: IntersectionObserverInit = js.native
+        
+        def root(): Document | Element = js.native
+        
+        def rootMargin(): String = js.native
+        
+        def takeRecords(): js.Array[IntersectionObserverEntry] = js.native
+        
+        def thresholds(): FrozenArray[Double] = js.native
+        
+        def unobserve(target: Element): Unit = js.native
+      }
+      
+      @js.native
+      class IntersectionObserverEntry protected () extends StObject {
+        def this(init: IntersectionObserverEntryInit) = this()
+        
+        def boundingClientRect(): DOMRectReadOnly = js.native
+        
+        val init: IntersectionObserverEntryInit = js.native
+        
+        def intersectionRatio(): Double = js.native
+        
+        def intersectionRect(): DOMRectReadOnly = js.native
+        
+        def isIntersecting(): Boolean = js.native
+        
+        def rootBounds(): DOMRectReadOnly = js.native
+        
+        def target(): Element = js.native
+        
+        def time(): Double = js.native
+      }
+      
+      @js.native
+      trait IntersectionObserverEntryInit extends StObject {
+        
+        var boundingClientRect: DOMRectInit = js.native
+        
+        var intersectionRatio: Double = js.native
+        
+        var intersectionRect: DOMRectInit = js.native
+        
+        var isIntersecting: Boolean = js.native
+        
+        var rootBounds: DOMRectInit = js.native
+        
+        var target: Element = js.native
+        
+        var time: Double = js.native
+      }
+      
+      @js.native
+      trait IntersectionObserverInit extends StObject {
+        
+        var root: js.UndefOr[Document | Element] = js.native
+        
+        var rootMargin: js.UndefOr[String] = js.native
+        
+        var threshold: js.UndefOr[Double | js.Array[Double]] = js.native
+      }
       
       @js.native
       trait JsonWebKey extends StObject {
@@ -5038,9 +5372,13 @@ object org {
         
         def charCode(): Int = js.native
         
+        def code(): String = js.native
+        
         def getModifierState(keyArg: String): Boolean = js.native
         
         val init: js.UndefOr[KeyboardEventInit] = js.native
+        
+        def isComposing(): Boolean = js.native
         
         def key(): String = js.native
         
@@ -5072,6 +5410,8 @@ object org {
         
         var charCode: js.UndefOr[Int] = js.native
         
+        var code: js.UndefOr[String] = js.native
+        
         var key: js.UndefOr[String] = js.native
         
         var keyCode: js.UndefOr[Int] = js.native
@@ -5082,6 +5422,11 @@ object org {
         
         var repeat: js.UndefOr[Boolean] = js.native
       }
+      
+      @js.native
+      sealed trait LazyLoadingState
+        extends StObject
+           with js.Any
       
       @js.native
       trait LinkStyle extends StObject {
@@ -5102,7 +5447,7 @@ object org {
         
         var href: String = js.native
         
-        def origin(): js.UndefOr[String] = js.native
+        def origin(): String = js.native
         
         var pathname: String = js.native
         
@@ -5110,7 +5455,7 @@ object org {
         
         var protocol: String = js.native
         
-        def reload(flag: Boolean): Unit = js.native
+        def reload(): Unit = js.native
         
         def replace(url: String): Unit = js.native
         
@@ -5118,9 +5463,93 @@ object org {
       }
       
       @js.native
+      class Lock private () extends StObject {
+        
+        def mode(): LockMode = js.native
+        
+        def name(): String = js.native
+      }
+      
+      @js.native
+      trait LockInfo extends StObject {
+        
+        def clientId(): String = js.native
+        
+        def mode(): LockMode = js.native
+        
+        def name(): String = js.native
+      }
+      
+      @js.native
+      class LockManager private () extends StObject {
+        
+        def query(): js.Promise[LockManagerSnapshot] = js.native
+        
+        def request(name: String, callback: js.Function1[Lock, js.Promise[Unit]]): js.Promise[Unit] = js.native
+        def request(name: String, options: LockOptions, callback: js.Function1[Lock, js.Promise[Unit]]): js.Promise[Unit] = js.native
+      }
+      
+      @js.native
+      trait LockManagerSnapshot extends StObject {
+        
+        def held(): js.Array[LockInfo] = js.native
+        
+        def pending(): js.Array[LockInfo] = js.native
+      }
+      
+      @js.native
+      sealed trait LockMode
+        extends StObject
+           with js.Any
+      
+      @js.native
+      trait LockOptions extends StObject {
+        
+        var ifAvailable: js.UndefOr[Boolean] = js.native
+        
+        var mode: js.UndefOr[LockMode] = js.native
+        
+        var signal: js.UndefOr[AbortSignal] = js.native
+        
+        var steal: js.UndefOr[Boolean] = js.native
+      }
+      
+      @js.native
       sealed trait MIMEType
         extends StObject
            with js.Any
+      
+      @js.native
+      class MathMLElement ()
+        extends StObject
+           with Element {
+        
+        var autofocus: Boolean = js.native
+        
+        var className: String = js.native
+        
+        var onclick: js.Function1[MouseEvent, _] = js.native
+        
+        var onfocusin: js.Function1[FocusEvent, _] = js.native
+        
+        var onfocusout: js.Function1[FocusEvent, _] = js.native
+        
+        var onload: js.Function1[Event, _] = js.native
+        
+        var onmousedown: js.Function1[MouseEvent, _] = js.native
+        
+        var onmousemove: js.Function1[MouseEvent, _] = js.native
+        
+        var onmouseout: js.Function1[MouseEvent, _] = js.native
+        
+        var onmouseover: js.Function1[MouseEvent, _] = js.native
+        
+        var onmouseup: js.Function1[MouseEvent, _] = js.native
+        
+        var style: CSSStyleDeclaration = js.native
+        
+        var tabIndex: Int = js.native
+      }
       
       @js.native
       trait MediaDeviceInfo extends StObject {
@@ -5195,13 +5624,15 @@ object org {
       }
       
       @js.native
-      trait MediaQueryList extends StObject {
+      trait MediaQueryList
+        extends StObject
+           with EventTarget {
         
         def addListener(listener: MediaQueryListListener): Unit = js.native
         
         def matches(): Boolean = js.native
         
-        var media: String = js.native
+        def media(): String = js.native
         
         def removeListener(listener: MediaQueryListListener): Unit = js.native
       }
@@ -5669,6 +6100,115 @@ object org {
       }
       
       @js.native
+      class NDEFMessage protected () extends StObject {
+        def this(messageInit: js.Array[NDEFRecordInit]) = this()
+        
+        val messageInit: js.Array[NDEFRecordInit] = js.native
+        
+        def records(): FrozenArray[NDEFRecord] = js.native
+      }
+      
+      @js.native
+      class NDEFReader ()
+        extends StObject
+           with EventTarget {
+        
+        var onreading: js.Function1[NDEFReadingEvent, Any] = js.native
+        
+        var onreadingerror: js.Function1[Event, Any] = js.native
+        
+        def scan(options: NDEFScanOptions): js.Promise[Unit] = js.native
+        
+        def write(message: String): js.Promise[Unit] = js.native
+        def write(message: String, options: NDEFWriteOptions): js.Promise[Unit] = js.native
+        def write(message: js.Array[NDEFRecord]): js.Promise[Unit] = js.native
+        def write(message: js.Array[NDEFRecord], options: NDEFWriteOptions): js.Promise[Unit] = js.native
+        def write(message: js.typedarray.ArrayBuffer): js.Promise[Unit] = js.native
+        def write(message: js.typedarray.ArrayBuffer, options: NDEFWriteOptions): js.Promise[Unit] = js.native
+        def write(message: js.typedarray.DataView): js.Promise[Unit] = js.native
+        def write(message: js.typedarray.DataView, options: NDEFWriteOptions): js.Promise[Unit] = js.native
+        def write(message: js.typedarray.TypedArray[_, _], options: NDEFWriteOptions): js.Promise[Unit] = js.native
+      }
+      
+      @js.native
+      class NDEFReadingEvent protected ()
+        extends StObject
+           with Event {
+        def this(typeArg: String, init: NDEFReadingEventInit) = this()
+        
+        val init: NDEFReadingEventInit = js.native
+        
+        def message(): NDEFMessage = js.native
+        
+        def serialNumber(): String = js.native
+        
+        val typeArg: String = js.native
+      }
+      
+      @js.native
+      trait NDEFReadingEventInit
+        extends StObject
+           with EventInit {
+        
+        var message: NDEFRecordInit = js.native
+        
+        var serialNumber: js.UndefOr[String] = js.native
+      }
+      
+      @js.native
+      class NDEFRecord protected () extends StObject {
+        def this(init: NDEFRecordInit) = this()
+        
+        def data(): js.typedarray.DataView = js.native
+        
+        def encoding(): js.UndefOr[String] = js.native
+        
+        def id(): js.UndefOr[String] = js.native
+        
+        val init: NDEFRecordInit = js.native
+        
+        def lang(): js.UndefOr[String] = js.native
+        
+        def mediaType(): js.UndefOr[String] = js.native
+        
+        def recordType(): String = js.native
+        
+        def toRecords(): js.UndefOr[js.Array[NDEFRecord]] = js.native
+      }
+      
+      @js.native
+      trait NDEFRecordInit extends StObject {
+        
+        var data: js.UndefOr[
+                String | js.typedarray.DataView | js.typedarray.ArrayBuffer | (js.typedarray.TypedArray[_, _]) | js.Array[NDEFRecord]
+              ] = js.native
+        
+        var encoding: js.UndefOr[String] = js.native
+        
+        var id: js.UndefOr[String] = js.native
+        
+        var lang: js.UndefOr[String] = js.native
+        
+        var mediaType: js.UndefOr[String] = js.native
+        
+        var recordType: String = js.native
+      }
+      
+      @js.native
+      trait NDEFScanOptions extends StObject {
+        
+        var signal: js.UndefOr[AbortSignal] = js.native
+      }
+      
+      @js.native
+      trait NDEFWriteOptions extends StObject {
+        
+        var overwrite: js.UndefOr[Boolean] = js.native
+        
+        var signal: js.UndefOr[AbortSignal] = js.native
+      }
+      
+      @js.native
       class NamedNodeMap () extends StObject {
         
         def apply(index: Int): Attr = js.native
@@ -5701,6 +6241,7 @@ object org {
            with NavigatorGeolocation
            with NavigatorStorageUtils
            with NavigatorLanguage
+           with NavigatorLocks
            with NavigatorVibration {
         
         def clipboard(): Clipboard = js.native
@@ -5719,7 +6260,14 @@ object org {
       }
       
       @js.native
-      trait NavigatorContentUtils extends StObject
+      trait NavigatorContentUtils extends StObject {
+        
+        def registerProtocolHandler(scheme: String, url: String): Unit = js.native
+        def registerProtocolHandler(scheme: String, url: URL): Unit = js.native
+        
+        def unregisterProtocolHandler(scheme: String, url: String): Unit = js.native
+        def unregisterProtocolHandler(scheme: String, url: URL): Unit = js.native
+      }
       
       @js.native
       trait NavigatorGeolocation extends StObject {
@@ -5748,6 +6296,12 @@ object org {
       }
       
       @js.native
+      trait NavigatorLocks extends StObject {
+        
+        def locks(): LockManager = js.native
+      }
+      
+      @js.native
       trait NavigatorOnLine extends StObject {
         
         def onLine(): Boolean = js.native
@@ -5764,13 +6318,11 @@ object org {
       }
       
       @js.native
-      abstract class Node ()
+      class Node ()
         extends StObject
            with EventTarget {
         
         def appendChild(newChild: Node): Node = js.native
-        
-        def attributes(): NamedNodeMap = js.native
         
         def baseURI(): String = js.native
         
@@ -5783,8 +6335,6 @@ object org {
         def contains(otherNode: Node): Boolean = js.native
         
         def firstChild(): Node = js.native
-        
-        def hasAttributes(): Boolean = js.native
         
         def hasChildNodes(): Boolean = js.native
         
@@ -6160,6 +6710,47 @@ object org {
       }
       
       @js.native
+      class Path2D () extends StObject {
+        
+        def addPath(path: Path2D): Unit = js.native
+        
+        def arc(x: Double, y: Double, radius: Double, startAngle: Double, endAngle: Double): Unit = js.native
+        def arc(
+          x: Double,
+          y: Double,
+          radius: Double,
+          startAngle: Double,
+          endAngle: Double,
+          counterclockwise: Boolean
+        ): Unit = js.native
+        
+        def arcTo(x1: Double, y1: Double, x2: Double, y2: Double, radius: Double): Unit = js.native
+        
+        def bezierCurveTo(cp1x: Double, cp1y: Double, cp2x: Double, cp2y: Double, x: Double, y: Double): Unit = js.native
+        
+        def closePath(): Unit = js.native
+        
+        def ellipse(
+          x: Double,
+          y: Double,
+          radiusX: Double,
+          radiusY: Double,
+          rotation: Double,
+          startAngle: Double,
+          endAngle: Double,
+          counterclockwise: Boolean
+        ): Unit = js.native
+        
+        def lineTo(x: Double, y: Double): Unit = js.native
+        
+        def moveTo(x: Double, y: Double): Unit = js.native
+        
+        def quadraticCurveTo(cpx: Double, cpy: Double, x: Double, y: Double): Unit = js.native
+        
+        def rect(x: Double, y: Double, w: Double, h: Double): Unit = js.native
+      }
+      
+      @js.native
       trait Pbkdf2Params
         extends StObject
            with HashAlgorithm {
@@ -6172,7 +6763,7 @@ object org {
       }
       
       @js.native
-      class Performance () extends StObject {
+      class Performance private () extends StObject {
         
         def clearMarks(markName: String): Unit = js.native
         
@@ -6180,19 +6771,19 @@ object org {
         
         def clearResourceTimings(): Unit = js.native
         
-        def getEntries(): js.Dynamic = js.native
+        def getEntries(): js.Array[PerformanceEntry] = js.native
         
-        def getEntriesByName(name: String, entryType: String): js.Dynamic = js.native
+        def getEntriesByName(name: String, `type`: String): js.Array[PerformanceEntry] = js.native
         
-        def getEntriesByType(entryType: String): js.Dynamic = js.native
+        def getEntriesByType(entryType: String): js.Array[PerformanceEntry] = js.native
         
         def getMarks(markName: String): js.Dynamic = js.native
         
         def getMeasures(measureName: String): js.Dynamic = js.native
         
-        def mark(markName: String): Unit = js.native
+        def mark(markName: String): PerformanceMark = js.native
         
-        def measure(measureName: String, startMarkName: String, endMarkName: String): Unit = js.native
+        def measure(measureName: String, startMarkName: String, endMarkName: String): PerformanceMeasure = js.native
         
         def navigation(): PerformanceNavigation = js.native
         
@@ -6202,7 +6793,7 @@ object org {
         
         def timing(): PerformanceTiming = js.native
         
-        def toJSON(): js.Dynamic = js.native
+        def toJSON(): js.Object = js.native
       }
       
       @js.native
@@ -6215,6 +6806,8 @@ object org {
         def name(): String = js.native
         
         def startTime(): Double = js.native
+        
+        def toJSON(): js.Object = js.native
       }
       
       @js.native
@@ -6459,7 +7052,17 @@ object org {
       }
       
       @js.native
-      abstract class ProcessingInstruction ()
+      sealed trait PredefinedColorSpace
+        extends StObject
+           with js.Any
+      
+      @js.native
+      sealed trait PresentationStyle
+        extends StObject
+           with js.Any
+      
+      @js.native
+      class ProcessingInstruction ()
         extends StObject
            with Node {
         
@@ -7317,7 +7920,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGAElement ()
+      class SVGAElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -7470,7 +8073,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGCircleElement ()
+      class SVGCircleElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -7487,7 +8090,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGClipPathElement ()
+      class SVGClipPathElement ()
         extends StObject
            with SVGElement
            with SVGUnitTypes
@@ -7501,7 +8104,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGComponentTransferFunctionElement ()
+      class SVGComponentTransferFunctionElement ()
         extends StObject
            with SVGElement {
         
@@ -7536,7 +8139,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGDefsElement ()
+      class SVGDefsElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -7546,14 +8149,14 @@ object org {
            with SVGExternalResourcesRequired
       
       @js.native
-      abstract class SVGDescElement ()
+      class SVGDescElement ()
         extends StObject
            with SVGElement
            with SVGStylable
            with SVGLangSpace
       
       @js.native
-      abstract class SVGElement ()
+      class SVGElement ()
         extends StObject
            with Element {
         
@@ -7615,7 +8218,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGEllipseElement ()
+      class SVGEllipseElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -7659,7 +8262,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFEBlendElement ()
+      class SVGFEBlendElement ()
         extends StObject
            with SVGElement
            with SVGFilterPrimitiveStandardAttributes {
@@ -7687,7 +8290,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFEColorMatrixElement ()
+      class SVGFEColorMatrixElement ()
         extends StObject
            with SVGElement
            with SVGFilterPrimitiveStandardAttributes {
@@ -7713,7 +8316,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFEComponentTransferElement ()
+      class SVGFEComponentTransferElement ()
         extends StObject
            with SVGElement
            with SVGFilterPrimitiveStandardAttributes {
@@ -7722,7 +8325,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFECompositeElement ()
+      class SVGFECompositeElement ()
         extends StObject
            with SVGElement
            with SVGFilterPrimitiveStandardAttributes {
@@ -7760,7 +8363,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFEConvolveMatrixElement ()
+      class SVGFEConvolveMatrixElement ()
         extends StObject
            with SVGElement
            with SVGFilterPrimitiveStandardAttributes {
@@ -7802,7 +8405,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFEDiffuseLightingElement ()
+      class SVGFEDiffuseLightingElement ()
         extends StObject
            with SVGElement
            with SVGFilterPrimitiveStandardAttributes {
@@ -7819,7 +8422,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFEDisplacementMapElement ()
+      class SVGFEDisplacementMapElement ()
         extends StObject
            with SVGElement
            with SVGFilterPrimitiveStandardAttributes {
@@ -7849,7 +8452,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFEDistantLightElement ()
+      class SVGFEDistantLightElement ()
         extends StObject
            with SVGElement {
         
@@ -7859,33 +8462,33 @@ object org {
       }
       
       @js.native
-      abstract class SVGFEFloodElement ()
+      class SVGFEFloodElement ()
         extends StObject
            with SVGElement
            with SVGFilterPrimitiveStandardAttributes
       
       @js.native
-      abstract class SVGFEFuncAElement ()
+      class SVGFEFuncAElement ()
         extends StObject
            with SVGComponentTransferFunctionElement
       
       @js.native
-      abstract class SVGFEFuncBElement ()
+      class SVGFEFuncBElement ()
         extends StObject
            with SVGComponentTransferFunctionElement
       
       @js.native
-      abstract class SVGFEFuncGElement ()
+      class SVGFEFuncGElement ()
         extends StObject
            with SVGComponentTransferFunctionElement
       
       @js.native
-      abstract class SVGFEFuncRElement ()
+      class SVGFEFuncRElement ()
         extends StObject
            with SVGComponentTransferFunctionElement
       
       @js.native
-      abstract class SVGFEGaussianBlurElement ()
+      class SVGFEGaussianBlurElement ()
         extends StObject
            with SVGElement
            with SVGFilterPrimitiveStandardAttributes {
@@ -7900,7 +8503,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFEImageElement ()
+      class SVGFEImageElement ()
         extends StObject
            with SVGElement
            with SVGLangSpace
@@ -7912,13 +8515,13 @@ object org {
       }
       
       @js.native
-      abstract class SVGFEMergeElement ()
+      class SVGFEMergeElement ()
         extends StObject
            with SVGElement
            with SVGFilterPrimitiveStandardAttributes
       
       @js.native
-      abstract class SVGFEMergeNodeElement ()
+      class SVGFEMergeNodeElement ()
         extends StObject
            with SVGElement {
         
@@ -7926,7 +8529,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFEMorphologyElement ()
+      class SVGFEMorphologyElement ()
         extends StObject
            with SVGElement
            with SVGFilterPrimitiveStandardAttributes {
@@ -7950,7 +8553,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFEOffsetElement ()
+      class SVGFEOffsetElement ()
         extends StObject
            with SVGElement
            with SVGFilterPrimitiveStandardAttributes {
@@ -7963,7 +8566,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFEPointLightElement ()
+      class SVGFEPointLightElement ()
         extends StObject
            with SVGElement {
         
@@ -7975,7 +8578,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFESpecularLightingElement ()
+      class SVGFESpecularLightingElement ()
         extends StObject
            with SVGElement
            with SVGFilterPrimitiveStandardAttributes {
@@ -7994,7 +8597,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFESpotLightElement ()
+      class SVGFESpotLightElement ()
         extends StObject
            with SVGElement {
         
@@ -8016,7 +8619,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFETileElement ()
+      class SVGFETileElement ()
         extends StObject
            with SVGElement
            with SVGFilterPrimitiveStandardAttributes {
@@ -8025,7 +8628,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFETurbulenceElement ()
+      class SVGFETurbulenceElement ()
         extends StObject
            with SVGElement
            with SVGFilterPrimitiveStandardAttributes {
@@ -8059,7 +8662,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGFilterElement ()
+      class SVGFilterElement ()
         extends StObject
            with SVGElement
            with SVGUnitTypes
@@ -8112,7 +8715,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGGElement ()
+      class SVGGElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -8122,7 +8725,7 @@ object org {
            with SVGExternalResourcesRequired
       
       @js.native
-      abstract class SVGGradientElement ()
+      class SVGGradientElement ()
         extends StObject
            with SVGElement
            with SVGUnitTypes
@@ -8149,7 +8752,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGImageElement ()
+      class SVGImageElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -8240,7 +8843,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGLineElement ()
+      class SVGLineElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -8289,7 +8892,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGMarkerElement ()
+      class SVGMarkerElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -8332,7 +8935,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGMaskElement ()
+      class SVGMaskElement ()
         extends StObject
            with SVGElement
            with SVGUnitTypes
@@ -8393,7 +8996,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGMetadataElement ()
+      class SVGMetadataElement ()
         extends StObject
            with SVGElement
       
@@ -8424,7 +9027,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGPathElement ()
+      class SVGPathElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -8796,7 +9399,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGPatternElement ()
+      class SVGPatternElement ()
         extends StObject
            with SVGElement
            with SVGUnitTypes
@@ -8853,7 +9456,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGPolygonElement ()
+      class SVGPolygonElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -8864,7 +9467,7 @@ object org {
            with SVGExternalResourcesRequired
       
       @js.native
-      abstract class SVGPolylineElement ()
+      class SVGPolylineElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -8942,7 +9545,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGRectElement ()
+      class SVGRectElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -8965,7 +9568,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGSVGElement ()
+      class SVGSVGElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -9063,7 +9666,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGScriptElement ()
+      class SVGScriptElement ()
         extends StObject
            with SVGElement
            with SVGExternalResourcesRequired
@@ -9073,7 +9676,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGStopElement ()
+      class SVGStopElement ()
         extends StObject
            with SVGElement
            with SVGStylable {
@@ -9110,7 +9713,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGStyleElement ()
+      class SVGStyleElement ()
         extends StObject
            with SVGElement
            with SVGLangSpace {
@@ -9123,7 +9726,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGSwitchElement ()
+      class SVGSwitchElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -9133,7 +9736,7 @@ object org {
            with SVGExternalResourcesRequired
       
       @js.native
-      abstract class SVGSymbolElement ()
+      class SVGSymbolElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -9142,7 +9745,7 @@ object org {
            with SVGExternalResourcesRequired
       
       @js.native
-      abstract class SVGTSpanElement ()
+      class SVGTSpanElement ()
         extends StObject
            with SVGTextPositioningElement
       
@@ -9159,7 +9762,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGTextContentElement ()
+      class SVGTextContentElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -9200,13 +9803,13 @@ object org {
       }
       
       @js.native
-      abstract class SVGTextElement ()
+      class SVGTextElement ()
         extends StObject
            with SVGTextPositioningElement
            with SVGTransformable
       
       @js.native
-      abstract class SVGTextPathElement ()
+      class SVGTextPathElement ()
         extends StObject
            with SVGTextContentElement
            with SVGURIReference {
@@ -9234,7 +9837,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGTextPositioningElement ()
+      class SVGTextPositioningElement ()
         extends StObject
            with SVGTextContentElement {
         
@@ -9250,7 +9853,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGTitleElement ()
+      class SVGTitleElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -9353,7 +9956,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGUseElement ()
+      class SVGUseElement ()
         extends StObject
            with SVGElement
            with SVGStylable
@@ -9377,7 +9980,7 @@ object org {
       }
       
       @js.native
-      abstract class SVGViewElement ()
+      class SVGViewElement ()
         extends StObject
            with SVGElement
            with SVGZoomAndPan
@@ -9606,7 +10209,7 @@ object org {
            with js.Any
       
       @js.native
-      abstract class ShadowRoot ()
+      class ShadowRoot ()
         extends StObject
            with DocumentFragment {
         
@@ -9751,7 +10354,7 @@ object org {
         
         def key(index: Int): String = js.native
         
-        var length: Int = js.native
+        def length(): Int = js.native
         
         def removeItem(key: String): Unit = js.native
         
@@ -9856,7 +10459,7 @@ object org {
         
         def decrypt(algorithm: AlgorithmIdentifier, key: CryptoKey, data: BufferSource): js.Promise[js.Any] = js.native
         
-        def deriveBits(algorithm: AlgorithmIdentifier, baseKey: CryptoKey, length: Double): js.Promise[js.Any] = js.native
+        def deriveBits(algorithm: AlgorithmIdentifier, baseKey: CryptoKey, length: Double): js.Promise[js.typedarray.ArrayBuffer] = js.native
         
         def deriveKey(
           algorithm: AlgorithmIdentifier,
@@ -9980,6 +10583,28 @@ object org {
       
       @js.native
       class TextMetrics () extends StObject {
+        
+        val actualBoundingBoxAscent: Double = js.native
+        
+        val actualBoundingBoxDescent: Double = js.native
+        
+        val actualBoundingBoxLeft: Double = js.native
+        
+        val actualBoundingBoxRight: Double = js.native
+        
+        val alphabeticBaseline: Double = js.native
+        
+        val emHeightAscent: Double = js.native
+        
+        val emHeightDescent: Double = js.native
+        
+        val fontBoundingBoxAscent: Double = js.native
+        
+        val fontBoundingBoxDescent: Double = js.native
+        
+        val hangingBaseline: Double = js.native
+        
+        val ideographicBaseline: Double = js.native
         
         var width: Double = js.native
       }
@@ -10286,7 +10911,7 @@ object org {
         
         var search: String = js.native
         
-        var searchParams: URLSearchParams = js.native
+        val searchParams: URLSearchParams = js.native
         
         val url: String = js.native
         
@@ -10296,6 +10921,7 @@ object org {
       object URL extends StObject {
         
         def createObjectURL(blob: Blob): String = js.native
+        def createObjectURL(src: MediaSource): String = js.native
         
         def revokeObjectURL(url: String): Unit = js.native
       }
@@ -10306,7 +10932,7 @@ object org {
            with js.Iterable[js.Tuple2[String, String]] {
         def this(init: String) = this()
         def this(init: js.Dictionary[String]) = this()
-        def this(init: Sequence[String]) = this()
+        def this(init: Sequence[js.Tuple2[String, String]]) = this()
         
         def append(name: String, value: String): Unit = js.native
         
@@ -10856,7 +11482,7 @@ object org {
         
         var onclose: js.Function1[CloseEvent, _] = js.native
         
-        var onerror: js.Function1[ErrorEvent, _] = js.native
+        var onerror: js.Function1[Event, _] = js.native
         
         var onmessage: js.Function1[MessageEvent, _] = js.native
         
@@ -11282,20 +11908,18 @@ object org {
       }
       
       @js.native
-      class Worker protected ()
+      class Worker ()
         extends StObject
            with EventTarget
            with AbstractWorker {
         def this(scriptURL: String) = this()
+        def this(scriptURL: URL) = this()
         def this(scriptURL: String, options: WorkerOptions) = this()
+        def this(scriptURL: URL, options: WorkerOptions) = this()
         
         var onmessage: js.Function1[MessageEvent, _] = js.native
         
-        val options: WorkerOptions = js.native
-        
         def postMessage(message: js.Any, transfer: js.UndefOr[js.Array[Transferable]]): Unit = js.native
-        
-        val scriptURL: String = js.native
         
         def terminate(): Unit = js.native
       }
@@ -11392,6 +12016,11 @@ object org {
         
         def write(chunk: Chunk[T]): js.Promise[Any] = js.native
       }
+      
+      @js.native
+      class XMLDocument ()
+        extends StObject
+           with Document
       
       @js.native
       class XMLHttpRequest ()
@@ -12112,6 +12741,8 @@ object org {
         
         type DataList = HTMLDataListElement
         
+        type Dialog = HTMLDialogElement
+        
         type Div = HTMLDivElement
         
         type Document = HTMLDocument
@@ -12306,6 +12937,8 @@ object org {
           var era: js.UndefOr[String] = js.native
           
           var formatMatcher: js.UndefOr[String] = js.native
+          
+          var fractionalSecondDigits: js.UndefOr[Int] = js.native
           
           var hour: js.UndefOr[String] = js.native
           

--- a/import-scalajs-definitions/src/test/resources/imported/scala.scala
+++ b/import-scalajs-definitions/src/test/resources/imported/scala.scala
@@ -12,6 +12,23 @@ object scala {
     object js {
       
       @js.native
+      class AggregateError protected ()
+        extends StObject
+           with js.Error {
+        def this(errors: js.Iterable[Any], message: String) = this()
+        
+        val errors: js.Iterable[Any] = js.native
+        def errors(): js.Array[Any] = js.native
+        
+        val message: String = js.native
+      }
+      @js.native
+      object AggregateError extends StObject {
+        
+        def apply(errors: js.Iterable[Any], message: String): js.AggregateError = js.native
+      }
+      
+      @js.native
       class Array[A] ()
         extends StObject
            with js.Iterable[A] {
@@ -67,6 +84,8 @@ object scala {
         def `&`(other: js.BigInt): js.BigInt = js.native
         
         def `*`(other: js.BigInt): js.BigInt = js.native
+        
+        def `**`(other: js.BigInt): js.BigInt = js.native
         
         def `+`(other: js.BigInt): js.BigInt = js.native
         
@@ -254,6 +273,8 @@ object scala {
         def `&&`(that: js.Dynamic): js.Dynamic = js.native
         
         def `*`(that: js.Dynamic): js.Dynamic = js.native
+        
+        def `**`(that: js.Dynamic): js.Dynamic = js.native
         
         def `+`(that: js.Dynamic): js.Dynamic = js.native
         
@@ -958,6 +979,8 @@ object scala {
         
         def ceil(x: Double): Double = js.native
         
+        def clz32(x: Int): Int = js.native
+        
         def cos(x: Double): Double = js.native
         
         def cosh(x: Double): Double = js.native
@@ -1163,6 +1186,8 @@ object scala {
         
         def apply(): js.Symbol = js.native
         def apply(description: String): js.Symbol = js.native
+        
+        val asyncIterator: js.Symbol = js.native
         
         def forKey(key: String): js.Symbol = js.native
         
@@ -2547,16 +2572,32 @@ object scala {
       }
     }
     
+    object reflect {
+      
+      object Reflect {
+        
+        @js.native
+        trait JSFunctionVarArgs
+          extends StObject
+             with js.Function {
+          
+          def apply(args: Any): Any = js.native
+        }
+      }
+    }
+    
     object runtime {
       
       @js.native
-      sealed trait LinkingInfo extends StObject {
+      trait LinkingInfo extends StObject {
         
         val assumingES6: Boolean = js.native
         
         val esVersion: Int = js.native
         
         val fileLevelThis: Any = js.native
+        
+        val isWebAssembly: Boolean = js.native
         
         val linkerVersion: String = js.native
         

--- a/import-scalajs-definitions/src/test/resources/imported/slinky.scala
+++ b/import-scalajs-definitions/src/test/resources/imported/slinky.scala
@@ -7,6 +7,57 @@ import org.scalajs.dom.DataTransfer
 import org.scalajs.dom.Element
 import org.scalajs.dom.EventTarget
 import org.scalajs.dom.FocusEvent
+import org.scalajs.dom.HTMLAnchorElement
+import org.scalajs.dom.HTMLAreaElement
+import org.scalajs.dom.HTMLAudioElement
+import org.scalajs.dom.HTMLBRElement
+import org.scalajs.dom.HTMLBaseElement
+import org.scalajs.dom.HTMLBodyElement
+import org.scalajs.dom.HTMLButtonElement
+import org.scalajs.dom.HTMLCanvasElement
+import org.scalajs.dom.HTMLDListElement
+import org.scalajs.dom.HTMLDataListElement
+import org.scalajs.dom.HTMLDivElement
+import org.scalajs.dom.HTMLElement
+import org.scalajs.dom.HTMLEmbedElement
+import org.scalajs.dom.HTMLFieldSetElement
+import org.scalajs.dom.HTMLFormElement
+import org.scalajs.dom.HTMLHRElement
+import org.scalajs.dom.HTMLHeadElement
+import org.scalajs.dom.HTMLHeadingElement
+import org.scalajs.dom.HTMLHtmlElement
+import org.scalajs.dom.HTMLIFrameElement
+import org.scalajs.dom.HTMLImageElement
+import org.scalajs.dom.HTMLInputElement
+import org.scalajs.dom.HTMLLIElement
+import org.scalajs.dom.HTMLLabelElement
+import org.scalajs.dom.HTMLLegendElement
+import org.scalajs.dom.HTMLLinkElement
+import org.scalajs.dom.HTMLMapElement
+import org.scalajs.dom.HTMLMenuElement
+import org.scalajs.dom.HTMLMetaElement
+import org.scalajs.dom.HTMLOListElement
+import org.scalajs.dom.HTMLObjectElement
+import org.scalajs.dom.HTMLOptGroupElement
+import org.scalajs.dom.HTMLOptionElement
+import org.scalajs.dom.HTMLParagraphElement
+import org.scalajs.dom.HTMLParamElement
+import org.scalajs.dom.HTMLPreElement
+import org.scalajs.dom.HTMLProgressElement
+import org.scalajs.dom.HTMLQuoteElement
+import org.scalajs.dom.HTMLScriptElement
+import org.scalajs.dom.HTMLSelectElement
+import org.scalajs.dom.HTMLSourceElement
+import org.scalajs.dom.HTMLSpanElement
+import org.scalajs.dom.HTMLStyleElement
+import org.scalajs.dom.HTMLTableCellElement
+import org.scalajs.dom.HTMLTableElement
+import org.scalajs.dom.HTMLTableRowElement
+import org.scalajs.dom.HTMLTextAreaElement
+import org.scalajs.dom.HTMLTitleElement
+import org.scalajs.dom.HTMLTrackElement
+import org.scalajs.dom.HTMLVideoElement
+import org.scalajs.dom.InputEvent
 import org.scalajs.dom.KeyboardEvent
 import org.scalajs.dom.MouseEvent
 import org.scalajs.dom.PointerEvent
@@ -16,54 +67,6 @@ import org.scalajs.dom.TransitionEvent
 import org.scalajs.dom.UIEvent
 import org.scalajs.dom.WheelEvent
 import org.scalajs.dom.Window
-import org.scalajs.dom.html.Anchor
-import org.scalajs.dom.html.Area
-import org.scalajs.dom.html.Audio
-import org.scalajs.dom.html.BR
-import org.scalajs.dom.html.Base
-import org.scalajs.dom.html.Body
-import org.scalajs.dom.html.Button
-import org.scalajs.dom.html.Canvas
-import org.scalajs.dom.html.DList
-import org.scalajs.dom.html.DataList
-import org.scalajs.dom.html.Div
-import org.scalajs.dom.html.Embed
-import org.scalajs.dom.html.FieldSet
-import org.scalajs.dom.html.Form
-import org.scalajs.dom.html.HR
-import org.scalajs.dom.html.Head
-import org.scalajs.dom.html.Heading
-import org.scalajs.dom.html.Html
-import org.scalajs.dom.html.IFrame
-import org.scalajs.dom.html.Image
-import org.scalajs.dom.html.Input
-import org.scalajs.dom.html.LI
-import org.scalajs.dom.html.Label
-import org.scalajs.dom.html.Legend
-import org.scalajs.dom.html.Link
-import org.scalajs.dom.html.Map
-import org.scalajs.dom.html.Menu
-import org.scalajs.dom.html.Meta
-import org.scalajs.dom.html.OList
-import org.scalajs.dom.html.Object
-import org.scalajs.dom.html.OptGroup
-import org.scalajs.dom.html.Paragraph
-import org.scalajs.dom.html.Param
-import org.scalajs.dom.html.Pre
-import org.scalajs.dom.html.Progress
-import org.scalajs.dom.html.Quote
-import org.scalajs.dom.html.Script
-import org.scalajs.dom.html.Select
-import org.scalajs.dom.html.Source
-import org.scalajs.dom.html.Span
-import org.scalajs.dom.html.Style
-import org.scalajs.dom.html.Table
-import org.scalajs.dom.html.TableCell
-import org.scalajs.dom.html.TableRow
-import org.scalajs.dom.html.TextArea
-import org.scalajs.dom.html.Title
-import org.scalajs.dom.html.Track
-import org.scalajs.dom.html.Video
 import slinky.core.ReactComponentClass
 import slinky.core.StatelessComponent.State
 import slinky.core.SyntheticEvent
@@ -103,7 +106,7 @@ object slinky {
     }
     
     @js.native
-    abstract class Component ()
+    class Component ()
       extends StObject
          with slinky.core.facade.React.Component {
       
@@ -143,7 +146,7 @@ object slinky {
     }
     
     @js.native
-    abstract class DefinitionBase[Props, State, Snapshot] protected ()
+    class DefinitionBase[Props, State, Snapshot] protected ()
       extends StObject
          with slinky.core.facade.React.Component {
       def this(jsProps: js.Object) = this()
@@ -227,7 +230,7 @@ object slinky {
     trait StateWriterProvider extends StObject
     
     @js.native
-    abstract class StatelessComponent ()
+    class StatelessComponent ()
       extends StObject
          with Component {
       
@@ -237,7 +240,7 @@ object slinky {
     }
     
     @js.native
-    abstract class StatelessDefinition[Props, Snapshot] protected ()
+    class StatelessDefinition[Props, Snapshot] protected ()
       extends StObject
          with DefinitionBase[Props, Unit, Snapshot] {
       def this(jsProps: js.Object) = this()
@@ -596,15 +599,25 @@ object slinky {
     @js.native
     object ReactDOM extends StObject {
       
-      def createPortal(child: ReactElement, container: Element): ReactElement = js.native
+      def createPortal(child: ReactElement, container: Element, key: js.UndefOr[String]): ReactElement = js.native
       
       def findDOMNode(instance: Component): Element = js.native
+      
+      def flushSync[T](callback: js.Function0[T]): T = js.native
       
       def hydrate(component: ReactElement, target: Element): ReactInstance = js.native
       
       def render(component: ReactElement, target: Element): ReactInstance = js.native
       
       def unmountComponentAtNode(container: Element): Unit = js.native
+    }
+    
+    @js.native
+    object ReactDOMClient extends StObject {
+      
+      def createRoot(target: Element): ReactRoot = js.native
+      
+      def hydrate(component: ReactElement, target: Element): ReactRoot = js.native
     }
     
     @js.native
@@ -617,6 +630,14 @@ object slinky {
       def renderToStaticNodeStream(element: ReactElement): js.Object = js.native
       
       def renderToString(element: ReactElement): String = js.native
+    }
+    
+    @js.native
+    trait ReactRoot extends StObject {
+      
+      def render(component: ReactElement): ReactInstance = js.native
+      
+      def unmount(): Unit = js.native
     }
     
     @js.native
@@ -653,6 +674,14 @@ object slinky {
          with SyntheticEvent[TargetType, FocusEvent] {
       
       val relatedTarget: EventTarget = js.native
+    }
+    
+    @js.native
+    trait SyntheticInputEvent[TargetType]
+      extends StObject
+         with SyntheticEvent[TargetType, InputEvent] {
+      
+      val data: String = js.native
     }
     
     @js.native
@@ -817,7 +846,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Anchor
+          type RefType = HTMLAnchorElement
         }
       }
       
@@ -825,7 +854,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -849,7 +878,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -865,7 +894,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Area
+          type RefType = HTMLAreaElement
         }
       }
       
@@ -881,7 +910,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -889,7 +918,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -905,7 +934,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Audio
+          type RefType = HTMLAudioElement
         }
       }
       
@@ -929,7 +958,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -937,7 +966,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Base
+          type RefType = HTMLBaseElement
         }
       }
       
@@ -945,7 +974,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -953,7 +982,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -961,7 +990,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -969,7 +998,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -977,7 +1006,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Body
+          type RefType = HTMLBodyElement
         }
       }
       
@@ -985,7 +1014,7 @@ object slinky {
         
         object tag {
           
-          type RefType = BR
+          type RefType = HTMLBRElement
         }
       }
       
@@ -993,7 +1022,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Button
+          type RefType = HTMLButtonElement
         }
       }
       
@@ -1001,7 +1030,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Canvas
+          type RefType = HTMLCanvasElement
         }
       }
       
@@ -1009,7 +1038,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1041,7 +1070,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1057,7 +1086,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1065,7 +1094,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1081,7 +1110,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1137,7 +1166,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1145,7 +1174,7 @@ object slinky {
         
         object tag {
           
-          type RefType = DataList
+          type RefType = HTMLDataListElement
         }
       }
       
@@ -1153,7 +1182,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1185,7 +1214,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1193,7 +1222,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1201,7 +1230,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1209,7 +1238,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1233,7 +1262,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Div
+          type RefType = HTMLDivElement
         }
       }
       
@@ -1241,7 +1270,7 @@ object slinky {
         
         object tag {
           
-          type RefType = DList
+          type RefType = HTMLDListElement
         }
       }
       
@@ -1265,7 +1294,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1273,7 +1302,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1281,7 +1310,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Embed
+          type RefType = HTMLEmbedElement
         }
       }
       
@@ -1289,7 +1318,7 @@ object slinky {
         
         object tag {
           
-          type RefType = FieldSet
+          type RefType = HTMLFieldSetElement
         }
       }
       
@@ -1297,7 +1326,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1305,7 +1334,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1313,7 +1342,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1321,7 +1350,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Form
+          type RefType = HTMLFormElement
         }
       }
       
@@ -1329,7 +1358,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Heading
+          type RefType = HTMLHeadingElement
         }
       }
       
@@ -1337,7 +1366,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Heading
+          type RefType = HTMLHeadingElement
         }
       }
       
@@ -1345,7 +1374,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Heading
+          type RefType = HTMLHeadingElement
         }
       }
       
@@ -1353,7 +1382,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Heading
+          type RefType = HTMLHeadingElement
         }
       }
       
@@ -1361,7 +1390,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Heading
+          type RefType = HTMLHeadingElement
         }
       }
       
@@ -1369,7 +1398,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Heading
+          type RefType = HTMLHeadingElement
         }
       }
       
@@ -1377,7 +1406,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Head
+          type RefType = HTMLHeadElement
         }
       }
       
@@ -1385,7 +1414,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1425,7 +1454,7 @@ object slinky {
         
         object tag {
           
-          type RefType = HR
+          type RefType = HTMLHRElement
         }
       }
       
@@ -1441,7 +1470,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Html
+          type RefType = HTMLHtmlElement
         }
       }
       
@@ -1457,7 +1486,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1481,7 +1510,7 @@ object slinky {
         
         object tag {
           
-          type RefType = IFrame
+          type RefType = HTMLIFrameElement
         }
       }
       
@@ -1489,7 +1518,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Image
+          type RefType = HTMLImageElement
         }
       }
       
@@ -1497,7 +1526,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Input
+          type RefType = HTMLInputElement
         }
       }
       
@@ -1505,7 +1534,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1521,7 +1550,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1537,7 +1566,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1553,7 +1582,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Label
+          type RefType = HTMLLabelElement
         }
       }
       
@@ -1569,7 +1598,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Legend
+          type RefType = HTMLLegendElement
         }
       }
       
@@ -1577,7 +1606,7 @@ object slinky {
         
         object tag {
           
-          type RefType = LI
+          type RefType = HTMLLIElement
         }
       }
       
@@ -1585,7 +1614,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Link
+          type RefType = HTMLLinkElement
         }
       }
       
@@ -1617,7 +1646,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1633,7 +1662,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Map
+          type RefType = HTMLMapElement
         }
       }
       
@@ -1641,7 +1670,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1665,7 +1694,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Menu
+          type RefType = HTMLMenuElement
         }
       }
       
@@ -1673,7 +1702,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1681,7 +1710,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Meta
+          type RefType = HTMLMetaElement
         }
       }
       
@@ -1689,7 +1718,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1737,7 +1766,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1761,7 +1790,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -1769,7 +1798,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Object
+          type RefType = HTMLObjectElement
         }
       }
       
@@ -1777,7 +1806,7 @@ object slinky {
         
         object tag {
           
-          type RefType = OList
+          type RefType = HTMLOListElement
         }
       }
       
@@ -1797,7 +1826,23 @@ object slinky {
         }
       }
       
+      object onAbortCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onAnimationEnd {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onAnimationEndCapture {
         
         object tag {
           
@@ -1813,7 +1858,39 @@ object slinky {
         }
       }
       
+      object onAnimationIterationCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onAnimationStart {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onAnimationStartCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onBeforeInput {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onBeforeInputCapture {
         
         object tag {
           
@@ -1829,6 +1906,14 @@ object slinky {
         }
       }
       
+      object onBlurCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onCanPlay {
         
         object tag {
@@ -1837,7 +1922,23 @@ object slinky {
         }
       }
       
+      object onCanPlayCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onCanPlayThrough {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onCanPlayThroughCapture {
         
         object tag {
           
@@ -1869,7 +1970,23 @@ object slinky {
         }
       }
       
+      object onClickCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onClose {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onCloseCapture {
         
         object tag {
           
@@ -1885,7 +2002,23 @@ object slinky {
         }
       }
       
+      object onCompositionEndCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onCompositionStart {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onCompositionStartCapture {
         
         object tag {
           
@@ -1901,7 +2034,23 @@ object slinky {
         }
       }
       
+      object onCompositionUpdateCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onContextMenu {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onContextMenuCapture {
         
         object tag {
           
@@ -1917,7 +2066,23 @@ object slinky {
         }
       }
       
+      object onCopyCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onCut {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onCutCapture {
         
         object tag {
           
@@ -1933,7 +2098,23 @@ object slinky {
         }
       }
       
+      object onDoubleClickCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onDrag {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onDragCapture {
         
         object tag {
           
@@ -1949,7 +2130,23 @@ object slinky {
         }
       }
       
+      object onDragEndCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onDragEnter {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onDragEnterCapture {
         
         object tag {
           
@@ -1981,7 +2178,23 @@ object slinky {
         }
       }
       
+      object onDragOverCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onDragStart {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onDragStartCapture {
         
         object tag {
           
@@ -1997,7 +2210,23 @@ object slinky {
         }
       }
       
+      object onDropCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onDurationChange {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onDurationChangeCapture {
         
         object tag {
           
@@ -2013,7 +2242,23 @@ object slinky {
         }
       }
       
+      object onEmptiedCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onEncrypted {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onEncryptedCapture {
         
         object tag {
           
@@ -2029,6 +2274,14 @@ object slinky {
         }
       }
       
+      object onEndedCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onError {
         
         object tag {
@@ -2037,7 +2290,23 @@ object slinky {
         }
       }
       
+      object onErrorCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onFocus {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onFocusCapture {
         
         object tag {
           
@@ -2077,7 +2346,23 @@ object slinky {
         }
       }
       
+      object onKeyDownCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onKeyPress {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onKeyPressCapture {
         
         object tag {
           
@@ -2093,7 +2378,23 @@ object slinky {
         }
       }
       
+      object onKeyUpCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onLoad {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onLoadCapture {
         
         object tag {
           
@@ -2109,6 +2410,14 @@ object slinky {
         }
       }
       
+      object onLoadStartCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onLoadedData {
         
         object tag {
@@ -2117,7 +2426,23 @@ object slinky {
         }
       }
       
+      object onLoadedDataCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onLoadedMetadata {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onLoadedMetadataCapture {
         
         object tag {
           
@@ -2134,6 +2459,14 @@ object slinky {
       }
       
       object onMouseDown {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onMouseDownCapture {
         
         object tag {
           
@@ -2173,6 +2506,14 @@ object slinky {
         }
       }
       
+      object onMouseOutCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onMouseOver {
         
         object tag {
@@ -2189,7 +2530,23 @@ object slinky {
         }
       }
       
+      object onMouseUpCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onPaste {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onPasteCapture {
         
         object tag {
           
@@ -2205,7 +2562,23 @@ object slinky {
         }
       }
       
+      object onPauseCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onPlay {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onPlayCapture {
         
         object tag {
           
@@ -2221,6 +2594,14 @@ object slinky {
         }
       }
       
+      object onPlayingCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onPointerCancel {
         
         object tag {
@@ -2229,7 +2610,23 @@ object slinky {
         }
       }
       
+      object onPointerCancelCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onPointerDown {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onPointerDownCapture {
         
         object tag {
           
@@ -2269,6 +2666,14 @@ object slinky {
         }
       }
       
+      object onPointerOutCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onPointerOver {
         
         object tag {
@@ -2285,7 +2690,23 @@ object slinky {
         }
       }
       
+      object onPointerUpCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onProgress {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onProgressCapture {
         
         object tag {
           
@@ -2301,7 +2722,23 @@ object slinky {
         }
       }
       
+      object onRateChangeCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onScroll {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onScrollCapture {
         
         object tag {
           
@@ -2317,7 +2754,23 @@ object slinky {
         }
       }
       
+      object onSeekedCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onSeeking {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onSeekingCapture {
         
         object tag {
           
@@ -2333,7 +2786,23 @@ object slinky {
         }
       }
       
+      object onSelectCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onStalled {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onStalledCapture {
         
         object tag {
           
@@ -2349,7 +2818,23 @@ object slinky {
         }
       }
       
+      object onSubmitCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onSuspend {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onSuspendCapture {
         
         object tag {
           
@@ -2365,7 +2850,23 @@ object slinky {
         }
       }
       
+      object onTimeUpdateCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onToggle {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onToggleCapture {
         
         object tag {
           
@@ -2381,7 +2882,23 @@ object slinky {
         }
       }
       
+      object onTouchCancelCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onTouchEnd {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onTouchEndCapture {
         
         object tag {
           
@@ -2397,7 +2914,23 @@ object slinky {
         }
       }
       
+      object onTouchMoveCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onTouchStart {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onTouchStartCapture {
         
         object tag {
           
@@ -2421,6 +2954,14 @@ object slinky {
         }
       }
       
+      object onVolumeChangeCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onWaiting {
         
         object tag {
@@ -2429,7 +2970,23 @@ object slinky {
         }
       }
       
+      object onWaitingCapture {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
       object onWheel {
+        
+        object tag {
+          
+          type RefType = scala.Nothing
+        }
+      }
+      
+      object onWheelCapture {
         
         object tag {
           
@@ -2449,7 +3006,7 @@ object slinky {
         
         object tag {
           
-          type RefType = OptGroup
+          type RefType = HTMLOptGroupElement
         }
       }
       
@@ -2465,7 +3022,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Option
+          type RefType = HTMLOptionElement
         }
       }
       
@@ -2473,7 +3030,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2481,7 +3038,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Paragraph
+          type RefType = HTMLParagraphElement
         }
       }
       
@@ -2489,7 +3046,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Param
+          type RefType = HTMLParamElement
         }
       }
       
@@ -2505,7 +3062,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2529,7 +3086,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Pre
+          type RefType = HTMLPreElement
         }
       }
       
@@ -2553,7 +3110,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Progress
+          type RefType = HTMLProgressElement
         }
       }
       
@@ -2561,7 +3118,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Quote
+          type RefType = HTMLQuoteElement
         }
       }
       
@@ -2633,7 +3190,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2641,7 +3198,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2649,7 +3206,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2657,7 +3214,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2665,7 +3222,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2697,7 +3254,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Script
+          type RefType = HTMLScriptElement
         }
       }
       
@@ -2713,7 +3270,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2721,7 +3278,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Select
+          type RefType = HTMLSelectElement
         }
       }
       
@@ -2761,7 +3318,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2769,7 +3326,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Source
+          type RefType = HTMLSourceElement
         }
       }
       
@@ -2777,7 +3334,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Span
+          type RefType = HTMLSpanElement
         }
       }
       
@@ -2825,7 +3382,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Style
+          type RefType = HTMLStyleElement
         }
       }
       
@@ -2833,7 +3390,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2841,7 +3398,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2849,7 +3406,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2873,7 +3430,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Table
+          type RefType = HTMLTableElement
         }
       }
       
@@ -2889,7 +3446,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2897,7 +3454,7 @@ object slinky {
         
         object tag {
           
-          type RefType = TableCell
+          type RefType = HTMLTableCellElement
         }
       }
       
@@ -2905,7 +3462,7 @@ object slinky {
         
         object tag {
           
-          type RefType = TextArea
+          type RefType = HTMLTextAreaElement
         }
       }
       
@@ -2913,7 +3470,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2921,7 +3478,7 @@ object slinky {
         
         object tag {
           
-          type RefType = TableCell
+          type RefType = HTMLTableCellElement
         }
       }
       
@@ -2929,7 +3486,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2937,7 +3494,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2945,7 +3502,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Title
+          type RefType = HTMLTitleElement
         }
       }
       
@@ -2953,7 +3510,7 @@ object slinky {
         
         object tag {
           
-          type RefType = TableRow
+          type RefType = HTMLTableRowElement
         }
       }
       
@@ -2961,7 +3518,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Track
+          type RefType = HTMLTrackElement
         }
       }
       
@@ -2977,7 +3534,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -2985,7 +3542,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -3001,7 +3558,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       
@@ -3009,7 +3566,7 @@ object slinky {
         
         object tag {
           
-          type RefType = Video
+          type RefType = HTMLVideoElement
         }
       }
       
@@ -3017,7 +3574,7 @@ object slinky {
         
         object tag {
           
-          type RefType = org.scalajs.dom.html.Element
+          type RefType = HTMLElement
         }
       }
       

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/Versions.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/Versions.scala
@@ -4,7 +4,7 @@ package scalajs
 import io.circe013.{Decoder, Encoder}
 
 object Versions {
-  val sbtVersion = "1.9.6"
+  val sbtVersion = "1.11.6"
 
   // this accepts any nightly or milestone with the same binversion as a major release. good enough for now
   private val Version = "(\\d+).(\\d+).(\\d+).*".r
@@ -48,8 +48,8 @@ object Versions {
   }
 
   val Scala212 = Scala("2.12.20")
-  val Scala213 = Scala("2.13.12")
-  val Scala3   = Scala("3.3.1")
+  val Scala213 = Scala("2.13.16")
+  val Scala3   = Scala("3.3.6")
 
   case class ScalaJs(scalaJsVersion: String) {
     val scalaJsBinVersion: String =
@@ -71,7 +71,7 @@ object Versions {
   implicit val encodes: Encoder[Versions] = io.circe013.generic.semiauto.deriveEncoder
   implicit val decodes: Decoder[Versions] = io.circe013.generic.semiauto.deriveDecoder
 
-  val ScalaJs1 = ScalaJs("1.11.0")
+  val ScalaJs1 = ScalaJs("1.20.1")
 }
 
 case class Versions(scala: Versions.Scala, scalaJs: Versions.ScalaJs) {
@@ -112,8 +112,8 @@ case class Versions(scala: Versions.Scala, scalaJs: Versions.ScalaJs) {
     else Some(Dep.ScalaFullVersion(scalaJs.scalaJsOrganization, "scalajs-compiler", scalaJs.scalaJsVersion))
 
   val runtime      = Dep.ScalaJs("com.olvind", "scalablytyped-runtime", "2.4.2")
-  val scalaJsDom   = Dep.ScalaJs("org.scala-js", "scalajs-dom", "2.3.0")
-  val slinkyWeb    = Dep.ScalaJs("me.shadaj", "slinky-web", "0.7.2")
-  val slinkyNative = Dep.ScalaJs("me.shadaj", "slinky-native", "0.7.2").for3Use2_13(scala.is3)
-  val scalajsReact = Dep.ScalaJs("com.github.japgolly.scalajs-react", "core", "2.1.1")
+  val scalaJsDom   = Dep.ScalaJs("org.scala-js", "scalajs-dom", "2.8.1")
+  val slinkyWeb    = Dep.ScalaJs("me.shadaj", "slinky-web", "0.7.5")
+  val slinkyNative = Dep.ScalaJs("me.shadaj", "slinky-native", "0.7.5").for3Use2_13(scala.is3)
+  val scalajsReact = Dep.ScalaJs("com.github.japgolly.scalajs-react", "core", "2.1.3")
 }

--- a/tests/antd/check-3/a/antd/build.sbt
+++ b/tests/antd/check-3/a/antd/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "antd"
-version := "4.3.1-665da6"
-scalaVersion := "3.3.1"
+version := "4.3.1-8ff24e"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/antd/check-3/a/antd/project/build.properties
+++ b/tests/antd/check-3/a/antd/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/antd/check-3/a/antd/project/plugins.sbt
+++ b/tests/antd/check-3/a/antd/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/antd/check-3/r/rc-field-form/build.sbt
+++ b/tests/antd/check-3/r/rc-field-form/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "rc-field-form"
-version := "1.4.4-54ecd6"
-scalaVersion := "3.3.1"
+version := "1.4.4-340798"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/antd/check-3/r/rc-field-form/project/build.properties
+++ b/tests/antd/check-3/r/rc-field-form/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/antd/check-3/r/rc-field-form/project/plugins.sbt
+++ b/tests/antd/check-3/r/rc-field-form/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/augment-module/check-3/l/lodash/build.sbt
+++ b/tests/augment-module/check-3/l/lodash/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "lodash"
-version := "4.14-a21d3d"
-scalaVersion := "3.3.1"
+version := "4.14-8251f6"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-bbca40")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-795bdf")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/augment-module/check-3/l/lodash/project/build.properties
+++ b/tests/augment-module/check-3/l/lodash/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/augment-module/check-3/l/lodash/project/plugins.sbt
+++ b/tests/augment-module/check-3/l/lodash/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/augment-module/check-3/l/lodash_dot_add/build.sbt
+++ b/tests/augment-module/check-3/l/lodash_dot_add/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "lodash_dot_add"
-version := "3.7-fdd209"
-scalaVersion := "3.3.1"
+version := "3.7-e6be6f"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/augment-module/check-3/l/lodash_dot_add/project/build.properties
+++ b/tests/augment-module/check-3/l/lodash_dot_add/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/augment-module/check-3/l/lodash_dot_add/project/plugins.sbt
+++ b/tests/augment-module/check-3/l/lodash_dot_add/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/augment-module/check-3/s/std/build.sbt
+++ b/tests/augment-module/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-bbca40"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-795bdf"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/augment-module/check-3/s/std/project/build.properties
+++ b/tests/augment-module/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/augment-module/check-3/s/std/project/plugins.sbt
+++ b/tests/augment-module/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/aws-sdk/check-3/a/aws-sdk/build.sbt
+++ b/tests/aws-sdk/check-3/a/aws-sdk/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "aws-sdk"
-version := "2.247.1-eb7aea"
-scalaVersion := "3.3.1"
+version := "2.247.1-edda72"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/aws-sdk/check-3/a/aws-sdk/project/build.properties
+++ b/tests/aws-sdk/check-3/a/aws-sdk/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/aws-sdk/check-3/a/aws-sdk/project/plugins.sbt
+++ b/tests/aws-sdk/check-3/a/aws-sdk/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/babylon/check-3/b/babylon/build.sbt
+++ b/tests/babylon/check-3/b/babylon/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "babylon"
-version := "0.0-unknown-0640f4"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-18d9fb"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/babylon/check-3/b/babylon/project/build.properties
+++ b/tests/babylon/check-3/b/babylon/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/babylon/check-3/b/babylon/project/plugins.sbt
+++ b/tests/babylon/check-3/b/babylon/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/babylon/check-3/n/node/build.sbt
+++ b/tests/babylon/check-3/n/node/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "0.0-unknown-8bae4b"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-fa3713"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/babylon/check-3/n/node/project/build.properties
+++ b/tests/babylon/check-3/n/node/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/babylon/check-3/n/node/project/plugins.sbt
+++ b/tests/babylon/check-3/n/node/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/bigint/check-3/b/bigint/build.sbt
+++ b/tests/bigint/check-3/b/bigint/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "bigint"
-version := "v5.5.3-f3d0a2"
-scalaVersion := "3.3.1"
+version := "v5.5.3-26fa6d"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-2d528b")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-886064")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/bigint/check-3/b/bigint/project/build.properties
+++ b/tests/bigint/check-3/b/bigint/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/bigint/check-3/b/bigint/project/plugins.sbt
+++ b/tests/bigint/check-3/b/bigint/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/bigint/check-3/s/std/build.sbt
+++ b/tests/bigint/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-2d528b"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-886064"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/bigint/check-3/s/std/project/build.properties
+++ b/tests/bigint/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/bigint/check-3/s/std/project/plugins.sbt
+++ b/tests/bigint/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/chart.js/check-3/c/chart_dot_js/build.sbt
+++ b/tests/chart.js/check-3/c/chart_dot_js/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "chart_dot_js"
-version := "0.0-unknown-a2d955"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-b27c67"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-1cc5d0")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-ef4259")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/chart.js/check-3/c/chart_dot_js/project/build.properties
+++ b/tests/chart.js/check-3/c/chart_dot_js/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/chart.js/check-3/c/chart_dot_js/project/plugins.sbt
+++ b/tests/chart.js/check-3/c/chart_dot_js/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/chart.js/check-3/s/std/build.sbt
+++ b/tests/chart.js/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-1cc5d0"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-ef4259"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/chart.js/check-3/s/std/project/build.properties
+++ b/tests/chart.js/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/chart.js/check-3/s/std/project/plugins.sbt
+++ b/tests/chart.js/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/cldrjs/check-3/c/cldrjs/build.sbt
+++ b/tests/cldrjs/check-3/c/cldrjs/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "cldrjs"
-version := "0.4.4-49ad83"
-scalaVersion := "3.3.1"
+version := "0.4.4-610fac"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-7479ef")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-222910")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/cldrjs/check-3/c/cldrjs/project/build.properties
+++ b/tests/cldrjs/check-3/c/cldrjs/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/cldrjs/check-3/c/cldrjs/project/plugins.sbt
+++ b/tests/cldrjs/check-3/c/cldrjs/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/cldrjs/check-3/s/std/build.sbt
+++ b/tests/cldrjs/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-7479ef"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-222910"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/cldrjs/check-3/s/std/project/build.properties
+++ b/tests/cldrjs/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/cldrjs/check-3/s/std/project/plugins.sbt
+++ b/tests/cldrjs/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/commander/check-3/c/commander/build.sbt
+++ b/tests/commander/check-3/c/commander/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "commander"
-version := "2.15.1-a5462b"
-scalaVersion := "3.3.1"
+version := "2.15.1-03bf00"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "node" % "0.0-unknown-4d9c4b",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-9f2205")
+  "org.scalablytyped" %%% "node" % "0.0-unknown-175e92",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-c4ef0d")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/commander/check-3/c/commander/project/build.properties
+++ b/tests/commander/check-3/c/commander/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/commander/check-3/c/commander/project/plugins.sbt
+++ b/tests/commander/check-3/c/commander/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/commander/check-3/n/node/build.sbt
+++ b/tests/commander/check-3/n/node/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "0.0-unknown-4d9c4b"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-175e92"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/commander/check-3/n/node/project/build.properties
+++ b/tests/commander/check-3/n/node/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/commander/check-3/n/node/project/plugins.sbt
+++ b/tests/commander/check-3/n/node/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/commander/check-3/s/std/build.sbt
+++ b/tests/commander/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-9f2205"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-c4ef0d"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/commander/check-3/s/std/project/build.properties
+++ b/tests/commander/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/commander/check-3/s/std/project/plugins.sbt
+++ b/tests/commander/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/const-enum/check-3/c/const-enum/build.sbt
+++ b/tests/const-enum/check-3/c/const-enum/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "const-enum"
-version := "0.0-unknown-c2a325"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-d97f44"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/const-enum/check-3/c/const-enum/project/build.properties
+++ b/tests/const-enum/check-3/c/const-enum/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/const-enum/check-3/c/const-enum/project/plugins.sbt
+++ b/tests/const-enum/check-3/c/const-enum/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/create-error/check-3/c/create-error/build.sbt
+++ b/tests/create-error/check-3/c/create-error/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "create-error"
-version := "0.3.1-095d8f"
-scalaVersion := "3.3.1"
+version := "0.3.1-37d55c"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-2afa55")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-38cca9")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/create-error/check-3/c/create-error/project/build.properties
+++ b/tests/create-error/check-3/c/create-error/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/create-error/check-3/c/create-error/project/plugins.sbt
+++ b/tests/create-error/check-3/c/create-error/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/create-error/check-3/s/std/build.sbt
+++ b/tests/create-error/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-2afa55"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-38cca9"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/create-error/check-3/s/std/project/build.properties
+++ b/tests/create-error/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/create-error/check-3/s/std/project/plugins.sbt
+++ b/tests/create-error/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/defaulted-tparams/check-3/d/defaulted-tparams/build.sbt
+++ b/tests/defaulted-tparams/check-3/d/defaulted-tparams/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "defaulted-tparams"
-version := "0.0-unknown-4ac081"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-68f93c"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-38aa94")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4cf57d")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/defaulted-tparams/check-3/d/defaulted-tparams/project/build.properties
+++ b/tests/defaulted-tparams/check-3/d/defaulted-tparams/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/defaulted-tparams/check-3/d/defaulted-tparams/project/plugins.sbt
+++ b/tests/defaulted-tparams/check-3/d/defaulted-tparams/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/defaulted-tparams/check-3/s/std/build.sbt
+++ b/tests/defaulted-tparams/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-38aa94"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-4cf57d"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/defaulted-tparams/check-3/s/std/project/build.properties
+++ b/tests/defaulted-tparams/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/defaulted-tparams/check-3/s/std/project/plugins.sbt
+++ b/tests/defaulted-tparams/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/documentation/check-3/d/documentation/build.sbt
+++ b/tests/documentation/check-3/d/documentation/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "documentation"
-version := "0.0-unknown-ba2b97"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-5c9ea4"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/documentation/check-3/d/documentation/project/build.properties
+++ b/tests/documentation/check-3/d/documentation/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/documentation/check-3/d/documentation/project/plugins.sbt
+++ b/tests/documentation/check-3/d/documentation/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/echarts/check-3/e/echarts/build.sbt
+++ b/tests/echarts/check-3/e/echarts/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "echarts"
-version := "0.0-unknown-678065"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-ba5e49"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/echarts/check-3/e/echarts/project/build.properties
+++ b/tests/echarts/check-3/e/echarts/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/echarts/check-3/e/echarts/project/plugins.sbt
+++ b/tests/echarts/check-3/e/echarts/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/elasticsearch-js/check-3/e/elasticsearch-js/build.sbt
+++ b/tests/elasticsearch-js/check-3/e/elasticsearch-js/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "elasticsearch-js"
-version := "0.0-unknown-5d07a2"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-090e78"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-7c4ebe")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4e4a18")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/elasticsearch-js/check-3/e/elasticsearch-js/project/build.properties
+++ b/tests/elasticsearch-js/check-3/e/elasticsearch-js/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/elasticsearch-js/check-3/e/elasticsearch-js/project/plugins.sbt
+++ b/tests/elasticsearch-js/check-3/e/elasticsearch-js/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/elasticsearch-js/check-3/s/std/build.sbt
+++ b/tests/elasticsearch-js/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-7c4ebe"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-4e4a18"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/elasticsearch-js/check-3/s/std/project/build.properties
+++ b/tests/elasticsearch-js/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/elasticsearch-js/check-3/s/std/project/plugins.sbt
+++ b/tests/elasticsearch-js/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/electron/check-3/e/electron/build.sbt
+++ b/tests/electron/check-3/e/electron/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "electron"
-version := "2.0.0-c6b1ed"
-scalaVersion := "3.3.1"
+version := "2.0.0-55b313"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "node" % "0.0-unknown-1addc5",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-1a7cea")
+  "org.scalablytyped" %%% "node" % "0.0-unknown-b1ccbf",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-32ea2a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/electron/check-3/e/electron/project/build.properties
+++ b/tests/electron/check-3/e/electron/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/electron/check-3/e/electron/project/plugins.sbt
+++ b/tests/electron/check-3/e/electron/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/electron/check-3/n/node/build.sbt
+++ b/tests/electron/check-3/n/node/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "0.0-unknown-1addc5"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-b1ccbf"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-1a7cea")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-32ea2a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/electron/check-3/n/node/project/build.properties
+++ b/tests/electron/check-3/n/node/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/electron/check-3/n/node/project/plugins.sbt
+++ b/tests/electron/check-3/n/node/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/electron/check-3/s/std/build.sbt
+++ b/tests/electron/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-1a7cea"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-32ea2a"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/electron/check-3/s/std/project/build.properties
+++ b/tests/electron/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/electron/check-3/s/std/project/plugins.sbt
+++ b/tests/electron/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/expand-type-parameters/check-3/e/expand-type-parameters/build.sbt
+++ b/tests/expand-type-parameters/check-3/e/expand-type-parameters/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "expand-type-parameters"
-version := "0.0-unknown-a060d6"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-af9d23"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/expand-type-parameters/check-3/e/expand-type-parameters/project/build.properties
+++ b/tests/expand-type-parameters/check-3/e/expand-type-parameters/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/expand-type-parameters/check-3/e/expand-type-parameters/project/plugins.sbt
+++ b/tests/expand-type-parameters/check-3/e/expand-type-parameters/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/export-as-namespace/check-3/a/angular-agility/build.sbt
+++ b/tests/export-as-namespace/check-3/a/angular-agility/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "angular-agility"
-version := "0.0-unknown-532787"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-982013"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "angular" % "1.6-beec63",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-12bced")
+  "org.scalablytyped" %%% "angular" % "1.6-8d6db2",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-5b27fc")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/export-as-namespace/check-3/a/angular-agility/project/build.properties
+++ b/tests/export-as-namespace/check-3/a/angular-agility/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/export-as-namespace/check-3/a/angular-agility/project/plugins.sbt
+++ b/tests/export-as-namespace/check-3/a/angular-agility/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/export-as-namespace/check-3/a/angular/build.sbt
+++ b/tests/export-as-namespace/check-3/a/angular/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "angular"
-version := "1.6-beec63"
-scalaVersion := "3.3.1"
+version := "1.6-8d6db2"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-12bced")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-5b27fc")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/export-as-namespace/check-3/a/angular/project/build.properties
+++ b/tests/export-as-namespace/check-3/a/angular/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/export-as-namespace/check-3/a/angular/project/plugins.sbt
+++ b/tests/export-as-namespace/check-3/a/angular/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/export-as-namespace/check-3/s/std/build.sbt
+++ b/tests/export-as-namespace/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-12bced"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-5b27fc"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/export-as-namespace/check-3/s/std/project/build.properties
+++ b/tests/export-as-namespace/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/export-as-namespace/check-3/s/std/project/plugins.sbt
+++ b/tests/export-as-namespace/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/firebase-admin/check-3/f/firebase-admin/build.sbt
+++ b/tests/firebase-admin/check-3/f/firebase-admin/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "firebase-admin"
-version := "8.2.0-106304"
-scalaVersion := "3.3.1"
+version := "8.2.0-54d3df"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "google-cloud__firestore" % "2.2.3-2ca05a")
+  "org.scalablytyped" %%% "google-cloud__firestore" % "2.2.3-18c38f")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/firebase-admin/check-3/f/firebase-admin/project/build.properties
+++ b/tests/firebase-admin/check-3/f/firebase-admin/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/firebase-admin/check-3/f/firebase-admin/project/plugins.sbt
+++ b/tests/firebase-admin/check-3/f/firebase-admin/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/firebase-admin/check-3/g/google-cloud__firestore/build.sbt
+++ b/tests/firebase-admin/check-3/g/google-cloud__firestore/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "google-cloud__firestore"
-version := "2.2.3-2ca05a"
-scalaVersion := "3.3.1"
+version := "2.2.3-18c38f"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/firebase-admin/check-3/g/google-cloud__firestore/project/build.properties
+++ b/tests/firebase-admin/check-3/g/google-cloud__firestore/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/firebase-admin/check-3/g/google-cloud__firestore/project/plugins.sbt
+++ b/tests/firebase-admin/check-3/g/google-cloud__firestore/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/firebase/check-3/f/firebase/build.sbt
+++ b/tests/firebase/check-3/f/firebase/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "firebase"
-version := "0.0-unknown-efb3cb"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-21e414"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/firebase/check-3/f/firebase/project/build.properties
+++ b/tests/firebase/check-3/f/firebase/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/firebase/check-3/f/firebase/project/plugins.sbt
+++ b/tests/firebase/check-3/f/firebase/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/fp-ts/check-3/f/fp-ts/build.sbt
+++ b/tests/fp-ts/check-3/f/fp-ts/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "fp-ts"
-version := "1.2.0-8927fe"
-scalaVersion := "3.3.1"
+version := "1.2.0-59aa99"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/fp-ts/check-3/f/fp-ts/project/build.properties
+++ b/tests/fp-ts/check-3/f/fp-ts/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/fp-ts/check-3/f/fp-ts/project/plugins.sbt
+++ b/tests/fp-ts/check-3/f/fp-ts/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/fullcalendar/check-3/f/fullcalendar/build.sbt
+++ b/tests/fullcalendar/check-3/f/fullcalendar/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "fullcalendar"
-version := "0.0-unknown-bfd502"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-aac0af"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/fullcalendar/check-3/f/fullcalendar/project/build.properties
+++ b/tests/fullcalendar/check-3/f/fullcalendar/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/fullcalendar/check-3/f/fullcalendar/project/plugins.sbt
+++ b/tests/fullcalendar/check-3/f/fullcalendar/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/insight/check-3/i/insight/build.sbt
+++ b/tests/insight/check-3/i/insight/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "insight"
-version := "0.0-unknown-db2551"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-13e90d"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/insight/check-3/i/insight/project/build.properties
+++ b/tests/insight/check-3/i/insight/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/insight/check-3/i/insight/project/plugins.sbt
+++ b/tests/insight/check-3/i/insight/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/interface-package/check-3/i/interface-package/build.sbt
+++ b/tests/interface-package/check-3/i/interface-package/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "interface-package"
-version := "0.0-unknown-ecc6b1"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-cd9c83"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/interface-package/check-3/i/interface-package/project/build.properties
+++ b/tests/interface-package/check-3/i/interface-package/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/interface-package/check-3/i/interface-package/project/plugins.sbt
+++ b/tests/interface-package/check-3/i/interface-package/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/keyof/check-3/k/keyof/build.sbt
+++ b/tests/keyof/check-3/k/keyof/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "keyof"
-version := "0.0-unknown-930fb1"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-e7d702"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/keyof/check-3/k/keyof/project/build.properties
+++ b/tests/keyof/check-3/k/keyof/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/keyof/check-3/k/keyof/project/plugins.sbt
+++ b/tests/keyof/check-3/k/keyof/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/material-ui/check-japgolly-3/m/material-ui/build.sbt
+++ b/tests/material-ui/check-japgolly-3/m/material-ui/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "material-ui"
-version := "0.0-unknown-9afdee"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-abe888"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-42a0ab",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-947741")
+  "org.scalablytyped" %%% "react" % "0.0-unknown-6ff325",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-6ad175")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/material-ui/check-japgolly-3/m/material-ui/project/build.properties
+++ b/tests/material-ui/check-japgolly-3/m/material-ui/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/material-ui/check-japgolly-3/m/material-ui/project/plugins.sbt
+++ b/tests/material-ui/check-japgolly-3/m/material-ui/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/material-ui/check-japgolly-3/r/react/build.sbt
+++ b/tests/material-ui/check-japgolly-3/r/react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-42a0ab"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-6ff325"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-947741")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-6ad175")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/material-ui/check-japgolly-3/r/react/project/build.properties
+++ b/tests/material-ui/check-japgolly-3/r/react/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/material-ui/check-japgolly-3/r/react/project/plugins.sbt
+++ b/tests/material-ui/check-japgolly-3/r/react/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/material-ui/check-japgolly-3/s/std/build.sbt
+++ b/tests/material-ui/check-japgolly-3/s/std/build.sbt
@@ -1,10 +1,10 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-947741"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-6ad175"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/material-ui/check-japgolly-3/s/std/project/build.properties
+++ b/tests/material-ui/check-japgolly-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/material-ui/check-japgolly-3/s/std/project/plugins.sbt
+++ b/tests/material-ui/check-japgolly-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/material-ui/check-slinky-3/m/material-ui/build.sbt
+++ b/tests/material-ui/check-slinky-3/m/material-ui/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "material-ui"
-version := "0.0-unknown-981ed9"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-b12c05"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-2b8689",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-2ba956")
+  "me.shadaj" %%% "slinky-web" % "0.7.5",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-2b1707",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-0c6769")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/material-ui/check-slinky-3/m/material-ui/project/build.properties
+++ b/tests/material-ui/check-slinky-3/m/material-ui/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/material-ui/check-slinky-3/m/material-ui/project/plugins.sbt
+++ b/tests/material-ui/check-slinky-3/m/material-ui/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/material-ui/check-slinky-3/r/react/build.sbt
+++ b/tests/material-ui/check-slinky-3/r/react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-2b8689"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-2b1707"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-2ba956")
+  "me.shadaj" %%% "slinky-web" % "0.7.5",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-0c6769")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/material-ui/check-slinky-3/r/react/project/build.properties
+++ b/tests/material-ui/check-slinky-3/r/react/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/material-ui/check-slinky-3/r/react/project/plugins.sbt
+++ b/tests/material-ui/check-slinky-3/r/react/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/material-ui/check-slinky-3/s/std/build.sbt
+++ b/tests/material-ui/check-slinky-3/s/std/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-2ba956"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-0c6769"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2")
+  "me.shadaj" %%% "slinky-web" % "0.7.5")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/material-ui/check-slinky-3/s/std/project/build.properties
+++ b/tests/material-ui/check-slinky-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/material-ui/check-slinky-3/s/std/project/plugins.sbt
+++ b/tests/material-ui/check-slinky-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/monaco-editor/check-3/m/monaco-editor/build.sbt
+++ b/tests/monaco-editor/check-3/m/monaco-editor/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "monaco-editor"
-version := "0.0-unknown-16bcb6"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-663f7c"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-13a4b6")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-13fa46")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/monaco-editor/check-3/m/monaco-editor/project/build.properties
+++ b/tests/monaco-editor/check-3/m/monaco-editor/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/monaco-editor/check-3/m/monaco-editor/project/plugins.sbt
+++ b/tests/monaco-editor/check-3/m/monaco-editor/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/monaco-editor/check-3/s/std/build.sbt
+++ b/tests/monaco-editor/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-13a4b6"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-13fa46"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/monaco-editor/check-3/s/std/project/build.properties
+++ b/tests/monaco-editor/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/monaco-editor/check-3/s/std/project/plugins.sbt
+++ b/tests/monaco-editor/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/mongoose-simple-random/check-3/m/mongoose-simple-random/build.sbt
+++ b/tests/mongoose-simple-random/check-3/m/mongoose-simple-random/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "mongoose-simple-random"
-version := "0.4-58cb7f"
-scalaVersion := "3.3.1"
+version := "0.4-f02660"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "mongoose" % "0.0-unknown-e3d3aa",
-  "org.scalablytyped" %%% "node" % "0.0-unknown-4d9c4b",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-73c9cd")
+  "org.scalablytyped" %%% "mongoose" % "0.0-unknown-bf386a",
+  "org.scalablytyped" %%% "node" % "0.0-unknown-175e92",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-ce80e9")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/mongoose-simple-random/check-3/m/mongoose-simple-random/project/build.properties
+++ b/tests/mongoose-simple-random/check-3/m/mongoose-simple-random/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/mongoose-simple-random/check-3/m/mongoose-simple-random/project/plugins.sbt
+++ b/tests/mongoose-simple-random/check-3/m/mongoose-simple-random/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/mongoose-simple-random/check-3/m/mongoose/build.sbt
+++ b/tests/mongoose-simple-random/check-3/m/mongoose/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "mongoose"
-version := "0.0-unknown-e3d3aa"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-bf386a"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/mongoose-simple-random/check-3/m/mongoose/project/build.properties
+++ b/tests/mongoose-simple-random/check-3/m/mongoose/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/mongoose-simple-random/check-3/m/mongoose/project/plugins.sbt
+++ b/tests/mongoose-simple-random/check-3/m/mongoose/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/mongoose-simple-random/check-3/n/node/build.sbt
+++ b/tests/mongoose-simple-random/check-3/n/node/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "0.0-unknown-4d9c4b"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-175e92"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/mongoose-simple-random/check-3/n/node/project/build.properties
+++ b/tests/mongoose-simple-random/check-3/n/node/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/mongoose-simple-random/check-3/n/node/project/plugins.sbt
+++ b/tests/mongoose-simple-random/check-3/n/node/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/mongoose-simple-random/check-3/s/std/build.sbt
+++ b/tests/mongoose-simple-random/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-73c9cd"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-ce80e9"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/mongoose-simple-random/check-3/s/std/project/build.properties
+++ b/tests/mongoose-simple-random/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/mongoose-simple-random/check-3/s/std/project/plugins.sbt
+++ b/tests/mongoose-simple-random/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/numjs/check-3/n/ndarray/build.sbt
+++ b/tests/numjs/check-3/n/ndarray/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "ndarray"
-version := "0.0-unknown-0d4a43"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-5ed15b"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-7479ef")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-222910")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/numjs/check-3/n/ndarray/project/build.properties
+++ b/tests/numjs/check-3/n/ndarray/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/numjs/check-3/n/ndarray/project/plugins.sbt
+++ b/tests/numjs/check-3/n/ndarray/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/numjs/check-3/n/numjs/build.sbt
+++ b/tests/numjs/check-3/n/numjs/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "numjs"
-version := "0.0-unknown-bcf884"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-5e3b07"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "ndarray" % "0.0-unknown-0d4a43",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-7479ef")
+  "org.scalablytyped" %%% "ndarray" % "0.0-unknown-5ed15b",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-222910")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/numjs/check-3/n/numjs/project/build.properties
+++ b/tests/numjs/check-3/n/numjs/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/numjs/check-3/n/numjs/project/plugins.sbt
+++ b/tests/numjs/check-3/n/numjs/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/numjs/check-3/s/std/build.sbt
+++ b/tests/numjs/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-7479ef"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-222910"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/numjs/check-3/s/std/project/build.properties
+++ b/tests/numjs/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/numjs/check-3/s/std/project/plugins.sbt
+++ b/tests/numjs/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/pixi.js/check-3/e/eventemitter3/build.sbt
+++ b/tests/pixi.js/check-3/e/eventemitter3/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "eventemitter3"
-version := "0.0-unknown-e13076"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-9c09cb"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/pixi.js/check-3/e/eventemitter3/project/build.properties
+++ b/tests/pixi.js/check-3/e/eventemitter3/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/pixi.js/check-3/e/eventemitter3/project/plugins.sbt
+++ b/tests/pixi.js/check-3/e/eventemitter3/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/pixi.js/check-3/p/pixi__utils/build.sbt
+++ b/tests/pixi.js/check-3/p/pixi__utils/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "pixi__utils"
-version := "0.0-unknown-816a41"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-74315b"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "eventemitter3" % "0.0-unknown-e13076")
+  "org.scalablytyped" %%% "eventemitter3" % "0.0-unknown-9c09cb")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/pixi.js/check-3/p/pixi__utils/project/build.properties
+++ b/tests/pixi.js/check-3/p/pixi__utils/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/pixi.js/check-3/p/pixi__utils/project/plugins.sbt
+++ b/tests/pixi.js/check-3/p/pixi__utils/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/pixi.js/check-3/p/pixi_dot_js/build.sbt
+++ b/tests/pixi.js/check-3/p/pixi_dot_js/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "pixi_dot_js"
-version := "0.0-unknown-047eec"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-e874e6"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "eventemitter3" % "0.0-unknown-e13076",
-  "org.scalablytyped" %%% "pixi__utils" % "0.0-unknown-816a41")
+  "org.scalablytyped" %%% "eventemitter3" % "0.0-unknown-9c09cb",
+  "org.scalablytyped" %%% "pixi__utils" % "0.0-unknown-74315b")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/pixi.js/check-3/p/pixi_dot_js/project/build.properties
+++ b/tests/pixi.js/check-3/p/pixi_dot_js/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/pixi.js/check-3/p/pixi_dot_js/project/plugins.sbt
+++ b/tests/pixi.js/check-3/p/pixi_dot_js/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/prisma/check-3/p/prisma/build.sbt
+++ b/tests/prisma/check-3/p/prisma/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "prisma"
-version := "0.0-unknown-ef4b4e"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-24f406"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-8ef969")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-23735b")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/prisma/check-3/p/prisma/project/build.properties
+++ b/tests/prisma/check-3/p/prisma/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/prisma/check-3/p/prisma/project/plugins.sbt
+++ b/tests/prisma/check-3/p/prisma/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/prisma/check-3/s/std/build.sbt
+++ b/tests/prisma/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-8ef969"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-23735b"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/prisma/check-3/s/std/project/build.properties
+++ b/tests/prisma/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/prisma/check-3/s/std/project/plugins.sbt
+++ b/tests/prisma/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/properties/check-3/p/properties/build.sbt
+++ b/tests/properties/check-3/p/properties/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "properties"
-version := "0.0-unknown-7cbf6a"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-a37ed7"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/properties/check-3/p/properties/project/build.properties
+++ b/tests/properties/check-3/p/properties/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/properties/check-3/p/properties/project/plugins.sbt
+++ b/tests/properties/check-3/p/properties/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/punchcard/check-3/p/punchcard/build.sbt
+++ b/tests/punchcard/check-3/p/punchcard/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "punchcard"
-version := "0.0-unknown-22376b"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-f46ff3"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-4233e4")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-cc29ad")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/punchcard/check-3/p/punchcard/project/build.properties
+++ b/tests/punchcard/check-3/p/punchcard/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/punchcard/check-3/p/punchcard/project/plugins.sbt
+++ b/tests/punchcard/check-3/p/punchcard/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/punchcard/check-3/s/std/build.sbt
+++ b/tests/punchcard/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-4233e4"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-cc29ad"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/punchcard/check-3/s/std/project/build.properties
+++ b/tests/punchcard/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/punchcard/check-3/s/std/project/plugins.sbt
+++ b/tests/punchcard/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-icons/check-3/r/react-icon-base/build.sbt
+++ b/tests/react-icons/check-3/r/react-icon-base/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-icon-base"
-version := "2.1-b63a15"
-scalaVersion := "3.3.1"
+version := "2.1-ceba61"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-e5ca07",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-6212a7")
+  "org.scalablytyped" %%% "react" % "0.0-unknown-76f093",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d01dfd")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-icons/check-3/r/react-icon-base/project/build.properties
+++ b/tests/react-icons/check-3/r/react-icon-base/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-icons/check-3/r/react-icon-base/project/plugins.sbt
+++ b/tests/react-icons/check-3/r/react-icon-base/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-icons/check-3/r/react-icons/build.sbt
+++ b/tests/react-icons/check-3/r/react-icons/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-icons"
-version := "2.2-f9e7e3"
-scalaVersion := "3.3.1"
+version := "2.2-e75ef4"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-e5ca07",
-  "org.scalablytyped" %%% "react-icon-base" % "2.1-b63a15",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-6212a7")
+  "org.scalablytyped" %%% "react" % "0.0-unknown-76f093",
+  "org.scalablytyped" %%% "react-icon-base" % "2.1-ceba61",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d01dfd")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-icons/check-3/r/react-icons/project/build.properties
+++ b/tests/react-icons/check-3/r/react-icons/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-icons/check-3/r/react-icons/project/plugins.sbt
+++ b/tests/react-icons/check-3/r/react-icons/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-icons/check-3/r/react/build.sbt
+++ b/tests/react-icons/check-3/r/react/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-e5ca07"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-76f093"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-6212a7")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d01dfd")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-icons/check-3/r/react/project/build.properties
+++ b/tests/react-icons/check-3/r/react/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-icons/check-3/r/react/project/plugins.sbt
+++ b/tests/react-icons/check-3/r/react/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-icons/check-3/s/std/build.sbt
+++ b/tests/react-icons/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-6212a7"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-d01dfd"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/react-icons/check-3/s/std/project/build.properties
+++ b/tests/react-icons/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-icons/check-3/s/std/project/plugins.sbt
+++ b/tests/react-icons/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-bbe6fa"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-b01d52"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-cf7dfd",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-98c468")
+  "org.scalablytyped" %%% "react" % "16.9.2-5cd5e4",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-fd1f02")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/project/build.properties
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/project/plugins.sbt
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-japgolly-3/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-bootstrap/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-d0d311"
-scalaVersion := "3.3.1"
+version := "0.32-fc5eea"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-cf7dfd",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-98c468")
+  "org.scalablytyped" %%% "react" % "16.9.2-5cd5e4",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-fd1f02")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-japgolly-3/r/react-bootstrap/project/build.properties
+++ b/tests/react-integration-test/check-japgolly-3/r/react-bootstrap/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-japgolly-3/r/react-bootstrap/project/plugins.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-bootstrap/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-japgolly-3/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-contextmenu/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-56c8d1"
-scalaVersion := "3.3.1"
+version := "2.13.0-d2d3c5"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-cf7dfd",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-98c468")
+  "org.scalablytyped" %%% "react" % "16.9.2-5cd5e4",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-fd1f02")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-japgolly-3/r/react-contextmenu/project/build.properties
+++ b/tests/react-integration-test/check-japgolly-3/r/react-contextmenu/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-japgolly-3/r/react-contextmenu/project/plugins.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-contextmenu/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-japgolly-3/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-dropzone/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-f3301a"
-scalaVersion := "3.3.1"
+version := "10.1.10-615cfe"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-cf7dfd",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-98c468")
+  "org.scalablytyped" %%% "react" % "16.9.2-5cd5e4",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-fd1f02")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-japgolly-3/r/react-dropzone/project/build.properties
+++ b/tests/react-integration-test/check-japgolly-3/r/react-dropzone/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-japgolly-3/r/react-dropzone/project/plugins.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-dropzone/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-japgolly-3/r/react-markdown/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-markdown/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-markdown"
-version := "0.0-unknown-23d422"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-1bca7c"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-cf7dfd",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-98c468")
+  "org.scalablytyped" %%% "react" % "16.9.2-5cd5e4",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-fd1f02")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-japgolly-3/r/react-markdown/project/build.properties
+++ b/tests/react-integration-test/check-japgolly-3/r/react-markdown/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-japgolly-3/r/react-markdown/project/plugins.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-markdown/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-japgolly-3/r/react-native/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-native/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-native"
-version := "0.0-unknown-2a8c7b"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-77538b"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-98c468")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-fd1f02")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-japgolly-3/r/react-native/project/build.properties
+++ b/tests/react-integration-test/check-japgolly-3/r/react-native/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-japgolly-3/r/react-native/project/plugins.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-native/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-japgolly-3/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-select/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-b2c55c"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-463d10"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-cf7dfd",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-98c468")
+  "org.scalablytyped" %%% "react" % "16.9.2-5cd5e4",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-fd1f02")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-japgolly-3/r/react-select/project/build.properties
+++ b/tests/react-integration-test/check-japgolly-3/r/react-select/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-japgolly-3/r/react-select/project/plugins.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react-select/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-japgolly-3/r/react/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-cf7dfd"
-scalaVersion := "3.3.1"
+version := "16.9.2-5cd5e4"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-98c468")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-fd1f02")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-japgolly-3/r/react/project/build.properties
+++ b/tests/react-integration-test/check-japgolly-3/r/react/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-japgolly-3/r/react/project/plugins.sbt
+++ b/tests/react-integration-test/check-japgolly-3/r/react/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-japgolly-3/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/s/semantic-ui-react/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-01f219"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-edf860"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-cf7dfd",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-98c468")
+  "org.scalablytyped" %%% "react" % "16.9.2-5cd5e4",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-fd1f02")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-japgolly-3/s/semantic-ui-react/project/build.properties
+++ b/tests/react-integration-test/check-japgolly-3/s/semantic-ui-react/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-japgolly-3/s/semantic-ui-react/project/plugins.sbt
+++ b/tests/react-integration-test/check-japgolly-3/s/semantic-ui-react/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-6e0484"
-scalaVersion := "3.3.1"
+version := "0.38.0-209dc6"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-cf7dfd",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-98c468")
+  "org.scalablytyped" %%% "react" % "16.9.2-5cd5e4",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-fd1f02")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-event-listener/project/build.properties
+++ b/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-event-listener/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-event-listener/project/plugins.sbt
+++ b/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-event-listener/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-ref/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-7bb286"
-scalaVersion := "3.3.1"
+version := "0.38.0-f5292d"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-cf7dfd",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-98c468")
+  "org.scalablytyped" %%% "react" % "16.9.2-5cd5e4",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-fd1f02")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-ref/project/build.properties
+++ b/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-ref/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-ref/project/plugins.sbt
+++ b/tests/react-integration-test/check-japgolly-3/s/stardust-ui__react-component-ref/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-japgolly-3/s/std/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/s/std/build.sbt
@@ -1,10 +1,10 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-98c468"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-fd1f02"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-integration-test/check-japgolly-3/s/std/project/build.properties
+++ b/tests/react-integration-test/check-japgolly-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-japgolly-3/s/std/project/plugins.sbt
+++ b/tests/react-integration-test/check-japgolly-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-0d196f"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-7da622"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-a736a4",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-37da08")
+  "me.shadaj" %%% "slinky-web" % "0.7.5",
+  "org.scalablytyped" %%% "react" % "16.9.2-69b387",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4012b3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/project/build.properties
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/project/plugins.sbt
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-slinky-3/r/react-bootstrap/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-bootstrap/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-bootstrap"
-version := "0.32-e8868e"
-scalaVersion := "3.3.1"
+version := "0.32-1e0fad"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-a736a4",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-37da08")
+  "me.shadaj" %%% "slinky-web" % "0.7.5",
+  "org.scalablytyped" %%% "react" % "16.9.2-69b387",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4012b3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-slinky-3/r/react-bootstrap/project/build.properties
+++ b/tests/react-integration-test/check-slinky-3/r/react-bootstrap/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-slinky-3/r/react-bootstrap/project/plugins.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-bootstrap/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-slinky-3/r/react-contextmenu/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-contextmenu/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-contextmenu"
-version := "2.13.0-fe5a02"
-scalaVersion := "3.3.1"
+version := "2.13.0-f7f7b5"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-a736a4",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-37da08")
+  "me.shadaj" %%% "slinky-web" % "0.7.5",
+  "org.scalablytyped" %%% "react" % "16.9.2-69b387",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4012b3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-slinky-3/r/react-contextmenu/project/build.properties
+++ b/tests/react-integration-test/check-slinky-3/r/react-contextmenu/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-slinky-3/r/react-contextmenu/project/plugins.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-contextmenu/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-slinky-3/r/react-dropzone/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-dropzone/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-dropzone"
-version := "10.1.10-6e7dbe"
-scalaVersion := "3.3.1"
+version := "10.1.10-130e04"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-a736a4",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-37da08")
+  "me.shadaj" %%% "slinky-web" % "0.7.5",
+  "org.scalablytyped" %%% "react" % "16.9.2-69b387",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4012b3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-slinky-3/r/react-dropzone/project/build.properties
+++ b/tests/react-integration-test/check-slinky-3/r/react-dropzone/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-slinky-3/r/react-dropzone/project/plugins.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-dropzone/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-slinky-3/r/react-markdown/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-markdown/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-markdown"
-version := "0.0-unknown-af99ea"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-469a52"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-a736a4",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-37da08")
+  "me.shadaj" %%% "slinky-web" % "0.7.5",
+  "org.scalablytyped" %%% "react" % "16.9.2-69b387",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4012b3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-slinky-3/r/react-markdown/project/build.properties
+++ b/tests/react-integration-test/check-slinky-3/r/react-markdown/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-slinky-3/r/react-markdown/project/plugins.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-markdown/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-slinky-3/r/react-native/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-native/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react-native"
-version := "0.0-unknown-c89031"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-43f8c1"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-37da08")
+  "me.shadaj" %%% "slinky-web" % "0.7.5",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4012b3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-slinky-3/r/react-native/project/build.properties
+++ b/tests/react-integration-test/check-slinky-3/r/react-native/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-slinky-3/r/react-native/project/plugins.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-native/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-slinky-3/r/react-select/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-select/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-select"
-version := "0.0-unknown-54a89d"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-31f3fa"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-a736a4",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-37da08")
+  "me.shadaj" %%% "slinky-web" % "0.7.5",
+  "org.scalablytyped" %%% "react" % "16.9.2-69b387",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4012b3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-slinky-3/r/react-select/project/build.properties
+++ b/tests/react-integration-test/check-slinky-3/r/react-select/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-slinky-3/r/react-select/project/plugins.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react-select/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-slinky-3/r/react/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "16.9.2-a736a4"
-scalaVersion := "3.3.1"
+version := "16.9.2-69b387"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-37da08")
+  "me.shadaj" %%% "slinky-web" % "0.7.5",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4012b3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-slinky-3/r/react/project/build.properties
+++ b/tests/react-integration-test/check-slinky-3/r/react/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-slinky-3/r/react/project/plugins.sbt
+++ b/tests/react-integration-test/check-slinky-3/r/react/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "semantic-ui-react"
-version := "0.0-unknown-aea058"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-db5022"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-a736a4",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-37da08")
+  "me.shadaj" %%% "slinky-web" % "0.7.5",
+  "org.scalablytyped" %%% "react" % "16.9.2-69b387",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4012b3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/project/build.properties
+++ b/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/project/plugins.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/semantic-ui-react/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-event-listener/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-event-listener/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-event-listener"
-version := "0.38.0-bcdd71"
-scalaVersion := "3.3.1"
+version := "0.38.0-6fa8a7"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-a736a4",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-37da08")
+  "me.shadaj" %%% "slinky-web" % "0.7.5",
+  "org.scalablytyped" %%% "react" % "16.9.2-69b387",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4012b3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-event-listener/project/build.properties
+++ b/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-event-listener/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-event-listener/project/plugins.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-event-listener/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-ref/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-ref/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "stardust-ui__react-component-ref"
-version := "0.38.0-9944ca"
-scalaVersion := "3.3.1"
+version := "0.38.0-33429d"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "16.9.2-a736a4",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-37da08")
+  "me.shadaj" %%% "slinky-web" % "0.7.5",
+  "org.scalablytyped" %%% "react" % "16.9.2-69b387",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-4012b3")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-ref/project/build.properties
+++ b/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-ref/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-ref/project/plugins.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/stardust-ui__react-component-ref/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-integration-test/check-slinky-3/s/std/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/std/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-37da08"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-4012b3"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2")
+  "me.shadaj" %%% "slinky-web" % "0.7.5")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-integration-test/check-slinky-3/s/std/project/build.properties
+++ b/tests/react-integration-test/check-slinky-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-integration-test/check-slinky-3/s/std/project/plugins.sbt
+++ b/tests/react-integration-test/check-slinky-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-transition-group/check-japgolly-3/r/react-transition-group/build.sbt
+++ b/tests/react-transition-group/check-japgolly-3/r/react-transition-group/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-transition-group"
-version := "2.0-612ec6"
-scalaVersion := "3.3.1"
+version := "2.0-9ec82e"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-21f152",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-bb4822")
+  "org.scalablytyped" %%% "react" % "0.0-unknown-6d7b7d",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-6934ca")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-transition-group/check-japgolly-3/r/react-transition-group/project/build.properties
+++ b/tests/react-transition-group/check-japgolly-3/r/react-transition-group/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-transition-group/check-japgolly-3/r/react-transition-group/project/plugins.sbt
+++ b/tests/react-transition-group/check-japgolly-3/r/react-transition-group/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-transition-group/check-japgolly-3/r/react/build.sbt
+++ b/tests/react-transition-group/check-japgolly-3/r/react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-21f152"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-6d7b7d"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-bb4822")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-6934ca")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-transition-group/check-japgolly-3/r/react/project/build.properties
+++ b/tests/react-transition-group/check-japgolly-3/r/react/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-transition-group/check-japgolly-3/r/react/project/plugins.sbt
+++ b/tests/react-transition-group/check-japgolly-3/r/react/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-transition-group/check-japgolly-3/s/std/build.sbt
+++ b/tests/react-transition-group/check-japgolly-3/s/std/build.sbt
@@ -1,10 +1,10 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-bb4822"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-6934ca"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
-  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1",
+  "com.github.japgolly.scalajs-react" %%% "core" % "2.1.3",
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")

--- a/tests/react-transition-group/check-japgolly-3/s/std/project/build.properties
+++ b/tests/react-transition-group/check-japgolly-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-transition-group/check-japgolly-3/s/std/project/plugins.sbt
+++ b/tests/react-transition-group/check-japgolly-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-transition-group/check-slinky-3/r/react-transition-group/build.sbt
+++ b/tests/react-transition-group/check-slinky-3/r/react-transition-group/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "react-transition-group"
-version := "2.0-be991d"
-scalaVersion := "3.3.1"
+version := "2.0-3cec9b"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-ef433e",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-c1f36e")
+  "me.shadaj" %%% "slinky-web" % "0.7.5",
+  "org.scalablytyped" %%% "react" % "0.0-unknown-813969",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-0556fe")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-transition-group/check-slinky-3/r/react-transition-group/project/build.properties
+++ b/tests/react-transition-group/check-slinky-3/r/react-transition-group/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-transition-group/check-slinky-3/r/react-transition-group/project/plugins.sbt
+++ b/tests/react-transition-group/check-slinky-3/r/react-transition-group/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-transition-group/check-slinky-3/r/react/build.sbt
+++ b/tests/react-transition-group/check-slinky-3/r/react/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-ef433e"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-813969"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-c1f36e")
+  "me.shadaj" %%% "slinky-web" % "0.7.5",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-0556fe")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-transition-group/check-slinky-3/r/react/project/build.properties
+++ b/tests/react-transition-group/check-slinky-3/r/react/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-transition-group/check-slinky-3/r/react/project/plugins.sbt
+++ b/tests/react-transition-group/check-slinky-3/r/react/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/react-transition-group/check-slinky-3/s/std/build.sbt
+++ b/tests/react-transition-group/check-slinky-3/s/std/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-c1f36e"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-0556fe"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "me.shadaj" %%% "slinky-web" % "0.7.2")
+  "me.shadaj" %%% "slinky-web" % "0.7.5")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/react-transition-group/check-slinky-3/s/std/project/build.properties
+++ b/tests/react-transition-group/check-slinky-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/react-transition-group/check-slinky-3/s/std/project/plugins.sbt
+++ b/tests/react-transition-group/check-slinky-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/recharts/check-3/r/recharts/build.sbt
+++ b/tests/recharts/check-3/r/recharts/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "recharts"
-version := "0.0-unknown-84c97f"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-41915b"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/recharts/check-3/r/recharts/project/build.properties
+++ b/tests/recharts/check-3/r/recharts/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/recharts/check-3/r/recharts/project/plugins.sbt
+++ b/tests/recharts/check-3/r/recharts/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/rxjs/check-3/r/rxjs/build.sbt
+++ b/tests/rxjs/check-3/r/rxjs/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "rxjs"
-version := "0.0-unknown-6bd7ca"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-e878e5"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/rxjs/check-3/r/rxjs/project/build.properties
+++ b/tests/rxjs/check-3/r/rxjs/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/rxjs/check-3/r/rxjs/project/plugins.sbt
+++ b/tests/rxjs/check-3/r/rxjs/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/sax/check-3/n/node/build.sbt
+++ b/tests/sax/check-3/n/node/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "9.6.x-b69b63"
-scalaVersion := "3.3.1"
+version := "9.6.x-faeff0"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-9a82f6")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-cd6ab2")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/sax/check-3/n/node/project/build.properties
+++ b/tests/sax/check-3/n/node/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/sax/check-3/n/node/project/plugins.sbt
+++ b/tests/sax/check-3/n/node/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/sax/check-3/s/sax/build.sbt
+++ b/tests/sax/check-3/s/sax/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "sax"
-version := "1.x-b3a7c7"
-scalaVersion := "3.3.1"
+version := "1.x-929a11"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "node" % "9.6.x-b69b63",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-9a82f6")
+  "org.scalablytyped" %%% "node" % "9.6.x-faeff0",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-cd6ab2")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/sax/check-3/s/sax/project/build.properties
+++ b/tests/sax/check-3/s/sax/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/sax/check-3/s/sax/project/plugins.sbt
+++ b/tests/sax/check-3/s/sax/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/sax/check-3/s/std/build.sbt
+++ b/tests/sax/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-9a82f6"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-cd6ab2"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/sax/check-3/s/std/project/build.properties
+++ b/tests/sax/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/sax/check-3/s/std/project/plugins.sbt
+++ b/tests/sax/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/serve-static/check-3/e/express-serve-static-core/build.sbt
+++ b/tests/serve-static/check-3/e/express-serve-static-core/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "express-serve-static-core"
-version := "0.0-unknown-1c724f"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-f17224"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/serve-static/check-3/e/express-serve-static-core/project/build.properties
+++ b/tests/serve-static/check-3/e/express-serve-static-core/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/serve-static/check-3/e/express-serve-static-core/project/plugins.sbt
+++ b/tests/serve-static/check-3/e/express-serve-static-core/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/serve-static/check-3/m/mime/build.sbt
+++ b/tests/serve-static/check-3/m/mime/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "mime"
-version := "2.0-2287e6"
-scalaVersion := "3.3.1"
+version := "2.0-6bf314"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-7479ef")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-222910")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/serve-static/check-3/m/mime/project/build.properties
+++ b/tests/serve-static/check-3/m/mime/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/serve-static/check-3/m/mime/project/plugins.sbt
+++ b/tests/serve-static/check-3/m/mime/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/serve-static/check-3/s/serve-static/build.sbt
+++ b/tests/serve-static/check-3/s/serve-static/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "serve-static"
-version := "0.0-unknown-e6e444"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-7d624e"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "express-serve-static-core" % "0.0-unknown-1c724f",
-  "org.scalablytyped" %%% "mime" % "2.0-2287e6",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-7479ef")
+  "org.scalablytyped" %%% "express-serve-static-core" % "0.0-unknown-f17224",
+  "org.scalablytyped" %%% "mime" % "2.0-6bf314",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-222910")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/serve-static/check-3/s/serve-static/project/build.properties
+++ b/tests/serve-static/check-3/s/serve-static/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/serve-static/check-3/s/serve-static/project/plugins.sbt
+++ b/tests/serve-static/check-3/s/serve-static/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/serve-static/check-3/s/std/build.sbt
+++ b/tests/serve-static/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-7479ef"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-222910"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/serve-static/check-3/s/std/project/build.properties
+++ b/tests/serve-static/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/serve-static/check-3/s/std/project/plugins.sbt
+++ b/tests/serve-static/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/stylis/check-3/s/std/build.sbt
+++ b/tests/stylis/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-7479ef"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-222910"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/stylis/check-3/s/std/project/build.properties
+++ b/tests/stylis/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/stylis/check-3/s/std/project/plugins.sbt
+++ b/tests/stylis/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/stylis/check-3/s/stylis/build.sbt
+++ b/tests/stylis/check-3/s/stylis/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "stylis"
-version := "0.0-unknown-e82190"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-26955c"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-7479ef")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-222910")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/stylis/check-3/s/stylis/project/build.properties
+++ b/tests/stylis/check-3/s/stylis/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/stylis/check-3/s/stylis/project/plugins.sbt
+++ b/tests/stylis/check-3/s/stylis/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/swiz/check-3/s/std/build.sbt
+++ b/tests/swiz/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-7479ef"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-222910"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/swiz/check-3/s/std/project/build.properties
+++ b/tests/swiz/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/swiz/check-3/s/std/project/plugins.sbt
+++ b/tests/swiz/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/swiz/check-3/s/swiz/build.sbt
+++ b/tests/swiz/check-3/s/swiz/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "swiz"
-version := "0.0-unknown-d3b94a"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-f2fad6"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-7479ef")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-222910")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/swiz/check-3/s/swiz/project/build.properties
+++ b/tests/swiz/check-3/s/swiz/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/swiz/check-3/s/swiz/project/plugins.sbt
+++ b/tests/swiz/check-3/s/swiz/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/tstl/check-3/t/tstl/build.sbt
+++ b/tests/tstl/check-3/t/tstl/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "tstl"
-version := "0.0-unknown-d16c85"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-34a768"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/tstl/check-3/t/tstl/project/build.properties
+++ b/tests/tstl/check-3/t/tstl/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/tstl/check-3/t/tstl/project/plugins.sbt
+++ b/tests/tstl/check-3/t/tstl/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/type-mappings/check-3/s/std/build.sbt
+++ b/tests/type-mappings/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-4dd403"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-d76ff4"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/type-mappings/check-3/s/std/project/build.properties
+++ b/tests/type-mappings/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/type-mappings/check-3/s/std/project/plugins.sbt
+++ b/tests/type-mappings/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/type-mappings/check-3/t/type-mappings/build.sbt
+++ b/tests/type-mappings/check-3/t/type-mappings/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "type-mappings"
-version := "0.0-unknown-a5c315"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-a9d9f1"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-4dd403")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-d76ff4")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/type-mappings/check-3/t/type-mappings/project/build.properties
+++ b/tests/type-mappings/check-3/t/type-mappings/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/type-mappings/check-3/t/type-mappings/project/plugins.sbt
+++ b/tests/type-mappings/check-3/t/type-mappings/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/typings-json/check-3/p/phaser/build.sbt
+++ b/tests/typings-json/check-3/p/phaser/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "phaser"
-version := "2.6.2-550532"
-scalaVersion := "3.3.1"
+version := "2.6.2-59628b"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-7479ef")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-222910")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/typings-json/check-3/p/phaser/project/build.properties
+++ b/tests/typings-json/check-3/p/phaser/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/typings-json/check-3/p/phaser/project/plugins.sbt
+++ b/tests/typings-json/check-3/p/phaser/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/typings-json/check-3/s/std/build.sbt
+++ b/tests/typings-json/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-7479ef"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-222910"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/typings-json/check-3/s/std/project/build.properties
+++ b/tests/typings-json/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/typings-json/check-3/s/std/project/plugins.sbt
+++ b/tests/typings-json/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/union-to-inheritance/check-3/s/std/build.sbt
+++ b/tests/union-to-inheritance/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-1b9f6f"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-622667"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/union-to-inheritance/check-3/s/std/project/build.properties
+++ b/tests/union-to-inheritance/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/union-to-inheritance/check-3/s/std/project/plugins.sbt
+++ b/tests/union-to-inheritance/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/union-to-inheritance/check-3/u/union-to-inheritance/build.sbt
+++ b/tests/union-to-inheritance/check-3/u/union-to-inheritance/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "union-to-inheritance"
-version := "0.0-unknown-3244f4"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-317f95"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-1b9f6f")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-622667")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/union-to-inheritance/check-3/u/union-to-inheritance/project/build.properties
+++ b/tests/union-to-inheritance/check-3/u/union-to-inheritance/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/union-to-inheritance/check-3/u/union-to-inheritance/project/plugins.sbt
+++ b/tests/union-to-inheritance/check-3/u/union-to-inheritance/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/vfile/check-3/s/std/build.sbt
+++ b/tests/vfile/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-4ac6f2"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-a7f971"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/vfile/check-3/s/std/project/build.properties
+++ b/tests/vfile/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/vfile/check-3/s/std/project/plugins.sbt
+++ b/tests/vfile/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/vfile/check-3/v/vfile/build.sbt
+++ b/tests/vfile/check-3/v/vfile/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "vfile"
-version := "0.0-unknown-119b19"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-bcb34b"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-4ac6f2")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-a7f971")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/vfile/check-3/v/vfile/project/build.properties
+++ b/tests/vfile/check-3/v/vfile/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/vfile/check-3/v/vfile/project/plugins.sbt
+++ b/tests/vfile/check-3/v/vfile/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/virtual-dom/check-3/v/virtual-dom/build.sbt
+++ b/tests/virtual-dom/check-3/v/virtual-dom/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "virtual-dom"
-version := "0.0-unknown-a0218e"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-2e43fb"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/virtual-dom/check-3/v/virtual-dom/project/build.properties
+++ b/tests/virtual-dom/check-3/v/virtual-dom/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/virtual-dom/check-3/v/virtual-dom/project/plugins.sbt
+++ b/tests/virtual-dom/check-3/v/virtual-dom/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/void-elements/check-3/s/std/build.sbt
+++ b/tests/void-elements/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-8a847d"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-82a14a"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/void-elements/check-3/s/std/project/build.properties
+++ b/tests/void-elements/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/void-elements/check-3/s/std/project/plugins.sbt
+++ b/tests/void-elements/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/void-elements/check-3/v/void-elements/build.sbt
+++ b/tests/void-elements/check-3/v/void-elements/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "void-elements"
-version := "3.1-ca0595"
-scalaVersion := "3.3.1"
+version := "3.1-2f9ce6"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-8a847d")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-82a14a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/void-elements/check-3/v/void-elements/project/build.properties
+++ b/tests/void-elements/check-3/v/void-elements/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/void-elements/check-3/v/void-elements/project/plugins.sbt
+++ b/tests/void-elements/check-3/v/void-elements/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/vue/check-3/n/node/build.sbt
+++ b/tests/vue/check-3/n/node/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "0.0-unknown-313abb"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-1d1346"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/vue/check-3/n/node/project/build.properties
+++ b/tests/vue/check-3/n/node/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/vue/check-3/n/node/project/plugins.sbt
+++ b/tests/vue/check-3/n/node/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/vue/check-3/s/std/build.sbt
+++ b/tests/vue/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-55ca38"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-7d7dd0"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/vue/check-3/s/std/project/build.properties
+++ b/tests/vue/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/vue/check-3/s/std/project/plugins.sbt
+++ b/tests/vue/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/vue/check-3/s/storybook__vue/build.sbt
+++ b/tests/vue/check-3/s/storybook__vue/build.sbt
@@ -1,13 +1,13 @@
 organization := "org.scalablytyped"
 name := "storybook__vue"
-version := "3.3-50d939"
-scalaVersion := "3.3.1"
+version := "3.3-5e6f7f"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-55ca38",
-  "org.scalablytyped" %%% "vue" % "2.5.13-854b14",
-  "org.scalablytyped" %%% "webpack-env" % "1.13-9507ff")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7d7dd0",
+  "org.scalablytyped" %%% "vue" % "2.5.13-1e5148",
+  "org.scalablytyped" %%% "webpack-env" % "1.13-3fafb9")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/vue/check-3/s/storybook__vue/project/build.properties
+++ b/tests/vue/check-3/s/storybook__vue/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/vue/check-3/s/storybook__vue/project/plugins.sbt
+++ b/tests/vue/check-3/s/storybook__vue/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/vue/check-3/v/vue-resource/build.sbt
+++ b/tests/vue/check-3/v/vue-resource/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "vue-resource"
-version := "0.9.3-84ce90"
-scalaVersion := "3.3.1"
+version := "0.9.3-97c57e"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-55ca38")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7d7dd0")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/vue/check-3/v/vue-resource/project/build.properties
+++ b/tests/vue/check-3/v/vue-resource/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/vue/check-3/v/vue-resource/project/plugins.sbt
+++ b/tests/vue/check-3/v/vue-resource/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/vue/check-3/v/vue-scrollto/build.sbt
+++ b/tests/vue/check-3/v/vue-scrollto/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "vue-scrollto"
-version := "2.7-b27789"
-scalaVersion := "3.3.1"
+version := "2.7-f1ecc0"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-55ca38",
-  "org.scalablytyped" %%% "vue" % "2.5.13-854b14")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7d7dd0",
+  "org.scalablytyped" %%% "vue" % "2.5.13-1e5148")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/vue/check-3/v/vue-scrollto/project/build.properties
+++ b/tests/vue/check-3/v/vue-scrollto/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/vue/check-3/v/vue-scrollto/project/plugins.sbt
+++ b/tests/vue/check-3/v/vue-scrollto/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/vue/check-3/v/vue/build.sbt
+++ b/tests/vue/check-3/v/vue/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "vue"
-version := "2.5.13-854b14"
-scalaVersion := "3.3.1"
+version := "2.5.13-1e5148"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-55ca38")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7d7dd0")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/vue/check-3/v/vue/project/build.properties
+++ b/tests/vue/check-3/v/vue/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/vue/check-3/v/vue/project/plugins.sbt
+++ b/tests/vue/check-3/v/vue/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/vue/check-3/w/webpack-env/build.sbt
+++ b/tests/vue/check-3/w/webpack-env/build.sbt
@@ -1,11 +1,11 @@
 organization := "org.scalablytyped"
 name := "webpack-env"
-version := "1.13-9507ff"
-scalaVersion := "3.3.1"
+version := "1.13-3fafb9"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-55ca38")
+  "org.scalablytyped" %%% "std" % "0.0-unknown-7d7dd0")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/vue/check-3/w/webpack-env/project/build.properties
+++ b/tests/vue/check-3/w/webpack-env/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/vue/check-3/w/webpack-env/project/plugins.sbt
+++ b/tests/vue/check-3/w/webpack-env/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/winston/check-3/w/winston/build.sbt
+++ b/tests/winston/check-3/w/winston/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "winston"
-version := "3.0.0-7763d2"
-scalaVersion := "3.3.1"
+version := "3.0.0-14f5f1"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/winston/check-3/w/winston/project/build.properties
+++ b/tests/winston/check-3/w/winston/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/winston/check-3/w/winston/project/plugins.sbt
+++ b/tests/winston/check-3/w/winston/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/with-theme/check-3/r/react/build.sbt
+++ b/tests/with-theme/check-3/r/react/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "react"
-version := "0.0-unknown-2c133c"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-ec3f95"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/with-theme/check-3/r/react/project/build.properties
+++ b/tests/with-theme/check-3/r/react/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/with-theme/check-3/r/react/project/plugins.sbt
+++ b/tests/with-theme/check-3/r/react/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/with-theme/check-3/s/std/build.sbt
+++ b/tests/with-theme/check-3/s/std/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.scalablytyped"
 name := "std"
-version := "0.0-unknown-bb58fa"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-c3355a"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")

--- a/tests/with-theme/check-3/s/std/project/build.properties
+++ b/tests/with-theme/check-3/s/std/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/with-theme/check-3/s/std/project/plugins.sbt
+++ b/tests/with-theme/check-3/s/std/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/with-theme/check-3/w/with-theme/build.sbt
+++ b/tests/with-theme/check-3/w/with-theme/build.sbt
@@ -1,12 +1,12 @@
 organization := "org.scalablytyped"
 name := "with-theme"
-version := "0.0-unknown-76a0e4"
-scalaVersion := "3.3.1"
+version := "0.0-unknown-c7e37d"
+scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(
   "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
-  "org.scalablytyped" %%% "react" % "0.0-unknown-2c133c",
-  "org.scalablytyped" %%% "std" % "0.0-unknown-bb58fa")
+  "org.scalablytyped" %%% "react" % "0.0-unknown-ec3f95",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-c3355a")
 publishArtifact in packageDoc := false
 scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/with-theme/check-3/w/with-theme/project/build.properties
+++ b/tests/with-theme/check-3/w/with-theme/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.6

--- a/tests/with-theme/check-3/w/with-theme/project/plugins.sbt
+++ b/tests/with-theme/check-3/w/with-theme/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")


### PR DESCRIPTION
Updates various dependency versions and refreshes scala definitions.

## Version updates:
- **sbt**: 1.9.6 → 1.11.6
- **Scala 2.13**: 2.13.12 → 2.13.16
- **Scala 3**: 3.3.1 → 3.3.6
- **Scala.js**: 1.11.0 → 1.20.1
- **scalajs-dom**: 2.3.0 → 2.8.1
- **slinky-web**: 0.7.2 → 0.7.5
- **slinky-native**: 0.7.2 → 0.7.5
- **scalajs-react**: 2.1.1 → 2.1.3

Also updates all test project configurations to use the new versions.