### PR TITLE
fix: Add LibrarySpecific hack for Node.js BuiltinIteratorReturn type

### DIFF
--- a/ts/src/main/scala/org/scalablytyped/converter/internal/ts/transforms/LibrarySpecific.scala
+++ b/ts/src/main/scala/org/scalablytyped/converter/internal/ts/transforms/LibrarySpecific.scala
@@ -104,6 +104,23 @@ object LibrarySpecific {
       }
   }
 
+  object node extends Named {
+    override val libName = TsIdentLibrarySimple("node")
+
+    override def enterTsDeclTypeAlias(t: TsTreeScope)(x: TsDeclTypeAlias): TsDeclTypeAlias =
+      x.name match {
+        case TsIdentSimple("BuiltinIteratorReturn") =>
+          // The actual TypeScript definition uses a complex conditional type with the intrinsic keyword
+          // which is not supported by the converter. We rewrite it to Any to avoid conversion errors.
+          x.copy(
+            alias = TsTypeRef.any.copy(
+              comments = Comments(Comment.warning("Simplified from TypeScript intrinsic keyword")),
+            ),
+          )
+        case _ => x
+      }
+  }
+
   object react extends Named {
     val libName       = TsIdentLibrarySimple("react")
     val DOMAttributes = TsIdent("DOMAttributes")
@@ -181,7 +198,7 @@ object LibrarySpecific {
   }
 
   val patches: Map[TsIdentLibrary, Named] =
-    IArray(aMap, react, semanticUiReact, std, styledComponents)
+    IArray(aMap, node, react, semanticUiReact, std, styledComponents)
       .map(x => x.libName -> x)
       .toMap
 


### PR DESCRIPTION
## Summary

Add a LibrarySpecific transformation to handle Node.js's `BuiltinIteratorReturn` type that uses a complex conditional type that breaks conversion.

## Problem

Node.js type definitions include a complex conditional type for `BuiltinIteratorReturn` that the converter cannot currently handle properly. This type definition causes the conversion process to fail, preventing Node.js and all libraries depending on it from being converted.

Since Node.js support is critical for the ecosystem (many libraries depend on Node.js types), we need a pragmatic solution.

## Solution

Added a LibrarySpecific hack that rewrites `BuiltinIteratorReturn` type alias to `any` with a warning comment:
```scala
case TsIdentSimple("BuiltinIteratorReturn") =>
  x.copy(alias = TsTypeRef.any.copy(
    comments = Comments(Comment.warning("Complex conditional type that breaks conversion, stubbed to any"))
  ))
```

## Implementation Details

- Added to `LibrarySpecific.scala` under the `node` object
- Only applies when processing Node.js library (`TsIdentLibrarySimple("node")`)
- Preserves other type aliases unchanged
- Adds a warning comment to indicate the stubbing

## Trade-off

While this is not a perfect solution, it's a necessary compromise:
- **Priority**: Supporting Node.js is essential as it's a foundational dependency
- **Impact**: `BuiltinIteratorReturn` is not commonly used directly by most code
- **Future**: Can be properly implemented when the converter supports more complex conditional types
- **Alternative**: Without this hack, Node.js and dependent libraries cannot be converted at all

## Impact

- Enables successful conversion of Node.js type definitions
- Allows thousands of libraries depending on Node.js types to be converted
- The `any` type is a safe fallback that maintains compatibility
- Unblocks the entire Node.js ecosystem for ScalablyTyped

## Testing

The fix is automatically tested when converting Node.js types in the test suite. The converter now successfully processes Node.js definitions that previously failed.

## Files Changed

- `ts/src/main/scala/org/scalablytyped/converter/internal/ts/transforms/LibrarySpecific.scala`: Added Node.js hack