### PR TITLE
Map tuple rest elements to js.Array to support @types/node 26

### DIFF
--- a/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/ImportType.scala
+++ b/importer-portable/src/main/scala/org/scalablytyped/converter/internal/importer/ImportType.scala
@@ -217,7 +217,7 @@ class ImportType(stdNames: QualifiedName.StdNames) {
                   IArray.exactlyOne(tpe),
                   ) =>
                 TypeRef(
-                  importName(TsQIdent.Array),
+                  QualifiedName.JsArray,
                   IArray(apply(scope, importName)(TsTypeUnion(rest.map(_.tpe) :+ tpe))).distinct,
                   labelComment(repeatedElem),
                 )

--- a/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterTest.scala
+++ b/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterTest.scala
@@ -63,6 +63,7 @@ trait ImporterTest extends AnyFunSuite with ImporterHarness with ParallelTestExe
   test("firebase-admin")(assertImportsOk("firebase-admin", pedantic                 = true))
   test("properties")(assertImportsOk("properties", pedantic                         = true))
   test("keyof")(assertImportsOk("keyof", pedantic                                   = true))
+  test("tuple-rest")(assertImportsOk("tuple-rest", pedantic                         = true))
   test("antd")(assertImportsOk("antd", pedantic                                     = true))
   test("echarts")(assertImportsOk("echarts", pedantic                               = true))
   test("elasticsearch-js")(assertImportsOk("elasticsearch-js", pedantic             = true))

--- a/tests/tuple-rest/check-3/s/std/build.sbt
+++ b/tests/tuple-rest/check-3/s/std/build.sbt
@@ -1,0 +1,10 @@
+organization := "org.scalablytyped"
+name := "std"
+version := "0.0-unknown-a71d49"
+scalaVersion := "3.3.6"
+enablePlugins(ScalaJSPlugin)
+libraryDependencies ++= Seq(
+  "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")
+publishArtifact in packageDoc := false
+scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
+licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/tuple-rest/check-3/s/std/project/build.properties
+++ b/tests/tuple-rest/check-3/s/std/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.6

