### PR TITLE
fix: Remove unavailable library from demo set

### DIFF
--- a/importer/src/main/scala/org/scalablytyped/converter/internal/importer/Libraries.scala
+++ b/importer/src/main/scala/org/scalablytyped/converter/internal/importer/Libraries.scala
@@ -650,7 +650,6 @@ object Libraries {
     "react-native",
     "react-native-gesture-handler",
     "react-native-vector-icons",
-    "react-navigation",
     "react-navigation-drawer",
     "react-navigation-stack",
     "react-redux",


### PR DESCRIPTION
## Summary

Remove a library from the demo set that no longer has available TypeScript type definitions.

## Problem

The demo set included a library that we don't have types for, causing the demo conversion to fail or produce incomplete results.

## Solution

Remove the problematic library from the demo set configuration to ensure clean demo runs.

## Impact

- Demo set will run successfully without errors
- More reliable testing and demonstration of the converter
- Cleaner CI builds when running demo conversions

## Testing

The demo set can now be run with:
```bash
sbt "importer/runMain org.scalablytyped.converter.Main -demoSet"
```