### PR TITLE
Identify React components behind aliased intersections and generic default exports

### DIFF
--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/IdentifyReactComponents.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/IdentifyReactComponents.scala
@@ -196,6 +196,8 @@ class IdentifyReactComponents(
 
     val flattenedParams = method.params.flatten
 
+    val jsName = jsNameOf(method)
+
     flattenedParams.length match {
       /* optional props and context */
       case 0 | 1 | 2 =>
@@ -204,8 +206,13 @@ class IdentifyReactComponents(
           case _ => true
         }
         val propsRef = reactNames.unpackedProps(flattenedParams.headOption.map(_.tpe).getOrElse(TypeRef.JsObject))
+        /* like mui's `export default function TextField(...)` in `@mui/material/TextField/TextField` */
+        def ownerIsJsModule = owner.annotations.exists {
+          case Annotation.JsImport(_, Imported.Namespace, _) => true
+          case _                                             => false
+        }
         def validName =
-          isUpper(method.name) || (Unnamed(method.name) && (isUpper(owner.name) || Unnamed(owner.name) || owner.name === Name.mod))
+          isUpper(method.name) || (Unnamed(jsName) && (isUpper(owner.name) || Unnamed(owner.name) || owner.name === Name.mod || ownerIsJsModule))
 
         if (!validName || !isTopLevel || !method.isNative) None
         else
@@ -226,7 +233,7 @@ class IdentifyReactComponents(
                 Component(
                   location      = Right(locationFrom(scope)),
                   scalaRef      = TypeRef(method.codePath, TypeParamTree.asTypeArgs(method.tparams), NoComments),
-                  fullName      = componentName(method.annotations, QualifiedName(IArray(method.name))),
+                  fullName      = componentName(method.annotations, QualifiedName(IArray(jsName))),
                   tparams       = method.tparams,
                   propsRef      = propsRef,
                   componentType = ComponentType.Function,
@@ -244,33 +251,33 @@ class IdentifyReactComponents(
       restAsPackage: PackageTree,
   )
 
+  /* also split intersections hidden behind type aliases, like
+   * mui's `type ExtendButtonBase<M> = ((props: ...) => JSX.Element) & OverridableComponent<M>` */
+  def flattenIntersections(scope: TreeScope)(tpe: TypeRef): IArray[TypeRef] =
+    tpe match {
+      case TypeRef.Intersection(types, _) => types.flatMap(flattenIntersections(scope))
+      case other =>
+        FollowAliases(scope)(other) match {
+          case TypeRef.Intersection(types, _) => types.flatMap(flattenIntersections(scope))
+          case _                              => IArray(other)
+        }
+    }
+
   def separateContainer(c: ContainerTree, scope: TreeScope): SeparatedContainer = {
     val parentRefs: IArray[TypeRef] = {
       val fromNamespaced: IArray[TypeRef] = {
         c.index
           .getOrElse(Name.namespaced, Empty)
           .collectFirst {
-            case m: ModuleTree =>
-              m.parents.flatMap {
-                case TypeRef.Intersection(types, _) => types
-                case tpe                            => IArray(tpe)
-              }
-            case f: FieldTree =>
-              f.tpe match {
-                case TypeRef.Intersection(types, _) => types
-                case other                          => IArray(other)
-              }
+            case m: ModuleTree => m.parents.flatMap(flattenIntersections(scope))
+            case f: FieldTree  => flattenIntersections(scope)(f.tpe)
           }
           .getOrElse(Empty)
       }
 
       val normal = c match {
         case _: PackageTree => Empty
-        case x: ModuleTree =>
-          x.parents.flatMap {
-            case TypeRef.Intersection(types, _) => types
-            case other                          => IArray(other)
-          }
+        case x: ModuleTree  => x.parents.flatMap(flattenIntersections(scope))
       }
 
       fromNamespaced ++ normal
@@ -290,7 +297,7 @@ class IdentifyReactComponents(
     val separated = separateContainer(c, scope)
 
     val componentOpt: Option[Component] = {
-      def fromParents = separated.parentRefs.firstDefined { tpe =>
+      def fromParents(f: FieldTree => Option[Component]) = separated.parentRefs.firstDefined { tpe =>
         val asField = FieldTree(
           annotations = c.annotations,
           level       = ProtectionLevel.Public,
@@ -302,11 +309,15 @@ class IdentifyReactComponents(
           comments    = c.comments,
           codePath    = c.codePath,
         )
-        maybeFieldComponent(asField, c, scope)
+        f(asField)
       }
       def fromApplies = separated.applyMembers.firstDefined(a => maybeMethodComponent(a, c, scope / a))
 
-      fromParents.orElse(fromApplies)
+      /* a bare function parent is tried last. mui's `ExtendButtonBase` is an intersection of a function which requires
+       * `href` and an `OverridableComponent`, and we want the latter */
+      fromParents(field => componentFromType(field, scope))
+        .orElse(fromApplies)
+        .orElse(fromParents(field => componentFromFunction(field, c, scope)))
     }
 
     componentOpt match {
@@ -318,7 +329,7 @@ class IdentifyReactComponents(
     }
   }
 
-  def maybeFieldComponent(field: FieldTree, owner: ContainerTree, scope: TreeScope): Option[Component] = {
+  def componentFromType(field: FieldTree, scope: TreeScope): Option[Component] = {
     def pointsAtComponentType(scope: TreeScope, current: TypeRef): Option[PropsRef] =
       reactNames.isComponent(current).orElse {
         scope
@@ -336,7 +347,7 @@ class IdentifyReactComponents(
           }
       }
 
-    val fieldResult = pointsAtComponentType(scope, field.tpe).map(propsRef =>
+    pointsAtComponentType(scope, field.tpe).map(propsRef =>
       Component(
         location      = Right(locationFrom(scope)),
         scalaRef      = TypeRef(field.codePath),
@@ -347,36 +358,36 @@ class IdentifyReactComponents(
         nested        = Empty,
       ),
     )
-    def isAliasToFC: Option[Component] =
-      FollowAliases(scope)(field.tpe) match {
-        case TypeRef.JsFunction(paramTypes, ret) =>
-          val params =
-            paramTypes.map(tpe =>
-              ParamTree(Name.dummy, isImplicit = false, isVal = false, tpe, NotImplemented, NoComments),
-            )
-
-          maybeMethodComponent(
-            MethodTree(
-              annotations = field.annotations,
-              level       = ProtectionLevel.Public,
-              name        = field.name,
-              tparams     = Empty,
-              params      = IArray(params),
-              impl        = field.impl,
-              resultType  = ret,
-              isOverride  = false,
-              comments    = field.comments,
-              codePath    = field.codePath,
-              isImplicit  = false,
-            ),
-            owner,
-            scope,
-          )
-        case _ => None
-      }
-
-    fieldResult.orElse(isAliasToFC)
   }
+
+  /* a field whose type is (an alias to) a function returning an element */
+  def componentFromFunction(field: FieldTree, owner: ContainerTree, scope: TreeScope): Option[Component] =
+    FollowAliases(scope)(field.tpe) match {
+      case TypeRef.JsFunction(paramTypes, ret) =>
+        val params =
+          paramTypes.map(tpe =>
+            ParamTree(Name.dummy, isImplicit = false, isVal = false, tpe, NotImplemented, NoComments),
+          )
+
+        maybeMethodComponent(
+          MethodTree(
+            annotations = field.annotations,
+            level       = ProtectionLevel.Public,
+            name        = field.name,
+            tparams     = Empty,
+            params      = IArray(params),
+            impl        = field.impl,
+            resultType  = ret,
+            isOverride  = false,
+            comments    = field.comments,
+            codePath    = field.codePath,
+            isImplicit  = false,
+          ),
+          owner,
+          scope,
+        )
+      case _ => None
+    }
 
   def maybeClassComponent(cls: ClassTree, scope: TreeScope): Option[Component] =
     if (cls.classType =/= ClassType.Class) None
@@ -431,6 +442,22 @@ class IdentifyReactComponents(
 
   def isUpper(n: Name): Boolean = n.value.head.isUpper
 
+  /* the name on the javascript side. `CombineOverloads` may have renamed a method, like mui's generic
+   * `export default function TextField<Variant>` which ends up as `default_variant`.
+   * The location of `apply` and `namespaced` members points at their owner, so they keep their names */
+  def jsNameOf(tree: Tree): Name =
+    tree match {
+      case x: MemberTree if x.name =/= Name.APPLY && x.name =/= Name.namespaced =>
+        x.annotations
+          .collectFirst {
+            case Annotation.JsName(name)                                   => name
+            case Annotation.JsImport(_, Imported.Default, _)               => Name.Default
+            case Annotation.JsImport(_, Imported.Named(IArray.last(n)), _) => n
+          }
+          .getOrElse(tree.name)
+      case other => other.name
+    }
+
   def locationFrom(scope: TreeScope): LocationAnnotation = {
     var baseLocationOpt: Option[LocationAnnotation] = None
     var after = List.empty[Tree]
@@ -466,24 +493,25 @@ class IdentifyReactComponents(
       (`import`, tree) match {
         case (ann, tree) if tree.name === Name.APPLY => ann
         case (Annotation.JsImport(mod, imported, globalOpt), tree) =>
+          val jsName = jsNameOf(tree)
           val newImported: Imported =
             imported match {
               case Imported.Namespace =>
-                tree.name match {
+                jsName match {
                   case Name.Default => Imported.Default
                   case other        => Imported.Named(IArray(other))
                 }
-              case Imported.Default     => Imported.Named(IArray(Name.Default, tree.name))
-              case Imported.Named(name) => Imported.Named(name :+ tree.name)
+              case Imported.Default     => Imported.Named(IArray(Name.Default, jsName))
+              case Imported.Named(name) => Imported.Named(name :+ jsName)
             }
 
           val newGlobal = globalOpt.map {
-            case Annotation.JsGlobal(old) => Annotation.JsGlobal(old + tree.name)
+            case Annotation.JsGlobal(old) => Annotation.JsGlobal(old + jsName)
           }
 
           Annotation.JsImport(mod, newImported, newGlobal)
-        case (Annotation.JsGlobal(name), tree) => Annotation.JsGlobal(name + tree.name)
-        case (Annotation.JsGlobalScope, tree)  => Annotation.JsGlobal(QualifiedName(IArray(tree.name)))
+        case (Annotation.JsGlobal(name), tree) => Annotation.JsGlobal(name + jsNameOf(tree))
+        case (Annotation.JsGlobalScope, tree)  => Annotation.JsGlobal(QualifiedName(IArray(jsNameOf(tree))))
 
       }
 

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/ReactNames.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/ReactNames.scala
@@ -56,6 +56,11 @@ class ReactNames(val outputPkg: Name) {
     "ForwardRefExoticComponent",
   )
 
+  /* components as far as identifying them goes. kept out of `ComponentQNames` because they may be function components,
+   * and Slinky rewrites everything in `ComponentLike` to `ReactComponentClass` */
+  val ComponentConstructorQNames: Set[QualifiedName] =
+    explode("JSXElementConstructor")
+
   val ComponentLike: Set[QualifiedName] =
     ComponentQNames ++ WrappedComponentsQNames
 

--- a/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/ReactNamesProxy.scala
+++ b/scalajs/src/main/scala/org/scalablytyped/converter/internal/scalajs/flavours/ReactNamesProxy.scala
@@ -15,6 +15,9 @@ class ReactNamesProxy(reactNames: ReactNames, rewrites: IArray[CastConversion]) 
   val ComponentQNames: Set[QualifiedName] =
     reactNames.ComponentQNames.flatMap(withRewritten)
 
+  val ComponentConstructorQNames: Set[QualifiedName] =
+    reactNames.ComponentConstructorQNames.flatMap(withRewritten)
+
   val WrappedComponentsQNames: Set[QualifiedName] =
     reactNames.WrappedComponentsQNames.flatMap(withRewritten)
 
@@ -25,7 +28,7 @@ class ReactNamesProxy(reactNames: ReactNames, rewrites: IArray[CastConversion]) 
     tr match {
       case TypeRef.Intersection(types, _) =>
         types.firstDefined(isComponent)
-      case TypeRef(c, IArray.first(props), _) if ComponentQNames(c) =>
+      case TypeRef(c, IArray.first(props), _) if ComponentQNames(c) || ComponentConstructorQNames(c) =>
         isComponent(props).orElse(Some(unpackedProps(props)))
       case TypeRef(c, IArray.first(cc), _) if WrappedComponentsQNames(c) =>
         isComponent(cc)

--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-1f706d"
+version := "0.0-unknown-e952d3"
 scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/anon.scala
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/anon.scala
@@ -1,10 +1,50 @@
 package typingsJapgolly.componentstest
 
+import japgolly.scalajs.react.facade.React.ElementType
+import typingsJapgolly.componentstest.textFieldMod.TextFieldVariants
 import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 object anon {
+  
+  trait `0`[Variant /* <: TextFieldVariants */] extends StObject {
+    
+    var variant: js.UndefOr[Variant] = js.undefined
+  }
+  object `0` {
+    
+    inline def apply[Variant /* <: TextFieldVariants */](): `0`[Variant] = {
+      val __obj = js.Dynamic.literal()
+      __obj.asInstanceOf[`0`[Variant]]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: `0`[?], Variant /* <: TextFieldVariants */] (val x: Self & `0`[Variant]) extends AnyVal {
+      
+      inline def setVariant(value: Variant): Self = StObject.set(x, "variant", value.asInstanceOf[js.Any])
+      
+      inline def setVariantUndefined: Self = StObject.set(x, "variant", js.undefined)
+    }
+  }
+  
+  trait Component[C /* <: ElementType */] extends StObject {
+    
+    var component: C
+  }
+  object Component {
+    
+    inline def apply[C /* <: ElementType */](component: C): Component[C] = {
+      val __obj = js.Dynamic.literal(component = component.asInstanceOf[js.Any])
+      __obj.asInstanceOf[Component[C]]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: Component[?], C /* <: ElementType */] (val x: Self & Component[C]) extends AnyVal {
+      
+      inline def setComponent(value: C): Self = StObject.set(x, "component", value.asInstanceOf[js.Any])
+    }
+  }
   
   trait Equals extends StObject {
     
@@ -36,6 +76,55 @@ object anon {
       inline def setNe_(value: /* other */ js.Object => Boolean): Self = StObject.set(x, "ne", js.Any.fromFunction1(value))
       
       inline def setNe_Undefined: Self = StObject.set(x, "ne", js.undefined)
+    }
+  }
+  
+  trait Href extends StObject {
+    
+    var href: String
+  }
+  object Href {
+    
+    inline def apply(href: String): Href = {
+      val __obj = js.Dynamic.literal(href = href.asInstanceOf[js.Any])
+      __obj.asInstanceOf[Href]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: Href] (val x: Self) extends AnyVal {
+      
+      inline def setHref(value: String): Self = StObject.set(x, "href", value.asInstanceOf[js.Any])
+    }
+  }
+  
+  /* Inlined {  href :string} & componentstest.componentstest.FooProps */
+  trait hrefstringFooProps extends StObject {
+    
+    var disabled: js.UndefOr[Boolean] = js.undefined
+    
+    var href: String
+    
+    var label: js.UndefOr[String] = js.undefined
+  }
+  object hrefstringFooProps {
+    
+    inline def apply(href: String): hrefstringFooProps = {
+      val __obj = js.Dynamic.literal(href = href.asInstanceOf[js.Any])
+      __obj.asInstanceOf[hrefstringFooProps]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: hrefstringFooProps] (val x: Self) extends AnyVal {
+      
+      inline def setDisabled(value: Boolean): Self = StObject.set(x, "disabled", value.asInstanceOf[js.Any])
+      
+      inline def setDisabledUndefined: Self = StObject.set(x, "disabled", js.undefined)
+      
+      inline def setHref(value: String): Self = StObject.set(x, "href", value.asInstanceOf[js.Any])
+      
+      inline def setLabel(value: String): Self = StObject.set(x, "label", value.asInstanceOf[js.Any])
+      
+      inline def setLabelUndefined: Self = StObject.set(x, "label", js.undefined)
     }
   }
 }

--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/components/Inline.scala
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/components/Inline.scala
@@ -1,0 +1,19 @@
+package typingsJapgolly.componentstest.components
+
+import typingsJapgolly.StBuildingComponent.Default
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object Inline {
+  
+  @JSImport("componentstest", "Inline")
+  @js.native
+  val component: js.Object = js.native
+  
+  type Props = /* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any
+  
+  implicit def make(companion: Inline.type): Default[js.Object] = new Default[js.Object](js.Array(this.component, js.Dictionary.empty))()
+  
+  def withProps(p: /* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any): Default[js.Object] = new Default[js.Object](js.Array(this.component, p.asInstanceOf[js.Any]))
+}

--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/components/Plain.scala
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/components/Plain.scala
@@ -1,0 +1,19 @@
+package typingsJapgolly.componentstest.components
+
+import typingsJapgolly.StBuildingComponent.Default
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object Plain {
+  
+  @JSImport("componentstest", "Plain")
+  @js.native
+  val component: js.Object = js.native
+  
+  type Props = /* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any
+  
+  implicit def make(companion: Plain.type): Default[js.Object] = new Default[js.Object](js.Array(this.component, js.Dictionary.empty))()
+  
+  def withProps(p: /* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any): Default[js.Object] = new Default[js.Object](js.Array(this.component, p.asInstanceOf[js.Any]))
+}

--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/components/TextField.scala
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/components/TextField.scala
@@ -1,0 +1,37 @@
+package typingsJapgolly.componentstest.components
+
+import typingsJapgolly.StBuildingComponent
+import typingsJapgolly.componentstest.anon.`0`
+import typingsJapgolly.componentstest.componentstestStrings.variant
+import typingsJapgolly.componentstest.textFieldMod.TextFieldProps
+import typingsJapgolly.componentstest.textFieldMod.TextFieldVariants
+import typingsJapgolly.std.Omit
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object TextField {
+  
+  inline def apply[Variant /* <: TextFieldVariants */](): Builder[Variant] = {
+    val __props = js.Dynamic.literal(variant = "filled")
+    new Builder[Variant](js.Array(this.component, __props.asInstanceOf[`0`[Variant] & (Omit[TextFieldProps[TextFieldVariants], variant])]))
+  }
+  
+  @JSImport("componentstest/TextField", JSImport.Default)
+  @js.native
+  val component: js.Object = js.native
+  
+  @scala.inline
+  open class Builder[Variant /* <: TextFieldVariants */] (val args: js.Array[Any])
+    extends AnyVal
+       with StBuildingComponent[js.Object] {
+    
+    inline def disabled(value: Boolean): this.type = set("disabled", value.asInstanceOf[js.Any])
+    
+    inline def label(value: String): this.type = set("label", value.asInstanceOf[js.Any])
+  }
+  
+  type Props[Variant /* <: TextFieldVariants */] = `0`[Variant] & (Omit[TextFieldProps[TextFieldVariants], variant])
+  
+  def withProps[Variant /* <: TextFieldVariants */](p: `0`[Variant] & (Omit[TextFieldProps[TextFieldVariants], variant])): Builder[Variant] = new Builder[Variant](js.Array(this.component, p.asInstanceOf[js.Any]))
+}

--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/components/ViaAlias.scala
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/components/ViaAlias.scala
@@ -1,0 +1,19 @@
+package typingsJapgolly.componentstest.components
+
+import typingsJapgolly.StBuildingComponent.Default
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object ViaAlias {
+  
+  @JSImport("componentstest", "ViaAlias")
+  @js.native
+  val component: js.Object = js.native
+  
+  type Props = /* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any
+  
+  implicit def make(companion: ViaAlias.type): Default[js.Object] = new Default[js.Object](js.Array(this.component, js.Dictionary.empty))()
+  
+  def withProps(p: /* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any): Default[js.Object] = new Default[js.Object](js.Array(this.component, p.asInstanceOf[js.Any]))
+}

--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/components/ViaConstructor.scala
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/components/ViaConstructor.scala
@@ -1,0 +1,30 @@
+package typingsJapgolly.componentstest.components
+
+import typingsJapgolly.StBuildingComponent
+import typingsJapgolly.componentstest.mod.FooProps
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object ViaConstructor {
+  
+  @JSImport("componentstest", "ViaConstructor")
+  @js.native
+  val component: js.Object = js.native
+  
+  @scala.inline
+  open class Builder (val args: js.Array[Any])
+    extends AnyVal
+       with StBuildingComponent[js.Object] {
+    
+    inline def disabled(value: Boolean): this.type = set("disabled", value.asInstanceOf[js.Any])
+    
+    inline def label(value: String): this.type = set("label", value.asInstanceOf[js.Any])
+  }
+  
+  type Props = FooProps
+  
+  implicit def make(companion: ViaConstructor.type): Builder = new Builder(js.Array(this.component, js.Dictionary.empty))()
+  
+  def withProps(p: FooProps): Builder = new Builder(js.Array(this.component, p.asInstanceOf[js.Any]))
+}

--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/componentstestStrings.scala
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/componentstestStrings.scala
@@ -1,0 +1,35 @@
+package typingsJapgolly.componentstest
+
+import typingsJapgolly.componentstest.textFieldMod.TextFieldVariants
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object componentstestStrings {
+  
+  @js.native
+  sealed trait button extends StObject
+  inline def button: button = "button".asInstanceOf[button]
+  
+  @js.native
+  sealed trait filled
+    extends StObject
+       with TextFieldVariants
+  inline def filled: filled = "filled".asInstanceOf[filled]
+  
+  @js.native
+  sealed trait outlined
+    extends StObject
+       with TextFieldVariants
+  inline def outlined: outlined = "outlined".asInstanceOf[outlined]
+  
+  @js.native
+  sealed trait standard
+    extends StObject
+       with TextFieldVariants
+  inline def standard: standard = "standard".asInstanceOf[standard]
+  
+  @js.native
+  sealed trait variant extends StObject
+  inline def variant: variant = "variant".asInstanceOf[variant]
+}

--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/mod.scala
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/mod.scala
@@ -4,17 +4,22 @@ import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.CallbackTo
 import japgolly.scalajs.react.ReactEventFrom
 import japgolly.scalajs.react.ReactMouseEventFrom
-import org.scalajs.dom.Element
+import japgolly.scalajs.react.facade.React.ElementType
 import org.scalajs.dom.HTMLDivElement
 import typingsJapgolly.componentstest.anon.Equals
+import typingsJapgolly.componentstest.anon.Href
+import typingsJapgolly.componentstest.anon.hrefstringFooProps
+import typingsJapgolly.componentstest.componentstestStrings.button
 import typingsJapgolly.react.mod.CSSProperties
 import typingsJapgolly.react.mod.ComponentType
 import typingsJapgolly.react.mod.FC
 import typingsJapgolly.react.mod.ForwardRefExoticComponent
 import typingsJapgolly.react.mod.FunctionComponent
+import typingsJapgolly.react.mod.JSXElementConstructor
 import typingsJapgolly.react.mod.MemoExoticComponent
 import typingsJapgolly.react.mod.MouseEventHandler
 import typingsJapgolly.react.mod.RefAttributes
+import typingsJapgolly.react.mod.global.JSX.Element
 import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
@@ -33,13 +38,29 @@ object mod {
   @js.native
   val Grid: FC[CardGridProps] = js.native
   
+  @JSImport("componentstest", "Inline")
+  @js.native
+  val Inline: (js.Function1[/* props */ hrefstringFooProps, Element]) & OverridableComponent[FooTypeMap] = js.native
+  
   @JSImport("componentstest", "ObjectNames")
   @js.native
   val ObjectNames: FC[Equals] = js.native
   
+  @JSImport("componentstest", "Plain")
+  @js.native
+  val Plain: OverridableComponent[FooTypeMap] = js.native
+  
   @JSImport("componentstest", "VeryExotic")
   @js.native
   val VeryExotic: MemoExoticComponent[ForwardRefExoticComponent[RefAttributes[HTMLDivElement]]] = js.native
+  
+  @JSImport("componentstest", "ViaAlias")
+  @js.native
+  val ViaAlias: ExtendButtonBase[FooTypeMap] = js.native
+  
+  @JSImport("componentstest", "ViaConstructor")
+  @js.native
+  val ViaConstructor: JSXElementConstructor[FooProps] = js.native
   
   trait A
     extends StObject
@@ -154,7 +175,7 @@ object mod {
     @scala.inline
     implicit open class MutableBuilder[Self <: CardProps] (val x: Self) extends AnyVal {
       
-      inline def setOnClick(value: ReactMouseEventFrom[HTMLDivElement & Element] => Callback): Self = StObject.set(x, "onClick", js.Any.fromFunction1((t0: ReactMouseEventFrom[HTMLDivElement & Element]) => value(t0).runNow()))
+      inline def setOnClick(value: ReactMouseEventFrom[HTMLDivElement & org.scalajs.dom.Element] => Callback): Self = StObject.set(x, "onClick", js.Any.fromFunction1((t0: ReactMouseEventFrom[HTMLDivElement & org.scalajs.dom.Element]) => value(t0).runNow()))
       
       inline def setOnClickUndefined: Self = StObject.set(x, "onClick", js.undefined)
       
@@ -166,19 +187,96 @@ object mod {
   
   trait Events extends StObject {
     
-    def onClick(event: ReactEventFrom[Any & Element]): Unit
+    def onClick(event: ReactEventFrom[Any & org.scalajs.dom.Element]): Unit
   }
   object Events {
     
-    inline def apply(onClick: ReactEventFrom[Any & Element] => Callback): Events = {
-      val __obj = js.Dynamic.literal(onClick = js.Any.fromFunction1((t0: ReactEventFrom[Any & Element]) => onClick(t0).runNow()))
+    inline def apply(onClick: ReactEventFrom[Any & org.scalajs.dom.Element] => Callback): Events = {
+      val __obj = js.Dynamic.literal(onClick = js.Any.fromFunction1((t0: ReactEventFrom[Any & org.scalajs.dom.Element]) => onClick(t0).runNow()))
       __obj.asInstanceOf[Events]
     }
     
     @scala.inline
     implicit open class MutableBuilder[Self <: Events] (val x: Self) extends AnyVal {
       
-      inline def setOnClick(value: ReactEventFrom[Any & Element] => Callback): Self = StObject.set(x, "onClick", js.Any.fromFunction1((t0: ReactEventFrom[Any & Element]) => value(t0).runNow()))
+      inline def setOnClick(value: ReactEventFrom[Any & org.scalajs.dom.Element] => Callback): Self = StObject.set(x, "onClick", js.Any.fromFunction1((t0: ReactEventFrom[Any & org.scalajs.dom.Element]) => value(t0).runNow()))
+    }
+  }
+  
+  type ExtendButtonBase[M /* <: OverridableTypeMap */] = (js.Function1[
+    /* props */ Href & (/* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any), 
+    Element
+  ]) & OverridableComponent[M]
+  
+  trait FooProps extends StObject {
+    
+    var disabled: js.UndefOr[Boolean] = js.undefined
+    
+    var label: js.UndefOr[String] = js.undefined
+  }
+  object FooProps {
+    
+    inline def apply(): FooProps = {
+      val __obj = js.Dynamic.literal()
+      __obj.asInstanceOf[FooProps]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: FooProps] (val x: Self) extends AnyVal {
+      
+      inline def setDisabled(value: Boolean): Self = StObject.set(x, "disabled", value.asInstanceOf[js.Any])
+      
+      inline def setDisabledUndefined: Self = StObject.set(x, "disabled", js.undefined)
+      
+      inline def setLabel(value: String): Self = StObject.set(x, "label", value.asInstanceOf[js.Any])
+      
+      inline def setLabelUndefined: Self = StObject.set(x, "label", js.undefined)
+    }
+  }
+  
+  trait FooTypeMap extends StObject {
+    
+    var defaultComponent: button
+    
+    var props: FooProps
+  }
+  object FooTypeMap {
+    
+    inline def apply(props: FooProps): FooTypeMap = {
+      val __obj = js.Dynamic.literal(defaultComponent = "button", props = props.asInstanceOf[js.Any])
+      __obj.asInstanceOf[FooTypeMap]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: FooTypeMap] (val x: Self) extends AnyVal {
+      
+      inline def setDefaultComponent(value: button): Self = StObject.set(x, "defaultComponent", value.asInstanceOf[js.Any])
+      
+      inline def setProps(value: FooProps): Self = StObject.set(x, "props", value.asInstanceOf[js.Any])
+    }
+  }
+  
+  @js.native
+  trait OverridableComponent[M /* <: OverridableTypeMap */] extends StObject {
+    
+    def apply(props: /* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any): Element | Null = js.native
+  }
+  
+  trait OverridableTypeMap extends StObject {
+    
+    var defaultComponent: ElementType
+  }
+  object OverridableTypeMap {
+    
+    inline def apply(defaultComponent: ElementType): OverridableTypeMap = {
+      val __obj = js.Dynamic.literal(defaultComponent = defaultComponent.asInstanceOf[js.Any])
+      __obj.asInstanceOf[OverridableTypeMap]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: OverridableTypeMap] (val x: Self) extends AnyVal {
+      
+      inline def setDefaultComponent(value: ElementType): Self = StObject.set(x, "defaultComponent", value.asInstanceOf[js.Any])
     }
   }
   

--- a/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/textFieldMod.scala
+++ b/tests/react-integration-test/check-japgolly-3/c/componentstest/src/main/scala/typingsJapgolly/componentstest/textFieldMod.scala
@@ -1,0 +1,108 @@
+package typingsJapgolly.componentstest
+
+import typingsJapgolly.componentstest.anon.`0`
+import typingsJapgolly.componentstest.componentstestStrings.filled
+import typingsJapgolly.componentstest.componentstestStrings.outlined
+import typingsJapgolly.componentstest.componentstestStrings.standard
+import typingsJapgolly.componentstest.componentstestStrings.variant
+import typingsJapgolly.componentstest.mod.FooProps
+import typingsJapgolly.react.mod.global.JSX.Element
+import typingsJapgolly.std.Omit
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object textFieldMod {
+  
+  @JSImport("componentstest/TextField", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+  
+  inline def default_variant[Variant /* <: TextFieldVariants */](props: `0`[Variant] & (Omit[TextFieldProps[TextFieldVariants], variant])): Element = ^.asInstanceOf[js.Dynamic].applyDynamic("default")(props.asInstanceOf[js.Any]).asInstanceOf[Element]
+  
+  trait FilledTextFieldProps
+    extends StObject
+       with FooProps {
+    
+    var variant: filled
+  }
+  object FilledTextFieldProps {
+    
+    inline def apply(): FilledTextFieldProps = {
+      val __obj = js.Dynamic.literal(variant = "filled")
+      __obj.asInstanceOf[FilledTextFieldProps]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: FilledTextFieldProps] (val x: Self) extends AnyVal {
+      
+      inline def setVariant(value: filled): Self = StObject.set(x, "variant", value.asInstanceOf[js.Any])
+    }
+  }
+  
+  trait OutlinedTextFieldProps
+    extends StObject
+       with FooProps {
+    
+    var variant: outlined
+  }
+  object OutlinedTextFieldProps {
+    
+    inline def apply(): OutlinedTextFieldProps = {
+      val __obj = js.Dynamic.literal(variant = "outlined")
+      __obj.asInstanceOf[OutlinedTextFieldProps]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: OutlinedTextFieldProps] (val x: Self) extends AnyVal {
+      
+      inline def setVariant(value: outlined): Self = StObject.set(x, "variant", value.asInstanceOf[js.Any])
+    }
+  }
+  
+  trait StandardTextFieldProps
+    extends StObject
+       with FooProps {
+    
+    var variant: js.UndefOr[standard] = js.undefined
+  }
+  object StandardTextFieldProps {
+    
+    inline def apply(): StandardTextFieldProps = {
+      val __obj = js.Dynamic.literal()
+      __obj.asInstanceOf[StandardTextFieldProps]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: StandardTextFieldProps] (val x: Self) extends AnyVal {
+      
+      inline def setVariant(value: standard): Self = StObject.set(x, "variant", value.asInstanceOf[js.Any])
+      
+      inline def setVariantUndefined: Self = StObject.set(x, "variant", js.undefined)
+    }
+  }
+  
+  /** NOTE: Conditional type definitions are impossible to translate to Scala.
+    * See https://www.typescriptlang.org/docs/handbook/2/conditional-types.html for an intro.
+    * This RHS of the type alias is guess work. You should cast if it's not correct in your case.
+    * TS definition: {{{
+    Variant extends 'filled' ? componentstest.componentstest/TextField.FilledTextFieldProps : Variant extends 'standard' ? componentstest.componentstest/TextField.StandardTextFieldProps : componentstest.componentstest/TextField.OutlinedTextFieldProps
+    }}}
+    */
+  type TextFieldProps[Variant /* <: TextFieldVariants */] = FilledTextFieldProps
+  
+  /* Rewritten from type alias, can be one of: 
+    - typingsJapgolly.componentstest.componentstestStrings.outlined
+    - typingsJapgolly.componentstest.componentstestStrings.filled
+    - typingsJapgolly.componentstest.componentstestStrings.standard
+  */
+  trait TextFieldVariants extends StObject
+  object TextFieldVariants {
+    
+    inline def filled: typingsJapgolly.componentstest.componentstestStrings.filled = "filled".asInstanceOf[typingsJapgolly.componentstest.componentstestStrings.filled]
+    
+    inline def outlined: typingsJapgolly.componentstest.componentstestStrings.outlined = "outlined".asInstanceOf[typingsJapgolly.componentstest.componentstestStrings.outlined]
+    
+    inline def standard: typingsJapgolly.componentstest.componentstestStrings.standard = "standard".asInstanceOf[typingsJapgolly.componentstest.componentstestStrings.standard]
+  }
+}

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/build.sbt
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "componentstest"
-version := "0.0-unknown-e7ccfa"
+version := "0.0-unknown-07e9d3"
 scalaVersion := "3.3.6"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/anon.scala
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/anon.scala
@@ -1,10 +1,50 @@
 package typingsSlinky.componentstest
 
+import slinky.core.facade.ReactElement
+import typingsSlinky.componentstest.textFieldMod.TextFieldVariants
 import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
 
 object anon {
+  
+  trait `0`[Variant /* <: TextFieldVariants */] extends StObject {
+    
+    var variant: js.UndefOr[Variant] = js.undefined
+  }
+  object `0` {
+    
+    inline def apply[Variant /* <: TextFieldVariants */](): `0`[Variant] = {
+      val __obj = js.Dynamic.literal()
+      __obj.asInstanceOf[`0`[Variant]]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: `0`[?], Variant /* <: TextFieldVariants */] (val x: Self & `0`[Variant]) extends AnyVal {
+      
+      inline def setVariant(value: Variant): Self = StObject.set(x, "variant", value.asInstanceOf[js.Any])
+      
+      inline def setVariantUndefined: Self = StObject.set(x, "variant", js.undefined)
+    }
+  }
+  
+  trait Component[C /* <: ReactElement */] extends StObject {
+    
+    var component: C
+  }
+  object Component {
+    
+    inline def apply[C /* <: ReactElement */](component: C): Component[C] = {
+      val __obj = js.Dynamic.literal(component = component.asInstanceOf[js.Any])
+      __obj.asInstanceOf[Component[C]]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: Component[?], C /* <: ReactElement */] (val x: Self & Component[C]) extends AnyVal {
+      
+      inline def setComponent(value: C): Self = StObject.set(x, "component", value.asInstanceOf[js.Any])
+    }
+  }
   
   trait Equals extends StObject {
     
@@ -36,6 +76,55 @@ object anon {
       inline def setNe_(value: /* other */ js.Object => Boolean): Self = StObject.set(x, "ne", js.Any.fromFunction1(value))
       
       inline def setNe_Undefined: Self = StObject.set(x, "ne", js.undefined)
+    }
+  }
+  
+  trait Href extends StObject {
+    
+    var href: String
+  }
+  object Href {
+    
+    inline def apply(href: String): Href = {
+      val __obj = js.Dynamic.literal(href = href.asInstanceOf[js.Any])
+      __obj.asInstanceOf[Href]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: Href] (val x: Self) extends AnyVal {
+      
+      inline def setHref(value: String): Self = StObject.set(x, "href", value.asInstanceOf[js.Any])
+    }
+  }
+  
+  /* Inlined {  href :string} & componentstest.componentstest.FooProps */
+  trait hrefstringFooProps extends StObject {
+    
+    var disabled: js.UndefOr[Boolean] = js.undefined
+    
+    var href: String
+    
+    var label: js.UndefOr[String] = js.undefined
+  }
+  object hrefstringFooProps {
+    
+    inline def apply(href: String): hrefstringFooProps = {
+      val __obj = js.Dynamic.literal(href = href.asInstanceOf[js.Any])
+      __obj.asInstanceOf[hrefstringFooProps]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: hrefstringFooProps] (val x: Self) extends AnyVal {
+      
+      inline def setDisabled(value: Boolean): Self = StObject.set(x, "disabled", value.asInstanceOf[js.Any])
+      
+      inline def setDisabledUndefined: Self = StObject.set(x, "disabled", js.undefined)
+      
+      inline def setHref(value: String): Self = StObject.set(x, "href", value.asInstanceOf[js.Any])
+      
+      inline def setLabel(value: String): Self = StObject.set(x, "label", value.asInstanceOf[js.Any])
+      
+      inline def setLabelUndefined: Self = StObject.set(x, "label", js.undefined)
     }
   }
 }

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/components/Inline.scala
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/components/Inline.scala
@@ -1,0 +1,20 @@
+package typingsSlinky.componentstest.components
+
+import slinky.web.html.`*`.tag
+import typingsSlinky.StBuildingComponent.Default
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object Inline {
+  
+  @JSImport("componentstest", "Inline")
+  @js.native
+  val component: js.Object = js.native
+  
+  type Props = /* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any
+  
+  implicit def make(companion: Inline.type): Default[tag.type, js.Object] = new Default[tag.type, js.Object](js.Array(this.component, js.Dictionary.empty))()
+  
+  def withProps(p: /* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any): Default[tag.type, js.Object] = new Default[tag.type, js.Object](js.Array(this.component, p.asInstanceOf[js.Any]))
+}

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/components/Plain.scala
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/components/Plain.scala
@@ -1,0 +1,20 @@
+package typingsSlinky.componentstest.components
+
+import slinky.web.html.`*`.tag
+import typingsSlinky.StBuildingComponent.Default
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object Plain {
+  
+  @JSImport("componentstest", "Plain")
+  @js.native
+  val component: js.Object = js.native
+  
+  type Props = /* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any
+  
+  implicit def make(companion: Plain.type): Default[tag.type, js.Object] = new Default[tag.type, js.Object](js.Array(this.component, js.Dictionary.empty))()
+  
+  def withProps(p: /* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any): Default[tag.type, js.Object] = new Default[tag.type, js.Object](js.Array(this.component, p.asInstanceOf[js.Any]))
+}

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/components/TextField.scala
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/components/TextField.scala
@@ -1,0 +1,38 @@
+package typingsSlinky.componentstest.components
+
+import slinky.web.html.`*`.tag
+import typingsSlinky.StBuildingComponent
+import typingsSlinky.componentstest.anon.`0`
+import typingsSlinky.componentstest.componentstestStrings.variant
+import typingsSlinky.componentstest.textFieldMod.TextFieldProps
+import typingsSlinky.componentstest.textFieldMod.TextFieldVariants
+import typingsSlinky.std.Omit
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object TextField {
+  
+  inline def apply[Variant /* <: TextFieldVariants */](): Builder[Variant] = {
+    val __props = js.Dynamic.literal(variant = "filled")
+    new Builder[Variant](js.Array(this.component, __props.asInstanceOf[`0`[Variant] & (Omit[TextFieldProps[TextFieldVariants], variant])]))
+  }
+  
+  @JSImport("componentstest/TextField", JSImport.Default)
+  @js.native
+  val component: js.Object = js.native
+  
+  @scala.inline
+  open class Builder[Variant /* <: TextFieldVariants */] (val args: js.Array[Any])
+    extends AnyVal
+       with StBuildingComponent[tag.type, js.Object] {
+    
+    inline def disabled(value: Boolean): this.type = set("disabled", value.asInstanceOf[js.Any])
+    
+    inline def label(value: String): this.type = set("label", value.asInstanceOf[js.Any])
+  }
+  
+  type Props[Variant /* <: TextFieldVariants */] = `0`[Variant] & (Omit[TextFieldProps[TextFieldVariants], variant])
+  
+  def withProps[Variant /* <: TextFieldVariants */](p: `0`[Variant] & (Omit[TextFieldProps[TextFieldVariants], variant])): Builder[Variant] = new Builder[Variant](js.Array(this.component, p.asInstanceOf[js.Any]))
+}

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/components/ViaAlias.scala
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/components/ViaAlias.scala
@@ -1,0 +1,20 @@
+package typingsSlinky.componentstest.components
+
+import slinky.web.html.`*`.tag
+import typingsSlinky.StBuildingComponent.Default
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object ViaAlias {
+  
+  @JSImport("componentstest", "ViaAlias")
+  @js.native
+  val component: js.Object = js.native
+  
+  type Props = /* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any
+  
+  implicit def make(companion: ViaAlias.type): Default[tag.type, js.Object] = new Default[tag.type, js.Object](js.Array(this.component, js.Dictionary.empty))()
+  
+  def withProps(p: /* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any): Default[tag.type, js.Object] = new Default[tag.type, js.Object](js.Array(this.component, p.asInstanceOf[js.Any]))
+}

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/components/ViaConstructor.scala
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/components/ViaConstructor.scala
@@ -1,0 +1,31 @@
+package typingsSlinky.componentstest.components
+
+import slinky.web.html.`*`.tag
+import typingsSlinky.StBuildingComponent
+import typingsSlinky.componentstest.mod.FooProps
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object ViaConstructor {
+  
+  @JSImport("componentstest", "ViaConstructor")
+  @js.native
+  val component: js.Object = js.native
+  
+  @scala.inline
+  open class Builder (val args: js.Array[Any])
+    extends AnyVal
+       with StBuildingComponent[tag.type, js.Object] {
+    
+    inline def disabled(value: Boolean): this.type = set("disabled", value.asInstanceOf[js.Any])
+    
+    inline def label(value: String): this.type = set("label", value.asInstanceOf[js.Any])
+  }
+  
+  type Props = FooProps
+  
+  implicit def make(companion: ViaConstructor.type): Builder = new Builder(js.Array(this.component, js.Dictionary.empty))()
+  
+  def withProps(p: FooProps): Builder = new Builder(js.Array(this.component, p.asInstanceOf[js.Any]))
+}

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/componentstestStrings.scala
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/componentstestStrings.scala
@@ -1,0 +1,35 @@
+package typingsSlinky.componentstest
+
+import typingsSlinky.componentstest.textFieldMod.TextFieldVariants
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object componentstestStrings {
+  
+  @js.native
+  sealed trait button extends StObject
+  inline def button: button = "button".asInstanceOf[button]
+  
+  @js.native
+  sealed trait filled
+    extends StObject
+       with TextFieldVariants
+  inline def filled: filled = "filled".asInstanceOf[filled]
+  
+  @js.native
+  sealed trait outlined
+    extends StObject
+       with TextFieldVariants
+  inline def outlined: outlined = "outlined".asInstanceOf[outlined]
+  
+  @js.native
+  sealed trait standard
+    extends StObject
+       with TextFieldVariants
+  inline def standard: standard = "standard".asInstanceOf[standard]
+  
+  @js.native
+  sealed trait variant extends StObject
+  inline def variant: variant = "variant".asInstanceOf[variant]
+}

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/mod.scala
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/mod.scala
@@ -4,12 +4,18 @@ import org.scalajs.dom.Event
 import org.scalajs.dom.HTMLDivElement
 import slinky.core.ReactComponentClass
 import slinky.core.SyntheticEvent
+import slinky.core.facade.ReactElement
 import slinky.web.SyntheticMouseEvent
 import typingsSlinky.componentstest.anon.Equals
+import typingsSlinky.componentstest.anon.Href
+import typingsSlinky.componentstest.anon.hrefstringFooProps
+import typingsSlinky.componentstest.componentstestStrings.button
 import typingsSlinky.react.mod.CSSProperties
 import typingsSlinky.react.mod.FunctionComponent
+import typingsSlinky.react.mod.JSXElementConstructor
 import typingsSlinky.react.mod.MouseEventHandler
 import typingsSlinky.react.mod.RefAttributes
+import typingsSlinky.react.mod.global.JSX.Element
 import org.scalablytyped.runtime.StObject
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
@@ -28,13 +34,29 @@ object mod {
   @js.native
   val Grid: ReactComponentClass[CardGridProps] = js.native
   
+  @JSImport("componentstest", "Inline")
+  @js.native
+  val Inline: (js.Function1[/* props */ hrefstringFooProps, Element]) & OverridableComponent[FooTypeMap] = js.native
+  
   @JSImport("componentstest", "ObjectNames")
   @js.native
   val ObjectNames: ReactComponentClass[Equals] = js.native
   
+  @JSImport("componentstest", "Plain")
+  @js.native
+  val Plain: OverridableComponent[FooTypeMap] = js.native
+  
   @JSImport("componentstest", "VeryExotic")
   @js.native
   val VeryExotic: ReactComponentClass[ReactComponentClass[RefAttributes[HTMLDivElement]]] = js.native
+  
+  @JSImport("componentstest", "ViaAlias")
+  @js.native
+  val ViaAlias: ExtendButtonBase[FooTypeMap] = js.native
+  
+  @JSImport("componentstest", "ViaConstructor")
+  @js.native
+  val ViaConstructor: JSXElementConstructor[FooProps] = js.native
   
   trait A
     extends StObject
@@ -174,6 +196,83 @@ object mod {
     implicit open class MutableBuilder[Self <: Events] (val x: Self) extends AnyVal {
       
       inline def setOnClick(value: SyntheticEvent[Any, Event] => Unit): Self = StObject.set(x, "onClick", js.Any.fromFunction1(value))
+    }
+  }
+  
+  type ExtendButtonBase[M /* <: OverridableTypeMap */] = (js.Function1[
+    /* props */ Href & (/* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any), 
+    Element
+  ]) & OverridableComponent[M]
+  
+  trait FooProps extends StObject {
+    
+    var disabled: js.UndefOr[Boolean] = js.undefined
+    
+    var label: js.UndefOr[String] = js.undefined
+  }
+  object FooProps {
+    
+    inline def apply(): FooProps = {
+      val __obj = js.Dynamic.literal()
+      __obj.asInstanceOf[FooProps]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: FooProps] (val x: Self) extends AnyVal {
+      
+      inline def setDisabled(value: Boolean): Self = StObject.set(x, "disabled", value.asInstanceOf[js.Any])
+      
+      inline def setDisabledUndefined: Self = StObject.set(x, "disabled", js.undefined)
+      
+      inline def setLabel(value: String): Self = StObject.set(x, "label", value.asInstanceOf[js.Any])
+      
+      inline def setLabelUndefined: Self = StObject.set(x, "label", js.undefined)
+    }
+  }
+  
+  trait FooTypeMap extends StObject {
+    
+    var defaultComponent: button
+    
+    var props: FooProps
+  }
+  object FooTypeMap {
+    
+    inline def apply(props: FooProps): FooTypeMap = {
+      val __obj = js.Dynamic.literal(defaultComponent = "button", props = props.asInstanceOf[js.Any])
+      __obj.asInstanceOf[FooTypeMap]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: FooTypeMap] (val x: Self) extends AnyVal {
+      
+      inline def setDefaultComponent(value: button): Self = StObject.set(x, "defaultComponent", value.asInstanceOf[js.Any])
+      
+      inline def setProps(value: FooProps): Self = StObject.set(x, "props", value.asInstanceOf[js.Any])
+    }
+  }
+  
+  @js.native
+  trait OverridableComponent[M /* <: OverridableTypeMap */] extends StObject {
+    
+    def apply(props: /* import warning: importer.ImportType#apply Failed type conversion: M['props'] */ js.Any): Element | Null = js.native
+  }
+  
+  trait OverridableTypeMap extends StObject {
+    
+    var defaultComponent: ReactElement
+  }
+  object OverridableTypeMap {
+    
+    inline def apply(defaultComponent: ReactElement): OverridableTypeMap = {
+      val __obj = js.Dynamic.literal(defaultComponent = defaultComponent.asInstanceOf[js.Any])
+      __obj.asInstanceOf[OverridableTypeMap]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: OverridableTypeMap] (val x: Self) extends AnyVal {
+      
+      inline def setDefaultComponent(value: ReactElement): Self = StObject.set(x, "defaultComponent", value.asInstanceOf[js.Any])
     }
   }
   

--- a/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/textFieldMod.scala
+++ b/tests/react-integration-test/check-slinky-3/c/componentstest/src/main/scala/typingsSlinky/componentstest/textFieldMod.scala
@@ -1,0 +1,108 @@
+package typingsSlinky.componentstest
+
+import typingsSlinky.componentstest.anon.`0`
+import typingsSlinky.componentstest.componentstestStrings.filled
+import typingsSlinky.componentstest.componentstestStrings.outlined
+import typingsSlinky.componentstest.componentstestStrings.standard
+import typingsSlinky.componentstest.componentstestStrings.variant
+import typingsSlinky.componentstest.mod.FooProps
+import typingsSlinky.react.mod.global.JSX.Element
+import typingsSlinky.std.Omit
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object textFieldMod {
+  
+  @JSImport("componentstest/TextField", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+  
+  inline def default_variant[Variant /* <: TextFieldVariants */](props: `0`[Variant] & (Omit[TextFieldProps[TextFieldVariants], variant])): Element = ^.asInstanceOf[js.Dynamic].applyDynamic("default")(props.asInstanceOf[js.Any]).asInstanceOf[Element]
+  
+  trait FilledTextFieldProps
+    extends StObject
+       with FooProps {
+    
+    var variant: filled
+  }
+  object FilledTextFieldProps {
+    
+    inline def apply(): FilledTextFieldProps = {
+      val __obj = js.Dynamic.literal(variant = "filled")
+      __obj.asInstanceOf[FilledTextFieldProps]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: FilledTextFieldProps] (val x: Self) extends AnyVal {
+      
+      inline def setVariant(value: filled): Self = StObject.set(x, "variant", value.asInstanceOf[js.Any])
+    }
+  }
+  
+  trait OutlinedTextFieldProps
+    extends StObject
+       with FooProps {
+    
+    var variant: outlined
+  }
+  object OutlinedTextFieldProps {
+    
+    inline def apply(): OutlinedTextFieldProps = {
+      val __obj = js.Dynamic.literal(variant = "outlined")
+      __obj.asInstanceOf[OutlinedTextFieldProps]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: OutlinedTextFieldProps] (val x: Self) extends AnyVal {
+      
+      inline def setVariant(value: outlined): Self = StObject.set(x, "variant", value.asInstanceOf[js.Any])
+    }
+  }
+  
+  trait StandardTextFieldProps
+    extends StObject
+       with FooProps {
+    
+    var variant: js.UndefOr[standard] = js.undefined
+  }
+  object StandardTextFieldProps {
+    
+    inline def apply(): StandardTextFieldProps = {
+      val __obj = js.Dynamic.literal()
+      __obj.asInstanceOf[StandardTextFieldProps]
+    }
+    
+    @scala.inline
+    implicit open class MutableBuilder[Self <: StandardTextFieldProps] (val x: Self) extends AnyVal {
+      
+      inline def setVariant(value: standard): Self = StObject.set(x, "variant", value.asInstanceOf[js.Any])
+      
+      inline def setVariantUndefined: Self = StObject.set(x, "variant", js.undefined)
+    }
+  }
+  
+  /** NOTE: Conditional type definitions are impossible to translate to Scala.
+    * See https://www.typescriptlang.org/docs/handbook/2/conditional-types.html for an intro.
+    * This RHS of the type alias is guess work. You should cast if it's not correct in your case.
+    * TS definition: {{{
+    Variant extends 'filled' ? componentstest.componentstest/TextField.FilledTextFieldProps : Variant extends 'standard' ? componentstest.componentstest/TextField.StandardTextFieldProps : componentstest.componentstest/TextField.OutlinedTextFieldProps
+    }}}
+    */
+  type TextFieldProps[Variant /* <: TextFieldVariants */] = FilledTextFieldProps
+  
+  /* Rewritten from type alias, can be one of: 
+    - typingsSlinky.componentstest.componentstestStrings.outlined
+    - typingsSlinky.componentstest.componentstestStrings.filled
+    - typingsSlinky.componentstest.componentstestStrings.standard
+  */
+  trait TextFieldVariants extends StObject
+  object TextFieldVariants {
+    
+    inline def filled: typingsSlinky.componentstest.componentstestStrings.filled = "filled".asInstanceOf[typingsSlinky.componentstest.componentstestStrings.filled]
+    
+    inline def outlined: typingsSlinky.componentstest.componentstestStrings.outlined = "outlined".asInstanceOf[typingsSlinky.componentstest.componentstestStrings.outlined]
+    
+    inline def standard: typingsSlinky.componentstest.componentstestStrings.standard = "standard".asInstanceOf[typingsSlinky.componentstest.componentstestStrings.standard]
+  }
+}

--- a/tests/react-integration-test/in/componentstest/TextField.d.ts
+++ b/tests/react-integration-test/in/componentstest/TextField.d.ts
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { FooProps } from './index';
+
+export type TextFieldVariants = 'outlined' | 'filled' | 'standard';
+
+export interface OutlinedTextFieldProps extends FooProps {
+    variant: 'outlined';
+}
+export interface FilledTextFieldProps extends FooProps {
+    variant: 'filled';
+}
+export interface StandardTextFieldProps extends FooProps {
+    variant?: 'standard';
+}
+
+export type TextFieldProps<Variant extends TextFieldVariants = TextFieldVariants> = Variant extends 'filled'
+    ? FilledTextFieldProps
+    : Variant extends 'standard'
+    ? StandardTextFieldProps
+    : OutlinedTextFieldProps;
+
+/* like MUI TextField: a generic function component as the default export of a submodule */
+export default function TextField<Variant extends TextFieldVariants>(
+    props: {
+        variant?: Variant | undefined;
+    } & Omit<TextFieldProps, 'variant'>,
+): JSX.Element;

--- a/tests/react-integration-test/in/componentstest/index.d.ts
+++ b/tests/react-integration-test/in/componentstest/index.d.ts
@@ -42,3 +42,37 @@ export const VeryExotic: React.MemoExoticComponent<React.ForwardRefExoticCompone
 export interface Events {
     onClick: (event: React.SyntheticEvent<any>) => void;
 }
+
+/* https://github.com/ScalablyTyped/Converter/issues/767, same shape as @mui/material */
+export interface OverridableTypeMap {
+    props: {};
+    defaultComponent: React.ElementType;
+}
+
+export interface OverridableComponent<M extends OverridableTypeMap> {
+    <C extends React.ElementType>(props: { component: C } & M['props']): JSX.Element | null;
+    (props: M['props']): JSX.Element | null;
+}
+
+export type ExtendButtonBase<M extends OverridableTypeMap> =
+    ((props: { href: string } & M['props']) => JSX.Element) & OverridableComponent<M>;
+
+export interface FooProps {
+    label?: string;
+    disabled?: boolean;
+}
+
+export interface FooTypeMap {
+    props: FooProps;
+    defaultComponent: 'button';
+}
+
+/* like MUI Box/TableRow */
+export const Plain: OverridableComponent<FooTypeMap>;
+/* like MUI Button/IconButton */
+export const ViaAlias: ExtendButtonBase<FooTypeMap>;
+/* the same type as `ViaAlias`, with the alias expanded by hand */
+export const Inline: ((props: { href: string } & FooProps) => JSX.Element) & OverridableComponent<FooTypeMap>;
+
+/* like MUI SwipeableDrawer */
+export const ViaConstructor: React.JSXElementConstructor<FooProps>;


### PR DESCRIPTION
Fixes #767.

## Problem

With the `ScalajsReact` and Slinky flavours, 16 `@mui/material` components got no component facade: `Button`, `ButtonBase`, `IconButton`, `Fab`, `MenuItem`, `Tab`, `ToggleButton`, `ListItemButton`, `AccordionSummary`, `BottomNavigationAction`, `CardActionArea`, `StepButton`, `TableSortLabel`, `SwipeableDrawer`, `TablePaginationActions` and `TextField`.

## Changes (`IdentifyReactComponents`, `ReactNames`, `ReactNamesProxy`)

1. **Aliased intersections.** `separateContainer` now follows type aliases before splitting intersections. `ExtendButtonBase<M> = ((props) => JSX.Element) & OverridableComponent<M>` now reaches `OverridableComponent`'s `apply` members.
2. **Member preference.** Detection now tries React component types first, then `apply` members, and a bare function parent last. Otherwise MUI buttons would get the `href` overload, with `href` required.
3. **`JSXElementConstructor<P>`** is recognized as a component type, for detection only. It is kept out of `ComponentQNames` because Slinky casts everything in `ComponentLike` to `ReactComponentClass`.
4. **Default exports of submodules.** The name check accepted `default` only in the root `mod`. It now accepts the default export of any JS module (for example `@mui/material/TextField/TextField`).
5. **JS names for methods.** `CombineOverloads` renames the generic `export default function TextField<Variant>` to `default_variant`. Component names and locations now use the name from `@JSName`/`@JSImport`, not the Scala name. This also fixes existing facades that imported exports which don't exist: `@JSImport("@mui/material", "TextField_variant")` and `"ExperimentalCssVarsProvider"` (the real export is `Experimental_CssVarsProvider`). `apply`/`namespaced` members keep their names, because their location annotation points at their owner.

## Tests

- I added the issue's reproduction to the `react-integration-test` `componentstest` fixture: `Plain`, `ViaAlias`, `Inline`, `ViaConstructor`, and a `TextField.d.ts` that reproduces the `default_variant` rename. Before this change `ViaAlias`, `ViaConstructor` and `TextField` got no components.
- The full `ImporterTest3` suite passes. The only snapshot changes are `componentstest` (Slinky and Japgolly).
- Converting `@mui/material@9.2.0` with `scalajs-react`: components go from 161 to 181, and all 16 above are present. Existing components are unchanged, apart from the corrected `ExperimentalCssVarsProvider` import and `TextFieldVariant` → `TextField`.

## Known limitations (not addressed here)

- `Inline` from the issue now uses the `OverridableComponent` path. In the fixture its props are `js.Any`, because indexed-access types like `M['props']` on a type parameter aren't converted. Real MUI goes through `DefaultComponentProps<M>`.
- `TextField`'s builder sets `variant = "filled"` by default. This already happened with `TextFieldVariant`. The conditional `TextFieldProps<Variant>` is approximated as its first branch, and `Omit` isn't applied when resolving props.
- `@mui/material@9.2.0` doesn't fully compile, both before and after this change. `useAutocomplete`'s overloads produce 6 "Double definition" errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLJ6KPxFVco7fXsDVT2FhF
