### PR TITLE
fix: handle transitive dependencies in TreeScope

### DIFF
--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/LibScalaJs.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/LibScalaJs.scala
@@ -3,6 +3,7 @@ package importer
 
 import org.scalablytyped.converter.internal.scalajs.{Name, PackageTree, TreeScope}
 
+import scala.collection.mutable
 import scala.collection.immutable.SortedMap
 
 case class LibScalaJs(source: LibTsSource)(
@@ -16,6 +17,20 @@ case class LibScalaJs(source: LibTsSource)(
 ) extends TreeScope.Lib
 
 object LibScalaJs {
+  def allDependencies(deps: Iterable[LibScalaJs]): Map[Name, PackageTree] = {
+    val seen = mutable.Set.empty[Name]
+    val acc  = Map.newBuilder[Name, PackageTree]
+
+    def go(lib: LibScalaJs): Unit =
+      if (seen.add(lib.scalaName)) {
+        acc += lib.scalaName -> lib.packageTree
+        lib.dependencies.values.foreach(go)
+      }
+
+    deps.foreach(go)
+    acc.result()
+  }
+
   object Unpack {
     def unapply(m: SortedMap[LibTsSource, LibScalaJs]): Some[SortedMap[LibTsSource, LibScalaJs]] =
       Some(apply(m))

--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/Phase2ToScalaJs.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/Phase2ToScalaJs.scala
@@ -49,7 +49,7 @@ class Phase2ToScalaJs(
 
       val scope = new TreeScope.Root(
         libName       = scalaName,
-        _dependencies = scalaDeps.map { case (_, l) => l.scalaName -> l.packageTree },
+        _dependencies = LibScalaJs.allDependencies(scalaDeps.values),
         logger        = logger,
         pedantic      = pedantic,
         outputPkg     = outputPkg,

--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/Phase3Compile.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/Phase3Compile.scala
@@ -54,7 +54,7 @@ class Phase3Compile(
       case PublishedSbtProject.Unpack(deps) =>
         val scope = new TreeScope.Root(
           libName       = lib.scalaName,
-          _dependencies = lib.dependencies.map { case (_, lib) => lib.scalaName -> lib.packageTree },
+          _dependencies = LibScalaJs.allDependencies(lib.dependencies.values),
           logger        = logger,
           pedantic      = false,
           outputPkg     = flavour.outputPkg,

--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/PhaseFlavour.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/PhaseFlavour.scala
@@ -23,7 +23,7 @@ class PhaseFlavour(flavour: FlavourImpl, maybePrivateWithin: Option[Name])
     getDeps(SortedSet.empty[LibTsSource] ++ (lib.dependencies.keys: Iterable[LibTsSource])).map { deps =>
       val originalScope = new TreeScope.Root(
         libName       = lib.scalaName,
-        _dependencies = lib.dependencies.map { case (_, lib) => lib.scalaName -> lib.packageTree },
+        _dependencies = LibScalaJs.allDependencies(lib.dependencies.values),
         logger        = logger,
         pedantic      = false,
         outputPkg     = flavour.outputPkg,

--- a/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterTest.scala
+++ b/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterTest.scala
@@ -71,6 +71,7 @@ trait ImporterTest extends AnyFunSuite with ImporterHarness with ParallelTestExe
   test("recharts")(assertImportsOk("recharts", pedantic                             = true))
   test("firebase")(assertImportsOk("firebase", pedantic                             = true))
   test("prisma")(assertImportsOk("prisma", pedantic                                 = true))
+  test("aws-middleware-s3")(assertImportsOk("aws-middleware-s3", pedantic           = false))
 
   test("material-ui-slinky")(
     assertImportsOk("material-ui", pedantic = true, flavour = Slinky),

--- a/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterTest.scala
+++ b/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterTest.scala
@@ -71,7 +71,7 @@ trait ImporterTest extends AnyFunSuite with ImporterHarness with ParallelTestExe
   test("recharts")(assertImportsOk("recharts", pedantic                             = true))
   test("firebase")(assertImportsOk("firebase", pedantic                             = true))
   test("prisma")(assertImportsOk("prisma", pedantic                                 = true))
-  test("aws-middleware-s3")(assertImportsOk("aws-middleware-s3", pedantic           = false))
+  test("aws-middleware-s3")(assertImportsOk("aws-middleware-s3", pedantic           = true))
 
   test("material-ui-slinky")(
     assertImportsOk("material-ui", pedantic = true, flavour = Slinky),

--- a/tests/aws-middleware-s3/check-3/a/aws-sdk__core/build.sbt
+++ b/tests/aws-middleware-s3/check-3/a/aws-sdk__core/build.sbt
@@ -1,0 +1,13 @@
+organization := "org.scalablytyped"
+name := "aws-sdk__core"
+version := "0.0-unknown-f5f3a5"
+scalaVersion := "3.3.6"
+enablePlugins(ScalaJSPlugin)
+libraryDependencies ++= Seq(
+  "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
+  "org.scalablytyped" %%% "smithy__core" % "0.0-unknown-4fb756",
+  "org.scalablytyped" %%% "smithy__types" % "0.0-unknown-357e54",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-a9a9f5")
+publishArtifact in packageDoc := false
+scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
+licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/aws-middleware-s3/check-3/a/aws-sdk__core/project/build.properties
+++ b/tests/aws-middleware-s3/check-3/a/aws-sdk__core/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.6

--- a/tests/aws-middleware-s3/check-3/a/aws-sdk__core/project/plugins.sbt
+++ b/tests/aws-middleware-s3/check-3/a/aws-sdk__core/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/aws-middleware-s3/check-3/a/aws-sdk__core/readme.md
+++ b/tests/aws-middleware-s3/check-3/a/aws-sdk__core/readme.md
@@ -1,0 +1,15 @@
+
+# Scala.js typings for aws-sdk__core
+
+
+
+
+## Note
+This library has been generated from typescript code from first party type definitions.
+
+Provided with :purple_heart: from [ScalablyTyped](https://github.com/oyvindberg/ScalablyTyped)
+
+## Usage
+See [the main readme](../../readme.md) for instructions.
+
+

--- a/tests/aws-middleware-s3/check-3/a/aws-sdk__core/src/main/scala/typings/awsSdkCore/awsSdkCoreRequire.scala
+++ b/tests/aws-middleware-s3/check-3/a/aws-sdk__core/src/main/scala/typings/awsSdkCore/awsSdkCoreRequire.scala
@@ -1,0 +1,11 @@
+package typings.awsSdkCore
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+/* This can be used to `require` the library as a side effect.
+  If it is a global library this will make scalajs-bundler include it */
+@JSImport("@aws-sdk/core", JSImport.Namespace)
+@js.native
+object awsSdkCoreRequire extends StObject

--- a/tests/aws-middleware-s3/check-3/a/aws-sdk__core/src/main/scala/typings/awsSdkCore/protocolsMod.scala
+++ b/tests/aws-middleware-s3/check-3/a/aws-sdk__core/src/main/scala/typings/awsSdkCore/protocolsMod.scala
@@ -1,0 +1,13 @@
+package typings.awsSdkCore
+
+import typings.smithyCore.protocolsMod.HttpProtocol
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object protocolsMod {
+  
+  @JSImport("@aws-sdk/core/protocols", "AwsRestXmlProtocol")
+  @js.native
+  open class AwsRestXmlProtocol () extends HttpProtocol
+}

--- a/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/build.sbt
+++ b/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "aws-sdk__middleware-sdk-s3"
-version := "0.0-unknown-ec9690"
+version := "0.0-unknown-737b86"
 scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/build.sbt
+++ b/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/build.sbt
@@ -1,0 +1,14 @@
+organization := "org.scalablytyped"
+name := "aws-sdk__middleware-sdk-s3"
+version := "0.0-unknown-ec9690"
+scalaVersion := "3.3.6"
+enablePlugins(ScalaJSPlugin)
+libraryDependencies ++= Seq(
+  "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
+  "org.scalablytyped" %%% "aws-sdk__core" % "0.0-unknown-f5f3a5",
+  "org.scalablytyped" %%% "smithy__core" % "0.0-unknown-4fb756",
+  "org.scalablytyped" %%% "smithy__types" % "0.0-unknown-357e54",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-a9a9f5")
+publishArtifact in packageDoc := false
+scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
+licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/project/build.properties
+++ b/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.6

--- a/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/project/plugins.sbt
+++ b/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/readme.md
+++ b/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/readme.md
@@ -1,0 +1,15 @@
+
+# Scala.js typings for aws-sdk__middleware-sdk-s3
+
+
+
+
+## Note
+This library has been generated from typescript code from first party type definitions.
+
+Provided with :purple_heart: from [ScalablyTyped](https://github.com/oyvindberg/ScalablyTyped)
+
+## Usage
+See [the main readme](../../readme.md) for instructions.
+
+

--- a/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/src/main/scala/typings/awsSdkMiddlewareSdkS3/awsSdkMiddlewareSdkS3Require.scala
+++ b/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/src/main/scala/typings/awsSdkMiddlewareSdkS3/awsSdkMiddlewareSdkS3Require.scala
@@ -1,0 +1,11 @@
+package typings.awsSdkMiddlewareSdkS3
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+/* This can be used to `require` the library as a side effect.
+  If it is a global library this will make scalajs-bundler include it */
+@JSImport("@aws-sdk/middleware-sdk-s3", JSImport.Namespace)
+@js.native
+object awsSdkMiddlewareSdkS3Require extends StObject

--- a/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/src/main/scala/typings/awsSdkMiddlewareSdkS3/distTypesProtocolS3RestXmlProtocolMod.scala
+++ b/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/src/main/scala/typings/awsSdkMiddlewareSdkS3/distTypesProtocolS3RestXmlProtocolMod.scala
@@ -1,0 +1,16 @@
+package typings.awsSdkMiddlewareSdkS3
+
+import typings.awsSdkCore.protocolsMod.AwsRestXmlProtocol
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object distTypesProtocolS3RestXmlProtocolMod {
+  
+  @JSImport("@aws-sdk/middleware-sdk-s3/dist-types/protocol/S3RestXmlProtocol", "S3RestXmlProtocol")
+  @js.native
+  open class S3RestXmlProtocol () extends AwsRestXmlProtocol {
+    
+    def serializeRequest(): js.Promise[Any] = js.native
+  }
+}

--- a/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/src/main/scala/typings/awsSdkMiddlewareSdkS3/distTypesProtocolS3RestXmlProtocolMod.scala
+++ b/tests/aws-middleware-s3/check-3/a/aws-sdk__middleware-sdk-s3/src/main/scala/typings/awsSdkMiddlewareSdkS3/distTypesProtocolS3RestXmlProtocolMod.scala
@@ -9,8 +9,5 @@ object distTypesProtocolS3RestXmlProtocolMod {
   
   @JSImport("@aws-sdk/middleware-sdk-s3/dist-types/protocol/S3RestXmlProtocol", "S3RestXmlProtocol")
   @js.native
-  open class S3RestXmlProtocol () extends AwsRestXmlProtocol {
-    
-    def serializeRequest(): js.Promise[Any] = js.native
-  }
+  open class S3RestXmlProtocol () extends AwsRestXmlProtocol
 }

--- a/tests/aws-middleware-s3/check-3/s/smithy__core/build.sbt
+++ b/tests/aws-middleware-s3/check-3/s/smithy__core/build.sbt
@@ -1,0 +1,12 @@
+organization := "org.scalablytyped"
+name := "smithy__core"
+version := "0.0-unknown-4fb756"
+scalaVersion := "3.3.6"
+enablePlugins(ScalaJSPlugin)
+libraryDependencies ++= Seq(
+  "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
+  "org.scalablytyped" %%% "smithy__types" % "0.0-unknown-357e54",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-a9a9f5")
+publishArtifact in packageDoc := false
+scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
+licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/aws-middleware-s3/check-3/s/smithy__core/project/build.properties
+++ b/tests/aws-middleware-s3/check-3/s/smithy__core/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.6

--- a/tests/aws-middleware-s3/check-3/s/smithy__core/project/plugins.sbt
+++ b/tests/aws-middleware-s3/check-3/s/smithy__core/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/aws-middleware-s3/check-3/s/smithy__core/readme.md
+++ b/tests/aws-middleware-s3/check-3/s/smithy__core/readme.md
@@ -1,0 +1,15 @@
+
+# Scala.js typings for smithy__core
+
+
+
+
+## Note
+This library has been generated from typescript code from first party type definitions.
+
+Provided with :purple_heart: from [ScalablyTyped](https://github.com/oyvindberg/ScalablyTyped)
+
+## Usage
+See [the main readme](../../readme.md) for instructions.
+
+

--- a/tests/aws-middleware-s3/check-3/s/smithy__core/src/main/scala/typings/smithyCore/protocolsMod.scala
+++ b/tests/aws-middleware-s3/check-3/s/smithy__core/src/main/scala/typings/smithyCore/protocolsMod.scala
@@ -1,0 +1,19 @@
+package typings.smithyCore
+
+import typings.smithyTypes.mod.ClientProtocol
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object protocolsMod {
+  
+  /* note: abstract class */ @JSImport("@smithy/core/protocols", "HttpProtocol")
+  @js.native
+  open class HttpProtocol ()
+    extends StObject
+       with ClientProtocol {
+    
+    /* CompleteClass */
+    override def serializeRequest(): js.Promise[Any] = js.native
+  }
+}

--- a/tests/aws-middleware-s3/check-3/s/smithy__core/src/main/scala/typings/smithyCore/smithyCoreRequire.scala
+++ b/tests/aws-middleware-s3/check-3/s/smithy__core/src/main/scala/typings/smithyCore/smithyCoreRequire.scala
@@ -1,0 +1,11 @@
+package typings.smithyCore
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+/* This can be used to `require` the library as a side effect.
+  If it is a global library this will make scalajs-bundler include it */
+@JSImport("@smithy/core", JSImport.Namespace)
+@js.native
+object smithyCoreRequire extends StObject

--- a/tests/aws-middleware-s3/check-3/s/smithy__types/build.sbt
+++ b/tests/aws-middleware-s3/check-3/s/smithy__types/build.sbt
@@ -1,0 +1,11 @@
+organization := "org.scalablytyped"
+name := "smithy__types"
+version := "0.0-unknown-357e54"
+scalaVersion := "3.3.6"
+enablePlugins(ScalaJSPlugin)
+libraryDependencies ++= Seq(
+  "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-a9a9f5")
+publishArtifact in packageDoc := false
+scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
+licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/aws-middleware-s3/check-3/s/smithy__types/project/build.properties
+++ b/tests/aws-middleware-s3/check-3/s/smithy__types/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.6

--- a/tests/aws-middleware-s3/check-3/s/smithy__types/project/plugins.sbt
+++ b/tests/aws-middleware-s3/check-3/s/smithy__types/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/aws-middleware-s3/check-3/s/smithy__types/readme.md
+++ b/tests/aws-middleware-s3/check-3/s/smithy__types/readme.md
@@ -1,0 +1,15 @@
+
+# Scala.js typings for smithy__types
+
+
+
+
+## Note
+This library has been generated from typescript code from first party type definitions.
+
+Provided with :purple_heart: from [ScalablyTyped](https://github.com/oyvindberg/ScalablyTyped)
+
+## Usage
+See [the main readme](../../readme.md) for instructions.
+
+

--- a/tests/aws-middleware-s3/check-3/s/smithy__types/src/main/scala/typings/smithyTypes/mod.scala
+++ b/tests/aws-middleware-s3/check-3/s/smithy__types/src/main/scala/typings/smithyTypes/mod.scala
@@ -1,0 +1,26 @@
+package typings.smithyTypes
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object mod {
+  
+  trait ClientProtocol extends StObject {
+    
+    def serializeRequest(): js.Promise[Any]
+  }
+  object ClientProtocol {
+    
+    inline def apply(serializeRequest: () => js.Promise[Any]): ClientProtocol = {
+      val __obj = js.Dynamic.literal(serializeRequest = js.Any.fromFunction0(serializeRequest))
+      __obj.asInstanceOf[ClientProtocol]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: ClientProtocol] (val x: Self) extends AnyVal {
+      
+      inline def setSerializeRequest(value: () => js.Promise[Any]): Self = StObject.set(x, "serializeRequest", js.Any.fromFunction0(value))
+    }
+  }
+}

--- a/tests/aws-middleware-s3/check-3/s/smithy__types/src/main/scala/typings/smithyTypes/smithyTypesRequire.scala
+++ b/tests/aws-middleware-s3/check-3/s/smithy__types/src/main/scala/typings/smithyTypes/smithyTypesRequire.scala
@@ -1,0 +1,11 @@
+package typings.smithyTypes
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+/* This can be used to `require` the library as a side effect.
+  If it is a global library this will make scalajs-bundler include it */
+@JSImport("@smithy/types", JSImport.Namespace)
+@js.native
+object smithyTypesRequire extends StObject

--- a/tests/aws-middleware-s3/check-3/s/std/build.sbt
+++ b/tests/aws-middleware-s3/check-3/s/std/build.sbt
@@ -1,0 +1,10 @@
+organization := "org.scalablytyped"
+name := "std"
+version := "0.0-unknown-a9a9f5"
+scalaVersion := "3.3.6"
+enablePlugins(ScalaJSPlugin)
+libraryDependencies ++= Seq(
+  "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")
+publishArtifact in packageDoc := false
+scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
+licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/aws-middleware-s3/check-3/s/std/project/build.properties
+++ b/tests/aws-middleware-s3/check-3/s/std/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.6

--- a/tests/aws-middleware-s3/check-3/s/std/project/plugins.sbt
+++ b/tests/aws-middleware-s3/check-3/s/std/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/aws-middleware-s3/check-3/s/std/readme.md
+++ b/tests/aws-middleware-s3/check-3/s/std/readme.md
@@ -1,0 +1,15 @@
+
+# Scala.js typings for std
+
+
+
+
+## Note
+This library has been generated from typescript code from first party type definitions.
+
+Provided with :purple_heart: from [ScalablyTyped](https://github.com/oyvindberg/ScalablyTyped)
+
+## Usage
+See [the main readme](../../readme.md) for instructions.
+
+

--- a/tests/aws-middleware-s3/check-3/s/std/src/main/scala/typings/std/Promise.scala
+++ b/tests/aws-middleware-s3/check-3/s/std/src/main/scala/typings/std/Promise.scala
@@ -1,0 +1,18 @@
+package typings.std
+
+import scala.concurrent.Future
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+trait Promise[T] extends StObject
+object Promise {
+  
+  @scala.inline
+  implicit open class PromiseOps[T] (val promise: Promise[T]) extends AnyVal {
+    
+    def toFuture: Future[T] = toPromise.toFuture
+    
+    def toPromise: js.Promise[T] = promise.asInstanceOf[js.Promise[T]]
+  }
+}

--- a/tests/aws-middleware-s3/check-3/s/std/src/main/scala/typings/std/stdRequire.scala
+++ b/tests/aws-middleware-s3/check-3/s/std/src/main/scala/typings/std/stdRequire.scala
@@ -1,0 +1,11 @@
+package typings.std
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+/* This can be used to `require` the library as a side effect.
+  If it is a global library this will make scalajs-bundler include it */
+@JSImport("std", JSImport.Namespace)
+@js.native
+object stdRequire extends StObject

--- a/tests/aws-middleware-s3/in/@aws-sdk/core/protocols.d.ts
+++ b/tests/aws-middleware-s3/in/@aws-sdk/core/protocols.d.ts
@@ -1,0 +1,3 @@
+import { HttpProtocol } from "@smithy/core/protocols";
+
+export declare class AwsRestXmlProtocol extends HttpProtocol {}

--- a/tests/aws-middleware-s3/in/@aws-sdk/middleware-sdk-s3/dist-types/protocol/S3RestXmlProtocol.d.ts
+++ b/tests/aws-middleware-s3/in/@aws-sdk/middleware-sdk-s3/dist-types/protocol/S3RestXmlProtocol.d.ts
@@ -1,0 +1,5 @@
+import { AwsRestXmlProtocol } from "@aws-sdk/core/protocols";
+
+export declare class S3RestXmlProtocol extends AwsRestXmlProtocol {
+    serializeRequest(): Promise<any>;
+}

--- a/tests/aws-middleware-s3/in/@smithy/core/protocols.d.ts
+++ b/tests/aws-middleware-s3/in/@smithy/core/protocols.d.ts
@@ -1,0 +1,5 @@
+import type { ClientProtocol } from "@smithy/types";
+
+export declare abstract class HttpProtocol implements ClientProtocol {
+    abstract serializeRequest(): Promise<any>;
+}

--- a/tests/aws-middleware-s3/in/@smithy/types/index.d.ts
+++ b/tests/aws-middleware-s3/in/@smithy/types/index.d.ts
@@ -1,0 +1,3 @@
+export interface ClientProtocol {
+    serializeRequest(): Promise<any>;
+}

--- a/tests/aws-middleware-s3/in/stdlib.d.ts
+++ b/tests/aws-middleware-s3/in/stdlib.d.ts
@@ -1,0 +1,1 @@
+declare interface Promise<T> {}


### PR DESCRIPTION
## Summary

This PR fixes #747, where converting `@aws-sdk/middleware-sdk-s3` generated Scala code that failed to compile with an `inherits conflicting members` error.

The root cause was that `TreeScope` only considered direct dependencies. In this case, methods inherited through transitive dependencies were not visible during generation, so the converter emitted members such as `serializeRequest` without recognizing that they should override an inherited definition.

## Changes

- add a reproduction test for `aws-middleware-s3`
- resolve transitive Scala.js dependencies when building `TreeScope`

## Result

With the transitive dependency graph available during generation, the converter no longer emits the conflicting member definition for `S3RestXmlProtocol`

Closes #747.
