### PR TITLE
ci: Use macOS large runners for better performance

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-          - os: macos-latest
+          - os: macos-latest-large
           - os: windows-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

Switch from `macos-latest` to `macos-latest-large` in CI workflow to improve build performance.

## Changes

- Updated `.github/workflows/ci-build.yml` to use `macos-latest-large` runners

## Benefits

The large runners provide:
- **6 vCPUs** instead of 3 (2x improvement)
- **14 GB RAM** instead of 7 GB (2x improvement)  
- **Apple Silicon M1 processors** for better performance

This should significantly reduce CI build times on macOS, helping PRs merge faster.

## Notes

- Large runners are available for public repos at no additional cost
- The change only affects the macOS build matrix entry
- Ubuntu and Windows runners remain unchanged

## Commit Details

**ci: Use macOS large runners for better performance**

Switch from macos-latest to macos-latest-large in CI workflow to take advantage of:
- 6 vCPUs instead of 3
- 14 GB RAM instead of 7 GB
- Apple Silicon M1 processors

This should significantly improve build times on macOS CI runs.