--- a/tests/tuple-rest/check-3/s/std/project/plugins.sbt
+++ b/tests/tuple-rest/check-3/s/std/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/tuple-rest/check-3/s/std/readme.md
+++ b/tests/tuple-rest/check-3/s/std/readme.md
@@ -1,0 +1,15 @@
+
+# Scala.js typings for std
+
+
+
+
+## Note
+This library has been generated from typescript code from first party type definitions.
+
+Provided with :purple_heart: from [ScalablyTyped](https://github.com/oyvindberg/ScalablyTyped)
+
+## Usage
+See [the main readme](../../readme.md) for instructions.
+
+

--- a/tests/tuple-rest/check-3/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/tuple-rest/check-3/s/std/src/main/scala/typings/std/Array.scala
@@ -1,0 +1,7 @@
+package typings.std
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+trait Array[T] extends StObject

--- a/tests/tuple-rest/check-3/s/std/src/main/scala/typings/std/package.scala
+++ b/tests/tuple-rest/check-3/s/std/src/main/scala/typings/std/package.scala
@@ -1,0 +1,25 @@
+package typings.std
+
+import org.scalablytyped.runtime.StringDictionary
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+
+/** NOTE: Mapped type definitions are impossible to translate to Scala.
+  * See https://www.typescriptlang.org/docs/handbook/2/mapped-types.html for an intro.
+  * This translation is imprecise and ignores the effect of the type mapping. 
+  * TS definition: {{{
+  {[ P in keyof T ]:? T[P]}
+  }}}
+  */
+type Partial[T] = T
+
+/** NOTE: Mapped type definitions are impossible to translate to Scala.
+  * See https://www.typescriptlang.org/docs/handbook/2/mapped-types.html for an intro.
+  * This translation throws away the known field names. 
+  * TS definition: {{{
+  {[ P in K ]: T}
+  }}}
+  */
+type Record[K /* <: /* keyof any */ String */, T] = StringDictionary[T]

--- a/tests/tuple-rest/check-3/s/std/src/main/scala/typings/std/stdRequire.scala
+++ b/tests/tuple-rest/check-3/s/std/src/main/scala/typings/std/stdRequire.scala
@@ -1,0 +1,11 @@
+package typings.std
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+/* This can be used to `require` the library as a side effect.
+  If it is a global library this will make scalajs-bundler include it */
+@JSImport("std", JSImport.Namespace)
+@js.native
+object stdRequire extends StObject

--- a/tests/tuple-rest/check-3/t/tuple-rest/build.sbt
+++ b/tests/tuple-rest/check-3/t/tuple-rest/build.sbt
@@ -1,0 +1,11 @@
+organization := "org.scalablytyped"
+name := "tuple-rest"
+version := "0.0-unknown-448f75"
+scalaVersion := "3.3.6"
+enablePlugins(ScalaJSPlugin)
+libraryDependencies ++= Seq(
+  "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-a71d49")
+publishArtifact in packageDoc := false
+scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent")
+licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/tuple-rest/check-3/t/tuple-rest/project/build.properties
+++ b/tests/tuple-rest/check-3/t/tuple-rest/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.6

--- a/tests/tuple-rest/check-3/t/tuple-rest/project/plugins.sbt
+++ b/tests/tuple-rest/check-3/t/tuple-rest/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.20.1")

--- a/tests/tuple-rest/check-3/t/tuple-rest/readme.md
+++ b/tests/tuple-rest/check-3/t/tuple-rest/readme.md
@@ -1,0 +1,15 @@
+
+# Scala.js typings for tuple-rest
+
+
+
+
+## Note
+This library has been generated from typescript code from first party type definitions.
+
+Provided with :purple_heart: from [ScalablyTyped](https://github.com/oyvindberg/ScalablyTyped)
+
+## Usage
+See [the main readme](../../readme.md) for instructions.
+
+

--- a/tests/tuple-rest/check-3/t/tuple-rest/src/main/scala/typings/tupleRest/mod.scala
+++ b/tests/tuple-rest/check-3/t/tuple-rest/src/main/scala/typings/tupleRest/mod.scala
@@ -1,0 +1,39 @@
+package typings.tupleRest
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object mod {
+  
+  @JSImport("tuple-rest", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+  
+  object iter {
+    
+    @JSImport("tuple-rest", "iter")
+    @js.native
+    val ^ : js.Any = js.native
+    
+    inline def array(source: Source): js.Array[String] = ^.asInstanceOf[js.Dynamic].applyDynamic("array")(source.asInstanceOf[js.Any]).asInstanceOf[js.Array[String]]
+    
+    inline def compose(
+      /* import warning: parser.TsParser#functionParam Dropping repeated marker of param streams because its type [Source, ...Array<Transform>, Destination] is not an array type */ streams: js.Array[Source | Destination | Transform]
+    ): Destination = ^.asInstanceOf[js.Dynamic].applyDynamic("compose")(streams.asInstanceOf[js.Any]).asInstanceOf[Destination]
+  }
+  
+  inline def pipeline(
+    /* import warning: parser.TsParser#functionParam Dropping repeated marker of param streams because its type [Source, ...Array<Transform>, Destination] is not an array type */ streams: js.Array[Source | Destination | Transform]
+  ): Unit = ^.asInstanceOf[js.Dynamic].applyDynamic("pipeline")(streams.asInstanceOf[js.Any]).asInstanceOf[Unit]
+  
+  @JSImport("tuple-rest", "trailing")
+  @js.native
+  val trailing: js.Array[String | Double] = js.native
+  
+  trait Destination extends StObject
+  
+  trait Source extends StObject
+  
+  trait Transform extends StObject
+}

--- a/tests/tuple-rest/check-3/t/tuple-rest/src/main/scala/typings/tupleRest/tupleRestRequire.scala
+++ b/tests/tuple-rest/check-3/t/tuple-rest/src/main/scala/typings/tupleRest/tupleRestRequire.scala
@@ -1,0 +1,11 @@
+package typings.tupleRest
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+/* This can be used to `require` the library as a side effect.
+  If it is a global library this will make scalajs-bundler include it */
+@JSImport("tuple-rest", JSImport.Namespace)
+@js.native
+object tupleRestRequire extends StObject

--- a/tests/tuple-rest/in/stdlib.d.ts
+++ b/tests/tuple-rest/in/stdlib.d.ts
@@ -1,0 +1,9 @@
+/// <reference no-default-lib="true"/>
+
+interface Array<T>{}
+type Partial<T> = {
+    [P in keyof T]?: T[P];
+};
+type Record<K extends keyof any, T> = {
+    [P in K]: T;
+};

--- a/tests/tuple-rest/in/tuple-rest/index.d.ts
+++ b/tests/tuple-rest/in/tuple-rest/index.d.ts
@@ -1,0 +1,15 @@
+export interface Source {}
+export interface Transform {}
+export interface Destination {}
+
+// rest element in the middle of a tuple
+export declare function pipeline(...streams: [Source, ...Array<Transform>, Destination]): void;
+
+// rest element at the end of a tuple
+export declare const trailing: [string, ...number[]];
+
+// rest element in a member of an object type, with a sibling member named `array`
+export declare const iter: {
+    array(source: Source): Array<string>;
+    compose(...streams: [Source, ...Array<Transform>, Destination]): Destination;
+};


### PR DESCRIPTION
## Problem

Converting the latest `@types/node` (26.5.1) fails in the compile phase with 12 errors like:

```
typings.node.anon.Array does not take type parameters
```

Tuples with a rest element in a non-final position, e.g. `[Source, ...Array<Transform>, Destination]` (used by `stream.pipeline`, `compose`, `promises.finished`), were converted using `importName(TsQIdent.Array)`. That yields the unqualified one-part name `Array`, which is printed as a bare `Array[...]`:

- Normally it binds to `scala.Array`, which is the wrong type for a JS facade. It compiled, but it was wrong. In node 26 another 15 files had this.
- node 26 adds `stream/iter`, whose anonymous object type (first member `array`) is extracted as `typings.node.anon.Array`. Inside the `anon` package the bare `Array` resolves to that trait, so compilation fails.

## Fix

Use `QualifiedName.JsArray` directly. This matches how the regular `Array`/`std.Array` mapping is handled for non-inheritance positions.

## Tests

- New `tuple-rest` snapshot test (Scala 3). It fails without the fix in pedantic mode with `Couldn't resolve IArray(Name(Array))`, and passes with it.
- Full `ImporterTest3` suite passes; no existing snapshots changed.
- Converting `@types/node@26.5.1` through the CLI now succeeds for `node`, `std` and `undici-types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLJ6KPxFVco7fXsDVT2FhF
